### PR TITLE
docs: add doctest to generate binary dataset

### DIFF
--- a/glide/core/simulated_datasets.py
+++ b/glide/core/simulated_datasets.py
@@ -50,6 +50,19 @@ def generate_binary_dataset(
     ----------
     .. [SO] `Correlation between Bernoulli Variables <https://math.stackexchange.com/questions/610443/finding-a-correlation-between-bernoulli-variables>`_
 
+    Examples
+    --------
+    >>> from glide.core.simulated_datasets import generate_binary_dataset
+    >>> labeled, unlabeled = generate_binary_dataset(n=100, N=500, random_seed=42)
+    >>> len(labeled)
+    100
+    >>> len(unlabeled)
+    500
+    >>> list(labeled.records[0].keys())
+    ['y_true', 'y_proxy']
+    >>> list(unlabeled.records[0].keys())
+    ['y_proxy']
+
     """
     if not (0 < true_mean < 1):
         raise ValueError(f"true_mean must be in (0, 1), got {true_mean}")


### PR DESCRIPTION
### Description

- What does this PR do?
     Add a doctest to `generate_binary_dataset` function
- Which issue does it close? (use `Closes #<number>`)
  Fulfills this [ticket](https://github.com/orgs/EmertonData/projects/26/views/2?pane=issue&itemId=167882472) 
- Any noteworthy implementation decisions or trade-offs?

### Type of change

Checkbox list:
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring (no behavior change)
- [x] Documentation
- [ ] Repository hygiene

### Checklist

Quality gates that must be satisfied before requesting a review:

- [x] I have read `CONTRIBUTING.md`
- [x] `make lint` passes
- [x] `make type-check` passes
- [x] `make tests` passes
- [x] `make coverage` reports 100% coverage
- [ ] New public API has numpy-style docstrings
- [ ] New public API is inserted in the API reference section of the documentation
- [x] Docs build without warnings (`make doc`)
- [x] `CHANGELOG.md` updated if the change is user-facing

### LLM usage

Disclose if an LLM was used in writing this PR:
- [x] No LLM used
- [ ] LLM used — tool: ___, purpose: ___
- [x] I went through and validated all the code myself

