### PR TITLE
refactor: remove coverage omit for __init__.py and add version tests

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,7 @@ Every PR must satisfy all of the following before merge:
 - `tests/unit/` mirrors the `glide/` folder structure exactly (e.g., `glide/core/foo.py` → `tests/unit/core/test_foo.py`)
 - pytest runs with `--import-mode=importlib --doctest-modules`, so module docstrings are also tested
 - Every new feature needs: doctests in the docstring + unit tests + analytical verification (compare against known closed-form results)
-- 100% coverage is enforced; exempted files: `__init__.py` files
+- 100% coverage is enforced
 - Test names: `test_<name_of_tested_function>` with optional descriptive suffixes (e.g., `test_generate_binary_dataset_invalid_correlation`)
 - One test per distinct function call — do not write redundant tests
 - Use the smallest dataset possible (typically 2 records, rarely more than 10); tests must be lightning fast

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,9 +78,6 @@ respect-type-ignore-comments = true
 [tool.pytest.ini_options]
 addopts = "--import-mode=importlib --doctest-modules"
 
-[tool.coverage.run]
-omit = ["glide/__init__.py"]
-
 [[tool.uv.index]]
 name = "testpypi"
 url = "https://test.pypi.org/simple/"

--- a/tests/unit/test___init__.py
+++ b/tests/unit/test___init__.py
@@ -1,0 +1,18 @@
+import importlib
+import re
+from importlib.metadata import PackageNotFoundError
+from unittest.mock import patch
+
+import glide
+
+
+def test_version_is_set():
+    version = glide.__version__
+    assert isinstance(version, str)
+    assert re.match(r"^\d+\.\d+\.\d+", version)
+
+
+def test_version_fallback_when_package_not_found():
+    with patch("importlib.metadata.version", side_effect=PackageNotFoundError):
+        importlib.reload(glide)
+        assert glide.__version__ == "unknown"


### PR DESCRIPTION
### Description

Remove the coverage omit section while keeping 100% test coverage

### Type of change

Checkbox list:
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring (no behavior change)
- [ ] Documentation
- [X] Repository hygiene

### Checklist

Quality gates that must be satisfied before requesting a review:

- [X] I have read `CONTRIBUTING.md`
- [X] `make lint` passes
- [X] `make type-check` passes
- [X] `make tests` passes
- [X] `make coverage` reports 100% coverage
- [ ] New public API has numpy-style docstrings
- [ ] New public API is inserted in the API reference section of the documentation
- [ ] Docs build without warnings (`make doc`)
- [ ] `CHANGELOG.md` updated if the change is user-facing

### LLM usage

Disclose if an LLM was used in writing this PR:
- [ ] No LLM used
- [X] LLM used: Claude
- [X] I went through and validated all the code myself