### PR TITLE
format the docs in full page width

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,0 +1,3 @@
+.md-grid {
+  max-width: 100%;
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,6 +2,9 @@ site_name: Glide
 theme:
   name: material
 
+extra_css:
+  - stylesheets/extra.css
+
 plugins:
   - search
   - mkdocstrings


### PR DESCRIPTION
This PR allows to format the documentation in full page width.
This implies a few modifications to mkdocs.yml and adding an extra css file in stylesheets/extra.css