### PR TITLE
Remove float() in ClassicalMeanEstimator

### DIFF
--- a/glide/estimators/classical.py
+++ b/glide/estimators/classical.py
@@ -33,12 +33,12 @@ class ClassicalMeanEstimator:
         return y
 
     def _compute_mean_estimate(self, y: NDArray) -> float:
-        mean = float(np.nanmean(y))
+        mean = np.nanmean(y)
         return mean
 
     def _compute_std_estimate(self, y: NDArray) -> float:
         n_not_nan = np.sum(~np.isnan(y))
-        std = float(np.nanstd(y, ddof=1) / np.sqrt(n_not_nan))
+        std = np.nanstd(y, ddof=1) / np.sqrt(n_not_nan)
         return std
 
     def estimate(


### PR DESCRIPTION
### Description

- What does this PR do?
Removes useless `float()` casts in `ClassicalMeanEstimator`
- Which issue does it close? (use `Closes #<number>`)
Deals with [this ticket](https://github.com/orgs/EmertonData/projects/26/views/7?pane=issue&itemId=171905623)
- Any noteworthy implementation decisions or trade-offs?

### Type of change

Checkbox list:
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactoring (no behavior change)
- [ ] Documentation
- [ ] Repository hygiene

### Checklist

Quality gates that must be satisfied before requesting a review:

- [x] I have read `CONTRIBUTING.md`
- [x] `make lint` passes
- [x] `make type-check` passes
- [x] `make tests` passes
- [x] `make coverage` reports 100% coverage
- [ ] New public API has numpy-style docstrings
- [ ] New public API is inserted in the API reference section of the documentation
- [x] Docs build without warnings (`make doc`)
- [ ] `CHANGELOG.md` updated if the change is user-facing

### LLM usage

Disclose if an LLM was used in writing this PR:
- [x] No LLM used
- [ ] LLM used: ___
- [ ] I went through and validated all the code myself