### PR TITLE
update CLAUDE.md and changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ## [Next release]
 
 ### ✨ Added
-<<<<<<< doc/ptd-user-guide
 - Section about the PTD in the user guide.
-=======
 - Entry for `PTDMeanEstimator` in the ReadMe papers
 - CI workflow to verify notebook execution 
 - `PTDMeanEstimator` for mean estimation with Predict-Then-Debias (bootstrap)
->>>>>>> main
 - Section on which estimator to use in the user guide
 - `BootStrapConfidenceInterval` and `ConfidenceInterval` Protocol
 - `IPWClassicalMeanEstimator` for inverse probability weighted classical mean estimation

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,17 +25,17 @@ Run a single test file: `uv run pytest tests/unit/test_foo.py -vsx`
 
 ## Architecture
 
-The package has three layers:
+The package has multiple layers:
 
-**`glide/estimators/`** — Public API.
+**`glide/estimators/`** — Public API. Statistical estimators (classical, semi-supervised, stratified variants).
 
-**`glide/core/`** — Internal building blocks:
-- `dataset.py` — `Dataset` extends `list` with column/record access
-- `clt_confidence_interval.py` — CLT-based confidence intervals
-- `mean_inference_result/` — Result dataclasses
-- `simulated_datasets.py` — Test data generators
+**`glide/confidence_intervals/`** — Confidence interval implementations depending on statistical methods.
 
-**`glide/io/`** — Serialisation helpers (JSON export).
+**`glide/samplers/`** — Sampler object implementations for various strategies.
+
+**`glide/core/`** — Internal building blocks: data structures, result dataclasses, test data generators, and shared utilities.
+
+**`glide/io/`** — Serialisation helpers.
 
 ## Git Workflow
 
@@ -112,6 +112,7 @@ Do not use needless type conversions like `float()` or `int()` unless required b
 
 - MkDocs with mkdocstrings; docs must build without warnings
 - Update `CHANGELOG.md` for any user-facing changes (Keep a Changelog format, SemVer)
+- Add elements to the "Added" or "Changed " sections of `CHANGELOG.md` at the top of the existing list
 - Avoid using and escaping underscores in math mode in jupyter notebooks.
 - Avoid making excessive use of dashes like this — when writing documentation and notebooks. Prefer commas, colons and parentheses where possible.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,7 +112,7 @@ Do not use needless type conversions like `float()` or `int()` unless required b
 
 - MkDocs with mkdocstrings; docs must build without warnings
 - Update `CHANGELOG.md` for any user-facing changes (Keep a Changelog format, SemVer)
-- Add elements to the "Added" or "Changed " sections of `CHANGELOG.md` at the top of the existing list
+- Always add elements to the "Added" or "Changed" sections of `CHANGELOG.md` at the top of the existing list
 - Avoid using and escaping underscores in math mode in jupyter notebooks.
 - Avoid making excessive use of dashes like this — when writing documentation and notebooks. Prefer commas, colons and parentheses where possible.
 


### PR DESCRIPTION
### Description

- What does this PR do?
Updates CLAUDE.md  and fixes the changelog
- Which issue does it close? (use `Closes #<number>`)
Deals with [this](https://github.com/orgs/EmertonData/projects/26/views/2?pane=issue&itemId=176876464) and [this](https://github.com/orgs/EmertonData/projects/26/views/2?pane=issue&itemId=176878668) ticket
- Any noteworthy implementation decisions or trade-offs?

### Type of change

Checkbox list:
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring (no behavior change)
- [ ] Documentation
- [x] Repository hygiene

### Checklist

Quality gates that must be satisfied before requesting a review:

- [x] I have read `CONTRIBUTING.md`
- [x] `make lint` passes
- [x] `make type-check` passes
- [x] `make tests` passes
- [x] `make coverage` reports 100% coverage
- [x] `make test-notebooks` passes
- [ ] New public API has numpy-style docstrings
- [ ] New public API is inserted in the API reference section of the documentation
- [ ] Docs build without warnings (`make doc`)
- [x] `CHANGELOG.md` updated if the change is user-facing

### LLM usage

Disclose if an LLM was used in writing this PR:
- [ ] No LLM used
- [x] LLM used: Claude
- [x] I went through and validated all the code myself