### PR TITLE
Use Stratified classified mean as baseline in docs

### DIFF
--- a/docs/deep_dive/stratified_ppi_validation.ipynb
+++ b/docs/deep_dive/stratified_ppi_validation.ipynb
@@ -33,7 +33,7 @@
     "from glide.core.clt_confidence_interval import CLTConfidenceInterval\n",
     "from glide.core.dataset import Dataset\n",
     "from glide.core.simulated_datasets import generate_stratified_binary_dataset\n",
-    "from glide.estimators import ClassicalMeanEstimator, StratifiedPPIMeanEstimator"
+    "from glide.estimators import ClassicalMeanEstimator, StratifiedClassicalMeanEstimator, StratifiedPPIMeanEstimator"
    ]
   },
   {
@@ -200,9 +200,9 @@
     "    )\n",
     "\n",
     "    # --- Classical baselines ---\n",
-    "    estimator = ClassicalMeanEstimator()\n",
-    "    true_only_result = estimator.estimate(dataset, y_field=\"y_true\", confidence_level=CONFIDENCE_LEVEL)\n",
-    "    proxy_only_result = estimator.estimate(dataset, y_field=\"y_proxy\", confidence_level=CONFIDENCE_LEVEL)\n",
+    "    estimator = StratifiedClassicalMeanEstimator()\n",
+    "    true_only_result = estimator.estimate(dataset[\"y_true\"], dataset[\"stratum_id\"], confidence_level=CONFIDENCE_LEVEL)\n",
+    "    proxy_only_result = estimator.estimate(dataset[\"y_proxy\"], dataset[\"stratum_id\"], confidence_level=CONFIDENCE_LEVEL)\n",
     "\n",
     "    return {\n",
     "        \"True only\": {\n",
@@ -226,7 +226,7 @@
    "id": "10",
    "metadata": {},
    "source": [
-    "`StratifiedPPIMeanEstimator` splits the dataset by `stratum_id`, computes a power-tuned PPI++ estimate within each stratum, and combines them with population-proportional weights. `ClassicalMeanEstimator` implements conventional mean estimation using true labels only.\n",
+    "`StratifiedPPIMeanEstimator` splits the dataset by `stratum_id`, computes a power-tuned PPI++ estimate within each stratum, and combines them with population-proportional weights. `StratifiedClassicalMeanEstimator` implements conventional mean estimation using true labels only but partitions by stratum to compute the variance.\n",
     "\n",
     "The three next functions implement the Monte Carlo verification:\n",
     "\n",

--- a/docs/tutorials/stratified_ppi.ipynb
+++ b/docs/tutorials/stratified_ppi.ipynb
@@ -72,7 +72,7 @@
     "import numpy as np\n",
     "\n",
     "from glide.core.simulated_datasets import generate_stratified_binary_dataset\n",
-    "from glide.estimators import ClassicalMeanEstimator, StratifiedPPIMeanEstimator\n",
+    "from glide.estimators import StratifiedClassicalMeanEstimator, StratifiedPPIMeanEstimator\n",
     "\n",
     "# ── Colour palette ──────────────────────────────────────────\n",
     "C_JUDGE = \"#E74C3C\"  # LLM judge  — red-orange\n",
@@ -152,7 +152,7 @@
     "    true_mean=true_means_by_stratum.tolist(),  # True hallucination rates\n",
     "    proxy_mean=proxy_means_by_stratum.tolist(),  # Judge reports\n",
     "    correlation=correlations_by_stratum.tolist(),  # Judge quality\n",
-    "    random_seed=17,\n",
+    "    random_seed=1,\n",
     ")\n",
     "\n",
     "dataset = labeled + unlabeled\n",
@@ -207,7 +207,7 @@
     "**Option B — Trust only human annotations.**\n",
     "Unbiased, but sparse (~400 labeled conversations). Wide confidence intervals due to small sample size.\n",
     "\n",
-    "**Stratified PPI++**, introduced next, automatically partitions by region, computes a tailored bias correction per region, and combines estimates with population-proportional weights — giving you unbiased estimates *and* narrow confidence intervals by respecting regional data structure."
+    "**Stratified PPI++**, introduced next, partitions by region, computes a tailored bias correction per region, and combines estimates with population-proportional weights — giving you unbiased estimates *and* narrow confidence intervals by respecting regional data structure."
    ]
   },
   {
@@ -218,12 +218,14 @@
    "outputs": [],
    "source": [
     "# Option A: LLM judge on all conversations\n",
-    "judge_estimate = ClassicalMeanEstimator().estimate(\n",
-    "    dataset=dataset, y_field=\"y_proxy\", confidence_level=CONFIDENCE_LEVEL\n",
+    "judge_estimate = StratifiedClassicalMeanEstimator().estimate(\n",
+    "    dataset[\"y_proxy\"], dataset[\"stratum_id\"], confidence_level=CONFIDENCE_LEVEL\n",
     ")\n",
     "\n",
-    "# Option B: Human labels only, all regions pooled\n",
-    "human_estimate = ClassicalMeanEstimator().estimate(dataset=dataset, y_field=\"y_true\", confidence_level=CONFIDENCE_LEVEL)\n",
+    "# Option B: Human labels only, small sample\n",
+    "human_estimate = StratifiedClassicalMeanEstimator().estimate(\n",
+    "    dataset[\"y_true\"], dataset[\"stratum_id\"], confidence_level=CONFIDENCE_LEVEL\n",
+    ")\n",
     "\n",
     "# Extract CI bounds for cleaner formatting\n",
     "judge_lo = judge_estimate.confidence_interval.lower_bound\n",
@@ -244,7 +246,7 @@
     "print(f\"{'Method':<48} {'Estimate':>8}   {CONFIDENCE_LEVEL_PCT}{'% Confidence Interval':>18}\")\n",
     "print(sep)\n",
     "print(f\"{'Option A: LLM judge (all regions)':<48} {judge_estimate.mean:>7.1%}   [{judge_lo:.1%}, {judge_hi:.1%}]\")\n",
-    "print(f\"{'Option B: Human-only (pooled)':<48} {human_estimate.mean:>7.1%}   [{human_lo:.1%}, {human_hi:.1%}]\")\n",
+    "print(f\"{'Option B: Human-only (small sample)':<48} {human_estimate.mean:>7.1%}   [{human_lo:.1%}, {human_hi:.1%}]\")\n",
     "print(sep)\n",
     "print(f\"{'True rate  (simulation)':<48} {TRUE_RATE:>7.1%}\")\n",
     "print(sep)"
@@ -255,7 +257,7 @@
    "id": "10",
    "metadata": {},
    "source": [
-    "Note that option A (LLM judge) produces a wrong estimate and interval due to its bias. Option B produces a valid result but the interval remains wide."
+    "Note that, even when taking regional structure into account, option A (LLM judge) produces a wrong estimate and interval due to its bias. Option B produces a valid result but the interval remains wide."
    ]
   },
   {
@@ -603,7 +605,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "glide",
+   "display_name": "glide-py",
    "language": "python",
    "name": "python3"
   },
@@ -617,7 +619,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.12"
+   "version": "3.12.9"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
### Description

- What does this PR do?
Uses the StratifiedClassicalMeanEstimator as baseline in the doc sections about Stratified PPI
- Which issue does it close? (use `Closes #<number>`)
Finishes this [ticket](https://github.com/orgs/EmertonData/projects/26/views/2?pane=issue&itemId=171095804)
- Any noteworthy implementation decisions or trade-offs?
Tried to keep the modifications to a minimum

### Type of change

Checkbox list:
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring (no behavior change)
- [x] Documentation
- [ ] Repository hygiene

### Checklist

Quality gates that must be satisfied before requesting a review:

- [x] I have read `CONTRIBUTING.md`
- [x] `make lint` passes
- [x] `make type-check` passes
- [x] `make tests` passes
- [x] `make coverage` reports 100% coverage
- [ ] New public API has numpy-style docstrings
- [ ] New public API is inserted in the API reference section of the documentation
- [x] Docs build without warnings (`make doc`)
- [ ] `CHANGELOG.md` updated if the change is user-facing

### LLM usage

Disclose if an LLM was used in writing this PR:
- [ ] No LLM used
- [x] LLM used: Claude
- [x] I went through and validated all the code myself