### PR TITLE
Remove unsorted boostrap estimates in BootstrapConfidenceInterval

### DIFF
--- a/glide/confidence_intervals/bootstrap.py
+++ b/glide/confidence_intervals/bootstrap.py
@@ -30,7 +30,6 @@ class BootstrapConfidenceInterval:
     [4.453, 5.354]
     """
 
-    bootstrap_estimates: NDArray
     mean: float = field(init=False, repr=False)
     var: float = field(init=False, repr=False)
     std: float = field(init=False, repr=False)
@@ -41,7 +40,6 @@ class BootstrapConfidenceInterval:
     width: float = field(init=False, repr=False)
 
     def __init__(self, bootstrap_estimates: NDArray, confidence_level: float = 0.95) -> None:
-        self.bootstrap_estimates = bootstrap_estimates
         self.mean = float(np.mean(bootstrap_estimates))
         self.var = float(np.var(bootstrap_estimates, ddof=1))
         self.std = float(np.sqrt(self.var))


### PR DESCRIPTION
### Description

- What does this PR do?
See title
- Which issue does it close? (use `Closes #<number>`)
Deals with this [ticket](https://github.com/orgs/EmertonData/projects/26/views/2?pane=issue&itemId=178103942)
- Any noteworthy implementation decisions or trade-offs?

### Checklist

Quality gates that must be satisfied before requesting a review:

- [x] I have read `CONTRIBUTING.md`
- [x] `make lint` passes
- [x] `make type-check` passes
- [x] `make tests` passes
- [x] `make coverage` reports 100% coverage
- [x] `make test-notebooks` passes
- [ ] New public API has numpy-style docstrings
- [ ] New public API is inserted in the API reference section of the documentation
- [ ] Docs build without warnings (`make doc`)
- [ ] `CHANGELOG.md` updated if the change is user-facing

### LLM usage

Disclose if an LLM was used in writing this PR:
- [x] No LLM used
- [ ] I used an LLM and I went through and validated all the code myself