### PR TITLE
Revise StratifiedPPI docstring and add functional test

### DIFF
--- a/glide/estimators/stratified_ptd.py
+++ b/glide/estimators/stratified_ptd.py
@@ -111,9 +111,8 @@ class StratifiedPTDMeanEstimator:
 
         where ``w_k`` is the fraction of samples in stratum *k*.
 
-        Note that this assumes the portions of labeled vs unlabeled samples are
-        approximately the same in all strata which is important for statistical
-        validity.
+        Note that this assumes that these fractions reflect the true strata weights
+        in the target data distribution which is important for statistical validity.
 
         Labeled and unlabeled samples are distinguished by ``NaN`` in ``y_true``:
         a sample is labeled if its ``y_true`` entry is not ``NaN``.

--- a/tests/functional/estimators/test_stratified_ppi.py
+++ b/tests/functional/estimators/test_stratified_ppi.py
@@ -47,6 +47,26 @@ def test_two_equal_strata_matches_ppi():
     assert result_stratified.std == pytest.approx(result_single.std / np.sqrt(2), abs=1e-10)
 
 
+def test_single_stratum_matches_ppi():
+    """Stratified PPI with a single stratum reproduces PPI exactly.
+
+    With one stratum covering all data, the stratified estimator applies the same
+    estimation procedure as PPI on the same arrays. Given that the computations
+    are the same, the results match to floating-point precision.
+    """
+    n_labeled, n_unlabeled = 5, 8
+    random_seed = 7
+
+    y_true, y_proxy = generate_gaussian_dataset(n_labeled, n_unlabeled, random_seed=random_seed)
+    groups = np.full(len(y_true), "A")
+
+    stratified_result = StratifiedPPIMeanEstimator().estimate(y_true, y_proxy, groups)
+    ppi_result = PPIMeanEstimator().estimate(y_true, y_proxy)
+
+    assert stratified_result.mean == pytest.approx(ppi_result.mean, abs=1e-10)
+    assert stratified_result.std == pytest.approx(ppi_result.std, abs=1e-10)
+
+
 def test_stratified_ppi_narrower_ci_with_heterogeneous_strata():
     """Stratified PPI yields a narrower CI than standard PPI on heterogeneous strata.
 


### PR DESCRIPTION
### Description

- What does this PR do?
See title
- Which issue does it close? (use `Closes #<number>`)
Settles this [ticket](https://github.com/orgs/EmertonData/projects/26/views/2?pane=issue&itemId=179945044) and this [one](https://github.com/orgs/EmertonData/projects/26/views/2?pane=issue&itemId=179954705)
- Any noteworthy implementation decisions or trade-offs?


### Type of change

Checkbox list:
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactoring (no behavior change)
- [x] Documentation
- [ ] Repository hygiene

### Checklist

Quality gates that must be satisfied before requesting a review:

- [x] I have read `CONTRIBUTING.md`
- [x] `make lint` passes
- [x] `make type-check` passes
- [x] `make tests` passes
- [x] `make coverage` reports 100% coverage
- [ ] `make test-notebooks` passes
- [ ] New public API has numpy-style docstrings
- [ ] New public API is inserted in the API reference section of the documentation
- [ ] Docs build without warnings (`make doc`)
- [ ] `CHANGELOG.md` updated if the change is user-facing

### LLM usage

Disclose if an LLM was used in writing this PR:
- [x] No LLM used
- [ ] LLM used: ___
- [ ] I went through and validated all the code myself