### PR TITLE
Create the ticket skill

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -105,6 +105,10 @@ Always import from `typing`: `from typing import Dict, List, Optional, Tuple`.
 
 Do not use needless type conversions like `float()` or `int()` unless required by the caller or for debugging purposes.
 
+### Comments
+
+Only add a comment when the *why* is non-obvious: a hidden constraint, a subtle invariant, a workaround for a specific bug, behavior that would surprise a reader. No comments restating what the code does.
+
 ### Docstrings
 
 - NumPy-style docstrings with paper references for all public API

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,11 @@
 {
+  "permissions": {
+    "allow": [
+      "Bash(python3)"
+    ]
+  },
   "enabledPlugins": {
-    "code-review@claude-plugins-official": true
+    "code-review@claude-plugins-official": true,
+    "skill-creator@claude-plugins-official": true
   }
 }

--- a/.claude/skills/ticket/SKILL.md
+++ b/.claude/skills/ticket/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: ticket
+description: Writes a developer-ready GitHub ticket for the GLIDE dev team, from any input: research paper (arXiv, PDF, screenshots, reference implementation), refactoring request, documentation task, or repository maintenance work. Always use this skill when the user says "write a ticket", "create a ticket", "make a ticket for", or describes something they want the dev team to implement, refactor, document, or clean up. The skill explores the GLIDE codebase, proposes architecture choices, writes concrete pseudocode, and produces a markdown file in tickets/. Invoke even when the request is informal or partial.
+---
+
+## Overview
+
+This skill produces a single markdown file in `tickets/` that a junior Python developer can pick up and act on — without having read any paper and without a statistics background. Every concept gets explained, every term gets defined.
+
+There are four ticket types, each with its own template. The workflow is the same for all of them.
+
+---
+
+## Workflow
+
+### 1. Classify the ticket
+
+| Type | When to use |
+|---|---|
+| **Feature** | New algorithm, estimator, or capability. Often but not always from a paper. |
+| **Refactoring** | Restructuring, renaming, or reorganising existing code without changing behaviour. |
+| **Documentation** | New or improved docstrings, user guides, notebooks, or API reference. |
+| **Repository** | CI/CD, tooling, dependency updates, test infrastructure, or any non-functional improvement. |
+
+### 2. Gather inputs
+
+Collect everything the user provided before writing anything:
+
+- **Paper link** (arXiv, DOI, URL) — fetch it; read abstract, main theorem, algorithm box, and any worked examples.
+- **Screenshots** (formulas, pseudocode, paragraphs) — read them.
+- **Reference implementation** (R or Python from the authors) — read it.
+- **Code pointers** — read the files mentioned.
+- **Scope notes** — which parts to cover, which to skip, specific cases or generalisations.
+
+For **Feature** tickets with a paper but no scope notes, ask one question before proceeding: "Which part of this paper should the ticket cover?" Then wait.
+
+For all other ticket types, you usually have enough to start directly.
+
+### 3. Explore the codebase
+
+Read enough of GLIDE to answer:
+1. **Where does it live?** Which module and file to create or modify.
+2. **What does it mirror?** Which existing class or pattern to follow.
+3. **What does it touch?** Which shared utilities, data structures, or CI implementations it depends on.
+
+Start here:
+- `glide/estimators/` — for new estimators; read one or two for naming and structure patterns
+- `glide/core/` — shared data structures and utilities
+- `glide/confidence_intervals/` — if confidence interval computation is involved
+- `glide/samplers/` — if a sampling strategy is involved
+- The files the user pointed to — for refactoring and repository tickets
+
+Mirror rule: `glide/foo/bar.py` always pairs with `tests/unit/foo/test_bar.py`.
+
+### 4. Write the ticket
+
+Pick a filename: lowercase, hyphen-separated, prefixed with the type (`feat-`, `ref-`, `doc-`, `repo-`), derived from the algorithm or topic. Write to `tickets/<filename>.md`.
+
+Load the template for the ticket type from `references/`:
+
+| Type | Template file |
+|---|---|
+| Feature | `references/template-feature.md` |
+| Refactoring | `references/template-refactoring.md` |
+| Documentation | `references/template-documentation.md` |
+| Repository | `references/template-repository.md` |
+
+Follow the template exactly. Acceptance criteria must be specific to this ticket. Never include items already covered by the team's PR template — the following are required on every PR and must not appear in ticket-specific criteria:
+
+- `make lint` passes
+- `make type-check` passes
+- `make coverage` (100%) passes
+- `make doc` builds without warnings
+- `CHANGELOG.md` updated
+
+Only write criteria that are unique to this particular ticket: a specific class that must exist, a specific behaviour that must hold, a specific numerical result that must match.
+
+---
+
+## GLIDE conventions — apply throughout all pseudocode
+
+These are non-negotiable. All pseudocode in the ticket must follow them so developers can copy-adapt without translation.
+
+**Typing** — `typing` module only. Never use PEP 604 / 585 syntax:
+```python
+# Wrong: int | None, list[str], dict[str, int]
+# Right: Optional[int], List[str], Dict[str, int]
+from typing import Dict, List, Optional, Tuple
+```
+
+**Return statements** — assign first, then return; never compute inside `return`:
+```python
+result = a * b + c
+return result
+# not: return a * b + c
+```
+
+**Arrays** — `np.hstack` / `np.vstack` over `np.concatenate`. NumPy vectorization over Python loops.
+
+**Names** — self-explanatory, no abbreviations (`effective_sample_size` not `ess`). Consistent across classes (`compute_mean_estimate` everywhere).
+
+**Docstrings** — NumPy format with `Parameters`, `Returns`, `Examples`. Doctests always import from public namespaces (`from glide.estimators import ...`).
+
+**Line length** — 120 characters.
+
+**Comments** — only when the *why* is non-obvious. No comments restating what the code does.

--- a/.claude/skills/ticket/SKILL.md
+++ b/.claude/skills/ticket/SKILL.md
@@ -65,7 +65,7 @@ Load the template for the ticket type from `references/`:
 | Documentation | `references/template-documentation.md` |
 | Repository | `references/template-repository.md` |
 
-Follow the template exactly. Acceptance criteria must be specific to this ticket. Never include items already covered by the team's PR template — the following are required on every PR and must not appear in ticket-specific criteria:
+Follow the template exactly. Acceptance criteria must be specific to this ticket. Never include items already covered by the team's PR template (`.github/PULL_REQUEST_TEMPLATE.md`) — the following are required on every PR and must not appear in ticket-specific criteria:
 
 - `make lint` passes
 - `make type-check` passes
@@ -77,30 +77,4 @@ Only write criteria that are unique to this particular ticket: a specific class 
 
 ---
 
-## GLIDE conventions — apply throughout all pseudocode
-
-These are non-negotiable. All pseudocode in the ticket must follow them so developers can copy-adapt without translation.
-
-**Typing** — `typing` module only. Never use PEP 604 / 585 syntax:
-```python
-# Wrong: int | None, list[str], dict[str, int]
-# Right: Optional[int], List[str], Dict[str, int]
-from typing import Dict, List, Optional, Tuple
-```
-
-**Return statements** — assign first, then return; never compute inside `return`:
-```python
-result = a * b + c
-return result
-# not: return a * b + c
-```
-
-**Arrays** — `np.hstack` / `np.vstack` over `np.concatenate`. NumPy vectorization over Python loops.
-
-**Names** — self-explanatory, no abbreviations (`effective_sample_size` not `ess`). Consistent across classes (`compute_mean_estimate` everywhere).
-
-**Docstrings** — NumPy format with `Parameters`, `Returns`, `Examples`. Doctests always import from public namespaces (`from glide.estimators import ...`).
-
-**Line length** — 120 characters.
-
-**Comments** — only when the *why* is non-obvious. No comments restating what the code does.
+All pseudocode must follow the conventions in `CLAUDE.md` (typing, return statements, arrays, naming, docstrings, comments) so developers can copy-adapt without translation.

--- a/.claude/skills/ticket/evals/evals.json
+++ b/.claude/skills/ticket/evals/evals.json
@@ -1,0 +1,59 @@
+{
+  "skill_name": "ticket",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "Write a ticket for implementing Cluster PTD, section B.1 of https://arxiv.org/abs/2501.18577",
+      "expected_output": "A feature ticket markdown file in tickets/ with Background (plain-language explanation of Cluster PTD), Design choices (codebase fit), Implementation (Python pseudocode with signatures, NumPy docstrings, tentative implementation), Corner cases, and Acceptance criteria specific to this feature.",
+      "files": [],
+      "assertions": [
+        {"text": "has_background_section: the ticket contains a ## Background section"},
+        {"text": "has_design_choices_section: the ticket contains a ## Design choices section"},
+        {"text": "has_implementation_section: the ticket contains a ## Implementation section with at least one Python code block"},
+        {"text": "has_corner_cases_section: the ticket contains a ## Corner cases section"},
+        {"text": "has_acceptance_criteria_section: the ticket contains an ## Acceptance criteria section"},
+        {"text": "acceptance_criteria_are_specific: the acceptance criteria mention a concrete class or method name relevant to Cluster PTD (e.g. ClusterPTDMeanEstimator), not just generic CLAUDE.md boilerplate"},
+        {"text": "uses_typing_module_conventions: pseudocode uses Optional, List, etc. from the typing module — not int | None or bare list[str]"},
+        {"text": "filename_prefixed_feat: the output filename starts with feat-"},
+        {"text": "numpy_docstrings_present: pseudocode contains Parameters followed by ---------- (NumPy docstring pattern)"}
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "Write a refactoring ticket to factorize the preprocess method from StratifiedPPI and StratifiedPTD estimators",
+      "expected_output": "A refactoring ticket markdown file in tickets/ with Background (current duplication with file/line pointers), Design choices (proposed shared implementation), Implementation (before/after pseudocode, list of affected files), Corner cases, and specific Acceptance criteria.",
+      "files": [],
+      "assertions": [
+        {"text": "has_background_with_file_pointers: the Background section mentions specific file paths (glide/estimators/stratified_ppi.py and stratified_ptd.py)"},
+        {"text": "has_implementation_with_affected_files: the ticket lists specific files to create or modify"},
+        {"text": "has_acceptance_criteria_section: the ticket contains an ## Acceptance criteria section"},
+        {"text": "acceptance_criteria_are_specific: the acceptance criteria name a specific method or file (e.g. _preprocess_strata, stratified_core.py), not just 'refactor passes tests'"},
+        {"text": "filename_prefixed_ref: the output filename starts with ref-"}
+      ]
+    },
+    {
+      "id": 3,
+      "prompt": "Write a documentation ticket to improve the R-judge case study notebook. It is too verbose with many redundancies. The goal is conciseness: one sentence, one job.",
+      "expected_output": "A documentation ticket markdown file in tickets/ with Background (specific identified redundancies and verbose sections), Design choices (editing approach), Content plan (cell-by-cell or section-by-section), and Acceptance criteria naming specific artefacts.",
+      "files": [],
+      "assertions": [
+        {"text": "has_background_with_specific_issues: the Background identifies specific cells or sections by number or name that are redundant (not vague)"},
+        {"text": "has_content_plan: a Content plan or equivalent section lists cell-level or section-level edits"},
+        {"text": "acceptance_criteria_name_artefacts: the acceptance criteria name specific cells or sections that should be deleted, merged, or shortened — not 'make doc passes'"},
+        {"text": "filename_prefixed_doc: the output filename starts with doc-"}
+      ]
+    },
+    {
+      "id": 4,
+      "prompt": "Write a repository ticket to test multiple versions of Python and Scipy in CI according to our SPEC-0 commitment",
+      "expected_output": "A repository ticket markdown file in tickets/ with Background (current CI gap, SPEC-0 requirements), Design choices (matrix strategy approach), Task breakdown (specific config file changes), and Acceptance criteria that are concretely testable.",
+      "files": [],
+      "assertions": [
+        {"text": "mentions_spec0_versions: the ticket references concrete Python and SciPy versions from the SPEC-0 window (e.g. Python 3.12, 3.13, SciPy 1.13 through 1.17)"},
+        {"text": "has_task_breakdown: a Task breakdown or equivalent section contains specific subtasks naming config files (e.g. .github/workflows/compat.yml, pyproject.toml)"},
+        {"text": "acceptance_criteria_are_testable: the acceptance criteria describe a concrete CI outcome (e.g. 'all N matrix cells pass on main'), not just 'update the config'"},
+        {"text": "filename_prefixed_repo: the output filename starts with repo-"}
+      ]
+    }
+  ]
+}

--- a/.claude/skills/ticket/references/template-documentation.md
+++ b/.claude/skills/ticket/references/template-documentation.md
@@ -1,0 +1,27 @@
+# Documentation ticket template
+
+```markdown
+# [Documentation title: what is being written or improved]
+
+## Background
+
+[1–2 paragraphs. What is missing, inconsistent, or unclear in the current documentation. Be specific — point to the relevant files, sections, or docstrings. Explain why this matters for users or contributors (e.g. "the API reference omits the `alpha` parameter", "the user guide for samplers was never written", "three different notebooks use different notation for the same quantity").]
+
+## Design choices
+
+[The proposed approach. What format or structure to use and why. If the content touches maths, specify the notation convention. If it touches code examples, specify which public API to import from. Note any existing sections the new content should align with.]
+
+## Content plan
+
+[What to write, section by section or docstring by docstring. Be specific enough that the developer knows exactly what goes where.]
+
+- `glide/path/to/file.py` — `ClassName.method_name`: [what the docstring should cover]
+- `docs/user-guide/topic.md`: [sections to add or revise]
+- `notebooks/topic.ipynb`: [cells to add or revise]
+
+## Acceptance criteria
+
+- [ ] [Name the specific artefact completed, e.g. "`IPWPTDMeanEstimator` docstring includes a worked numerical example in the `Examples` section"]
+- [ ] [Another specific artefact, e.g. "The sampler user guide covers `StratifiedSampler` with a code snippet showing how to pass strata labels"]
+- [ ] [...]
+```

--- a/.claude/skills/ticket/references/template-feature.md
+++ b/.claude/skills/ticket/references/template-feature.md
@@ -1,0 +1,118 @@
+# Feature ticket template
+
+```markdown
+# [Feature title: algorithm name and brief purpose]
+
+## Background
+
+[2–4 paragraphs. Answer: what problem does this solve, what is the core mathematical idea, why does it matter for GLIDE's goal of evaluating GenAI systems with hybrid annotations, and what assumptions does it make.
+
+Write as if explaining to a smart developer who just graduated: comfortable with Python and NumPy, but no statistics background. Use plain analogies. Introduce any formula with a sentence like "In math notation this is written as..." before showing it. Never assume the reader has seen the paper.]
+
+## Design choices
+
+[2–3 paragraphs. Cover: where in the codebase this lives and why, how it relates to existing classes (inherits from X, mirrors Y, extends Z), any deliberate departures from the paper (scope restrictions, Python-idiomatic adaptations), and key interface decisions (constructor arguments, method names, return types). Explain the reasoning behind each choice — developers should understand the intent, not just the rule.]
+
+## Implementation
+
+[For each class or function in scope, write a block like the one below. The code here is a working blueprint: complete signatures, complete NumPy docstrings, concrete tentative implementation with inline comments that walk through the algorithm step by step. A developer should be able to run this without reading the paper.]
+
+### ClassName
+
+**Location:** `glide/<module>/<file>.py`
+
+**Purpose:** [One sentence.]
+
+```python
+from typing import Optional, List, Dict, Tuple
+import numpy as np
+
+
+class ClassName:
+    """One-line summary.
+
+    [Longer description: what it computes, when to use it.]
+
+    Parameters
+    ----------
+    param_name : type
+        Description.
+
+    Examples
+    --------
+    >>> from glide.estimators import ClassName
+    >>> estimator = ClassName(param=value)
+    >>> result = estimator.compute_mean_estimate(labeled, proxy)
+    1.5
+    """
+
+    def __init__(self, param: Type) -> None:
+        self.param = param
+
+    def compute_mean_estimate(self, labeled: np.ndarray, proxy: np.ndarray) -> float:
+        """One-line summary.
+
+        Parameters
+        ----------
+        labeled : np.ndarray
+            Description.
+        proxy : np.ndarray
+            Description.
+
+        Returns
+        -------
+        float
+            Description.
+
+        Examples
+        --------
+        >>> from glide.estimators import ClassName
+        >>> estimator = ClassName(param=value)
+        >>> estimator.compute_mean_estimate(np.array([1.0, 2.0]), np.array([1.1, 1.9]))
+        1.5
+        """
+        # [Explain this step in plain language, e.g. "Compute the correction term that removes proxy bias"]
+        correction = np.mean(labeled - proxy[:len(labeled)])
+        # [Explain the final estimate]
+        result = np.mean(proxy) + correction
+        return result
+```
+
+[Repeat for each class or standalone function in scope.]
+
+## Functional tests
+
+[Include this section only when a mathematical equivalence exists — typically when the new feature is a generalisation of an existing one and the simpler case should be recoverable as a special case. Omit entirely otherwise.
+
+For each equivalence, state it plainly and show the corresponding test structure.]
+
+**[Name of the equivalence, e.g. "Single-stratum stratified PPI equals plain PPI"]**
+
+[One sentence: "When all observations belong to a single stratum, StratifiedPPIMeanEstimator must return the same value as PPIMeanEstimator."]
+
+```python
+def test_single_stratum_equals_ppi():
+    labeled = np.array([1.0, 2.0])
+    proxy = np.array([1.1, 1.9, 2.1, 0.9])
+    strata = np.array(["a", "a", "a", "a"])
+
+    result_stratified = StratifiedPPIMeanEstimator(...).compute_mean_estimate(labeled, proxy, strata)
+    result_ppi = PPIMeanEstimator(...).compute_mean_estimate(labeled, proxy)
+
+    np.testing.assert_allclose(result_stratified, result_ppi, atol=1e-10)
+```
+
+## Corner cases
+
+- [Specific scenario and expected behaviour — raise, clamp, warn, or return a defined value. Be concrete about inputs and outputs.]
+- [Another scenario]
+- [...]
+
+## Acceptance criteria
+
+- [ ] [Specific deliverable tied to this ticket — name the class, method, or behaviour. E.g.: "ClusterPTDMeanEstimator.estimate returns a CI that contains the true mean in >95% of simulations", or "_preprocess raises ValueError when fewer than 2 clusters are selected".]
+- [ ] [Another specific deliverable — numerical validation, equivalence property, or observable behaviour.]
+- [ ] [...]
+
+Do not include items already in the PR template: `make lint`, `make type-check`, `make coverage`, `make doc`, and `CHANGELOG.md` are required on every PR and belong there, not here.
+```

--- a/.claude/skills/ticket/references/template-feature.md
+++ b/.claude/skills/ticket/references/template-feature.md
@@ -26,6 +26,7 @@ Write as if explaining to a smart developer who just graduated: comfortable with
 ```python
 from typing import Optional, List, Dict, Tuple
 import numpy as np
+from numpy.typing import NDArray
 
 
 class ClassName:
@@ -49,14 +50,14 @@ class ClassName:
     def __init__(self, param: Type) -> None:
         self.param = param
 
-    def compute_mean_estimate(self, labeled: np.ndarray, proxy: np.ndarray) -> float:
+    def compute_mean_estimate(self, labeled: NDArray, proxy: NDArray) -> float:
         """One-line summary.
 
         Parameters
         ----------
-        labeled : np.ndarray
+        labeled : NDArray
             Description.
-        proxy : np.ndarray
+        proxy : NDArray
             Description.
 
         Returns
@@ -82,24 +83,40 @@ class ClassName:
 
 ## Functional tests
 
-[Include this section only when a mathematical equivalence exists — typically when the new feature is a generalisation of an existing one and the simpler case should be recoverable as a special case. Omit entirely otherwise.
+[Include this section to specify mathematical properties the new object must satisfy beyond basic code correctness. These can be equivalences, ordering guarantees, monotonicity properties, or any other theoretically grounded expectation. Omit entirely if no such property applies.
 
-For each equivalence, state it plainly and show the corresponding test structure.]
+For each property, state it plainly and show the corresponding test structure.]
 
-**[Name of the equivalence, e.g. "Single-stratum stratified PPI equals plain PPI"]**
+**[Name of the property, e.g. "Single-stratum stratified PPI equals plain PPI"]**
 
-[One sentence: "When all observations belong to a single stratum, StratifiedPPIMeanEstimator must return the same value as PPIMeanEstimator."]
+[One sentence stating the property: "When all observations belong to a single stratum, StratifiedPPIMeanEstimator must return the same value as PPIMeanEstimator."]
 
 ```python
 def test_single_stratum_equals_ppi():
-    labeled = np.array([1.0, 2.0])
-    proxy = np.array([1.1, 1.9, 2.1, 0.9])
+    y_true = np.array([1.0, 2.0, np.nan, np.nan])
+    y_proxy = np.array([1.1, 1.9, 2.1, 0.9])
     strata = np.array(["a", "a", "a", "a"])
 
-    result_stratified = StratifiedPPIMeanEstimator(...).compute_mean_estimate(labeled, proxy, strata)
-    result_ppi = PPIMeanEstimator(...).compute_mean_estimate(labeled, proxy)
+    result_stratified = StratifiedPPIMeanEstimator(...).compute_mean_estimate(y_true, y_proxy, strata)
+    result_ppi = PPIMeanEstimator(...).compute_mean_estimate(y_true, y_proxy)
 
     np.testing.assert_allclose(result_stratified, result_ppi, atol=1e-10)
+```
+
+**[Name of an ordering property, e.g. "Stratified PPI confidence interval is no wider than plain PPI"]**
+
+[One sentence: "For the same data, StratifiedPPIMeanEstimator must produce a confidence interval at least as tight as PPIMeanEstimator."]
+
+```python
+def test_stratified_ppi_tighter_than_ppi():
+    y_true = np.array([1.0, 2.0, np.nan, np.nan])
+    y_proxy = np.array([1.1, 1.9, 2.1, 0.9])
+    strata = np.array(["a", "a", "b", "b"])
+
+    ci_stratified = StratifiedPPIMeanEstimator(...).compute_mean_estimate(y_true, y_proxy, strata)
+    ci_ppi = PPIMeanEstimator(...).compute_mean_estimate(y_true, y_proxy)
+
+    assert ci_stratified.width <= ci_ppi.width
 ```
 
 ## Corner cases

--- a/.claude/skills/ticket/references/template-feature.md
+++ b/.claude/skills/ticket/references/template-feature.md
@@ -43,14 +43,14 @@ class ClassName:
     --------
     >>> from glide.estimators import ClassName
     >>> estimator = ClassName(param=value)
-    >>> result = estimator.compute_mean_estimate(labeled, proxy)
+    >>> result = estimator.estimate(labeled, proxy)
     1.5
     """
 
     def __init__(self, param: Type) -> None:
         self.param = param
 
-    def compute_mean_estimate(self, labeled: NDArray, proxy: NDArray) -> float:
+    def estimate(self, labeled: NDArray, proxy: NDArray) -> float:
         """One-line summary.
 
         Parameters
@@ -69,7 +69,7 @@ class ClassName:
         --------
         >>> from glide.estimators import ClassName
         >>> estimator = ClassName(param=value)
-        >>> estimator.compute_mean_estimate(np.array([1.0, 2.0]), np.array([1.1, 1.9]))
+        >>> estimator.estimate(np.array([1.0, 2.0]), np.array([1.1, 1.9]))
         1.5
         """
         # [Explain this step in plain language, e.g. "Compute the correction term that removes proxy bias"]
@@ -95,10 +95,10 @@ For each property, state it plainly and show the corresponding test structure.]
 def test_single_stratum_equals_ppi():
     y_true = np.array([1.0, 2.0, np.nan, np.nan])
     y_proxy = np.array([1.1, 1.9, 2.1, 0.9])
-    strata = np.array(["a", "a", "a", "a"])
+    groups = np.array(["a", "a", "a", "a"])
 
-    result_stratified = StratifiedPPIMeanEstimator(...).compute_mean_estimate(y_true, y_proxy, strata)
-    result_ppi = PPIMeanEstimator(...).compute_mean_estimate(y_true, y_proxy)
+    result_stratified = StratifiedPPIMeanEstimator(...).estimate(y_true, y_proxy, groups)
+    result_ppi = PPIMeanEstimator(...).estimate(y_true, y_proxy)
 
     np.testing.assert_allclose(result_stratified, result_ppi, atol=1e-10)
 ```
@@ -111,10 +111,10 @@ def test_single_stratum_equals_ppi():
 def test_stratified_ppi_tighter_than_ppi():
     y_true = np.array([1.0, 2.0, np.nan, np.nan])
     y_proxy = np.array([1.1, 1.9, 2.1, 0.9])
-    strata = np.array(["a", "a", "b", "b"])
+    groups = np.array(["a", "a", "b", "b"])
 
-    ci_stratified = StratifiedPPIMeanEstimator(...).compute_mean_estimate(y_true, y_proxy, strata)
-    ci_ppi = PPIMeanEstimator(...).compute_mean_estimate(y_true, y_proxy)
+    ci_stratified = StratifiedPPIMeanEstimator(...).estimate(y_true, y_proxy, groups)
+    ci_ppi = PPIMeanEstimator(...).estimate(y_true, y_proxy)
 
     assert ci_stratified.width <= ci_ppi.width
 ```

--- a/.claude/skills/ticket/references/template-refactoring.md
+++ b/.claude/skills/ticket/references/template-refactoring.md
@@ -45,7 +45,7 @@ def new_method_name(self, x: NewType) -> NewReturn:
 
 ## Acceptance criteria
 
-- [ ] [Specific deliverable, e.g. "All estimators expose compute_mean_estimate rather than a class-specific alias"]
+- [ ] [Specific deliverable, e.g. "All estimators expose estimate rather than a class-specific alias"]
 - [ ] [Another specific deliverable — what is observable once the refactor is complete]
 - [ ] [...]
 

--- a/.claude/skills/ticket/references/template-refactoring.md
+++ b/.claude/skills/ticket/references/template-refactoring.md
@@ -1,0 +1,53 @@
+# Refactoring ticket template
+
+```markdown
+# [Refactoring title: what is changing and why]
+
+## Background
+
+[2–3 paragraphs. Explain what the current code does (with file and line pointers), why it needs to change (inconsistency, duplication, API mismatch, naming confusion), and what the goal state looks like. Be concrete — name the specific classes, methods, or files involved. A developer who has never touched this code should understand both the current problem and the intended result.]
+
+## Design choices
+
+[How the refactored code will be structured. What gets renamed, moved, merged, or split. Explain the reasoning behind each choice. If an alternative was considered and rejected, say why. Keep it honest — "we chose X over Y because Z" is more useful than just "we chose X".
+
+**On extractions:** when shared logic is pulled into a new function or module, callers should call it directly — not wrap it in a one-liner delegate method. One-liner delegates duplicate test surface and add indirection without any benefit. Remove the original method and update every caller to use the new function.]
+
+## Implementation
+
+[Show what changes. For renames, show the mapping. For interface changes, show old and new signatures side by side. For structural changes, show the before and after. The goal is for a developer to understand exactly what to do without needing to interpret anything.
+
+**On tests:** do not list individual test function signatures. Just note what moves (which existing tests are relocated and where they land) and any genuinely new scenario that didn't exist before. Existing tests that already cover the behaviour don't need to be re-described.]
+
+**Files affected:**
+
+| File | What changes |
+|---|---|
+| `glide/path/to/file.py` | [description] |
+| `tests/unit/path/to/test_file.py` | [description] |
+
+**Before / After (where helpful):**
+
+```python
+# Before
+def old_method_name(self, x: OldType) -> OldReturn:
+    ...
+
+# After
+def new_method_name(self, x: NewType) -> NewReturn:
+    ...
+```
+
+## Corner cases
+
+- [Things that could break during the refactor — callers that may not be obvious, implicit contracts, test fixtures that need updating, public API changes that affect users]
+- [Another scenario]
+
+## Acceptance criteria
+
+- [ ] [Specific deliverable, e.g. "All estimators expose compute_mean_estimate rather than a class-specific alias"]
+- [ ] [Another specific deliverable — what is observable once the refactor is complete]
+- [ ] [...]
+
+Do not include items already in the PR template: `make lint`, `make type-check`, `make coverage`, `make doc`, and `CHANGELOG.md` are always required and belong there, not here.
+```

--- a/.claude/skills/ticket/references/template-repository.md
+++ b/.claude/skills/ticket/references/template-repository.md
@@ -20,6 +20,6 @@
 ## Acceptance criteria
 
 - [ ] [Specific and testable, e.g. "A PR that introduces a new public function without a docstring is blocked by CI"]
-- [ ] [Another specific deliverable, e.g. "Running `make pre-commit` on a notebook with outputs strips them before committing"]
+- [ ] [Another specific deliverable, e.g. "Running `make pre-commit` strips all notebooks from outputs before committing"]
 - [ ] [...]
 ```

--- a/.claude/skills/ticket/references/template-repository.md
+++ b/.claude/skills/ticket/references/template-repository.md
@@ -1,0 +1,25 @@
+# Repository ticket template
+
+```markdown
+# [Repository title: what is being improved and why]
+
+## Background
+
+[1–2 paragraphs. What is the current problem or gap: a missing CI check, a slow test suite, a flaky pipeline, an outdated dependency, missing pre-commit hooks. Be concrete — link to the relevant config files, CI runs, or failing steps. Explain the impact (e.g. "coverage is not enforced on PRs", "the type-checker runs but its output is ignored", "notebook outputs are committed to the repository").]
+
+## Design choices
+
+[The proposed approach. What tool, configuration, or workflow to adopt and why. If there are alternatives, explain the trade-off briefly.]
+
+## Task breakdown
+
+- [ ] [Specific subtask — name the file to create or modify using full, self-explaining names (e.g. `compatibility.yml` not `compat.yml`, `spec0-matrix.yml` not `spec0.yml`)]
+- [ ] [Another subtask]
+- [ ] [...]
+
+## Acceptance criteria
+
+- [ ] [Specific and testable, e.g. "A PR that introduces a new public function without a docstring is blocked by CI"]
+- [ ] [Another specific deliverable, e.g. "Running `make pre-commit` on a notebook with outputs strips them before committing"]
+- [ ] [...]
+```


### PR DESCRIPTION
### Description

- Introduces the `ticket` skill for Claude Code: a specialized agent that writes developer-ready GitHub tickets for the GLIDE dev team from any input (research paper, refactoring request, documentation task, or repository hygiene work).
- The skill explores the codebase, proposes architecture choices, writes concrete pseudocode, and produces a markdown file in `tickets/`.
- Adds four reference ticket templates (feature, documentation, refactoring, repository) used by the skill to structure its output consistently.
- Adds an eval suite (`evals.json`) with test cases to benchmark skill quality and triggering accuracy.
- Enables the `skill-creator` plugin in `.claude/settings.json` to allow creating and improving skills directly from the IDE.

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring (no behavior change)
- [ ] Documentation
- [x] Repository hygiene

### Checklist

- [x] I have read `CONTRIBUTING.md`
- [x] `make lint` passes
- [x] `make type-check` passes
- [x] `make tests` passes
- [x] `make coverage` reports 100% coverage
- [x] `make test-notebooks` passes
- [ ] New public API has numpy-style docstrings
- [ ] New public API is inserted in the API reference section of the documentation
- [ ] Docs build without warnings (`make doc`)
- [ ] `CHANGELOG.md` updated if the change is user-facing

### LLM usage

- [ ] No LLM used
- [x] LLM used: Claude Sonnet 4.6
- [x] I went through and validated all the code myself
