### PR TITLE
CostOptimalRandomSampler user guide post-hoc

### DIFF
--- a/docs/user_guide/samplers.md
+++ b/docs/user_guide/samplers.md
@@ -85,7 +85,7 @@ Note that uncertainty scores must be strictly positive. The `ActiveSampler` requ
 
 ## Cost Optimal Random Sampler
 
-The `CostOptimalRandomSampler` addresses the following setting: two annotation sources are available, one **cheap but error-prone** (the proxy rater) and one **expensive but highly reliable** (the ground truth rater). A budget limit is imposed, potentially limiting the number of samples that can be annotated. The sampler determines how many samples are affordable so that the proxy is queried for all of them. The sampler additionally decides which samples to also send to the expensive rater, so that downstream estimation of the mean ground truth rating is as precise as possible within the available budget.
+The `CostOptimalRandomSampler` addresses the following setting: two annotation sources are available, one **cheap but error-prone** (the proxy rater) and one **expensive but highly reliable** (the ground truth rater). A budget limit is imposed, potentially limiting the number of samples that can be annotated. The sampler determines how many samples are affordable and the proxy is queried for all of them. The sampler additionally decides which samples to also send to the expensive rater, so that downstream estimation of the mean ground truth rating is as precise as possible within the available budget.
 
 The sampler models two raters:
 

--- a/docs/user_guide/samplers.md
+++ b/docs/user_guide/samplers.md
@@ -85,7 +85,7 @@ Note that uncertainty scores must be strictly positive. The `ActiveSampler` requ
 
 ## Cost Optimal Random Sampler
 
-The `CostOptimalRandomSampler` addresses the following setting: two annotation sources are available, one **cheap but error-prone** (the proxy rater) and one **expensive but highly reliable** (the ground truth rater). The proxy is queried for every sample in the dataset. The sampler decides which samples to also send to the expensive rater, so that downstream estimation of the mean ground truth rating is as precise as possible within the available budget.
+The `CostOptimalRandomSampler` addresses the following setting: two annotation sources are available, one **cheap but error-prone** (the proxy rater) and one **expensive but highly reliable** (the ground truth rater). A budget limit is imposed, potentially limiting the number of samples that can be annotated. The sampler determines how many samples are affordable so that the proxy is queried for all of them. The sampler additionally decides which samples to also send to the expensive rater, so that downstream estimation of the mean ground truth rating is as precise as possible within the available budget.
 
 The sampler models two raters:
 
@@ -119,7 +119,7 @@ The intuition: if $H$ has high variance but $G$ closely tracks it, the estimator
 
 ### Burn-in phase
 
-To compute $\pi^*$, estimates of $\text{Var}(H)$ and $\text{MSE}(H, G)$ are needed. When no labeled data is available upfront, one can first annotate a number of initial samples unconditionally with ground truth ($\pi = 1$). This burn-in dataset is used to compute the required statistics. Once $\pi^*$ is determined, the burn-in data can be retained and reused by downstream estimators that support inverse probability weighting.
+To compute $\pi^*$, estimates of $\text{Var}(H)$ and $\text{MSE}(H, G)$ are needed. When no labeled data is available upfront, one can first annotate a number of initial samples unconditionally with ground truth ($\pi = 1$). This burn-in dataset is used to compute the required statistics. Once $\pi^*$ is determined, the subsequent data is annotated with this probability and can be used by downstream estimators that support inverse probability weighting.
 
 ### Total cost and budget mapping
 


### PR DESCRIPTION
### Description

- What does this PR do?
Revises CostOptimalRandomSampler user guide
- Which issue does it close? (use `Closes #<number>`)
Settles this [https://github.com/orgs/EmertonData/projects/26/views/2?pane=issue&itemId=180066989](ticket)
- Any noteworthy implementation decisions or trade-offs?
Regarding the burn-in dataset. It was preferred not to explicitly say it would be discarded as this might appear clearly sub-optimal. We only talk about what would be done with the labeled samples

### Type of change

Checkbox list:
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring (no behavior change)
- [x] Documentation
- [ ] Repository hygiene

### Checklist

Quality gates that must be satisfied before requesting a review:

- [x] I have read `CONTRIBUTING.md`
- [ ] `make lint` passes
- [ ] `make type-check` passes
- [ ] `make tests` passes
- [ ] `make coverage` reports 100% coverage
- [ ] `make test-notebooks` passes
- [ ] New public API has numpy-style docstrings
- [ ] New public API is inserted in the API reference section of the documentation
- [x] Docs build without warnings (`make doc`)
- [ ] `CHANGELOG.md` updated if the change is user-facing

### LLM usage

Disclose if an LLM was used in writing this PR:
- [x] No LLM used
- [ ] LLM used: ___
- [ ] I went through and validated all the code myself