### PR TITLE
update claude.md with protocol deleted

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,7 @@ Run a single test file: `uv run pytest tests/unit/test_foo.py -vsx`
 
 The package has three layers:
 
-**`glide/estimators/`** — Public API. Each estimator implements the `MeanEstimator` Protocol (`estimate(dataset) -> MeanInferenceResult`). Current estimators: `ClassicalMeanEstimator`, `PPIMeanEstimator`, `ASIMeanEstimator`.
+**`glide/estimators/`** — Public API. Current estimators: `ClassicalMeanEstimator`, `PPIMeanEstimator`, `ASIMeanEstimator`.
 
 **`glide/core/`** — Internal building blocks:
 - `dataset.py` — `Dataset` extends `list` with column/record access
@@ -63,7 +63,7 @@ Every PR must satisfy all of the following before merge:
 - `tests/unit/` mirrors the `glide/` folder structure exactly (e.g., `glide/core/foo.py` → `tests/unit/core/test_foo.py`)
 - pytest runs with `--import-mode=importlib --doctest-modules`, so module docstrings are also tested
 - Every new feature needs: doctests in the docstring + unit tests + analytical verification (compare against known closed-form results)
-- 100% coverage is enforced; exempted files: `estimator_protocol.py`, `__init__.py` files
+- 100% coverage is enforced; exempted files: `__init__.py` files
 - Test names: `test_<name_of_tested_function>` with optional descriptive suffixes (e.g., `test_generate_binary_dataset_invalid_correlation`)
 - One test per distinct function call — do not write redundant tests
 - Use the smallest dataset possible (typically 2 records, rarely more than 10); tests must be lightning fast


### PR DESCRIPTION
### Description

- What does this PR do?
   Update claude.md now that estimator protocol was deleted form the core architecture
- Which issue does it close? (use `Closes #<number>`)
- Any noteworthy implementation decisions or trade-offs?

### Type of change

Checkbox list:
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring (no behavior change)
- [x] Documentation
- [ ] Repository hygiene

### Checklist

Quality gates that must be satisfied before requesting a review:

- [x] I have read `CONTRIBUTING.md`
- [x] `make lint` passes
- [x] `make type-check` passes
- [x] `make tests` passes
- [x] `make coverage` reports 100% coverage
- [ ] New public API has numpy-style docstrings
- [ ] New public API is inserted in the API reference section of the documentation
- [ ] Docs build without warnings (`make doc`)
- [ ] `CHANGELOG.md` updated if the change is user-facing

### LLM usage

Disclose if an LLM was used in writing this PR:
- [x] No LLM used
- [ ] LLM used: ___
- [ ] I went through and validated all the code myself