### PR TITLE
StratifiedSampler returns xi only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ## [Next release]
 
 ### ✨ Added
-<<<<<<< feat/uniform_sampler
 - `UniformSampler` for uniform random sampling
-=======
 - Example for `IPWPTDMeanEstimator`
->>>>>>> main
 - Section about IPWPTD in the user guide
 - `IPWPTDMeanEstimator` for inverse probability weighted PTD mean estimation
 - Section about `CostOptimalRandomSampler` in the user guide
@@ -21,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - `StratifiedPTDMeanEstimator` stratified extension of `PTDMeanEstimator`
 
 ### 🔄 Changed
+- `StratifiedSampler` now returns sampling indicators only
 - Refactored `glide.core.simulated_datasets` into dedicated `glide.simulators` module with separate files for each generator function
 - Replaced "semi-supervised" with "prediction-powered" everywhere in the docs and code
 

--- a/docs/deep_dive/icml_case_study.ipynb
+++ b/docs/deep_dive/icml_case_study.ipynb
@@ -212,7 +212,7 @@
     "        y_true[xi] = y_true_oracle[xi]\n",
     "        return y_true, y_proxy\n",
     "    elif workflow == \"Stratified\":\n",
-    "        pi, xi = StratifiedSampler().sample(y_proxy, groups, budget=N_LABELED, strategy=\"neyman\", random_seed=seed)\n",
+    "        xi = StratifiedSampler().sample(y_proxy, groups, budget=N_LABELED, strategy=\"neyman\", random_seed=seed)\n",
     "        where_no_annotation = ~(xi.astype(bool))\n",
     "\n",
     "        y_true = y_true_oracle.copy()\n",

--- a/glide/samplers/stratified.py
+++ b/glide/samplers/stratified.py
@@ -183,8 +183,10 @@ class StratifiedSampler:
         Raises
         ------
         ValueError
-            If strategy is unknown, if budget is not a strictly positive integer, or if budget exceeds
-            the number of samples in the input.
+            - If ``strategy`` is not a recognized allocation strategy.
+            - If ``budget`` is not a strictly positive integer.
+            - If ``budget`` is too low and results in zero allocations for some stratum.
+            - If ``budget`` exceeds the total number of samples in the input.
         """
         if (not isinstance(budget, (int, np.integer))) or isinstance(budget, bool) or budget <= 0:
             raise ValueError(f"'budget' must be a strictly positive integer; got {budget!r}.")
@@ -216,7 +218,7 @@ class StratifiedSampler:
         xi = np.zeros(len(y_proxy), dtype=int)
 
         for stratum_id in np.unique(groups):
-            stratum_indices = np.argwhere(groups == stratum_id)
+            stratum_indices = np.flatnonzero(groups == stratum_id)
             n_h = allocation[stratum_id]
             selected_samples = rng.choice(stratum_indices, size=n_h, replace=False)
             xi[selected_samples] = 1

--- a/glide/samplers/stratified.py
+++ b/glide/samplers/stratified.py
@@ -37,11 +37,9 @@ class StratifiedSampler:
     >>> y_proxy = np.array([0.8, 0.9, 0.85, 0.88, 0.2, 0.3])
     >>> groups = np.array(["A", "A", "A", "A", "B", "B"], dtype=object)
     >>> sampler = StratifiedSampler()
-    >>> pi, xi = sampler.sample(y_proxy, groups, budget=2, random_seed=1)
-    >>> pi
-    array([0.25, 0.25, 0.25, 0.25, 0.5 , 0.5 ])
+    >>> xi = sampler.sample(y_proxy, groups, budget=2, random_seed=1)
     >>> xi
-    array([0, 1, 0, 1, 0, 0])
+    array([0, 1, 0, 0, 0, 1])
     """
 
     def _validate(
@@ -151,18 +149,14 @@ class StratifiedSampler:
         budget: int,
         strategy: Literal["proportional", "neyman"] = "neyman",
         random_seed: Optional[int] = None,
-    ) -> Tuple[NDArray, NDArray]:
+    ) -> NDArray:
         """Allocate annotation budget across strata and perform stratified sampling.
 
-        Computes per-stratum sample sizes using the specified allocation strategy and performs
-        Bernoulli sampling for each sample based on its stratum's allocation. Neyman allocation
-        (default) assigns more budget to strata with higher proxy variance, minimising asymptotic
-        variance of downstream estimators. Proportional allocation allocates budget proportionally
-        to stratum sizes and serves as a baseline.
-
-        Each sample receives a drawing probability π_i = n_h / stratum_size (capped at 1), and
-        is independently selected via a Bernoulli trial. The actual number of selected items is
-        a random variable with expectation ≤ budget.
+        Computes allocated annotation counts ``n_h`` for each stratum ``h`` using the
+        specified allocation strategy and selects exactly ``n_h`` samples from each stratum
+        without replacement. Neyman allocation (default) assigns more budget to strata with higher
+        proxy variance, minimising asymptotic variance of downstream estimators. Proportional
+        allocation allocates budget proportionally to stratum sizes and serves as a baseline.
 
         Parameters
         ----------
@@ -182,10 +176,9 @@ class StratifiedSampler:
 
         Returns
         -------
-        Tuple[NDArray, NDArray]
-            A tuple ``(pi, xi)`` where ``pi`` is an array of drawing probabilities
-            in ``(0, 1]`` and ``xi`` is an array of Bernoulli selection indicators
-            (1 if selected for annotation, 0 otherwise), both of shape ``(n_samples,)``.
+        NDArray
+            Selection indicators of shape ``(n_samples,)``: 1 if the sample was selected
+            for annotation, 0 otherwise.
 
         Raises
         ------
@@ -220,15 +213,12 @@ class StratifiedSampler:
 
         rng = np.random.default_rng(random_seed)
 
-        pi = np.zeros(len(y_proxy))
         xi = np.zeros(len(y_proxy), dtype=int)
 
         for stratum_id in np.unique(groups):
-            stratum_mask = groups == stratum_id
+            stratum_indices = np.argwhere(groups == stratum_id)
             n_h = allocation[stratum_id]
-            stratum_size = stratum_mask.sum()
-            pi_value = np.minimum(n_h / stratum_size, 1.0)
-            pi[stratum_mask] = pi_value
-            xi[stratum_mask] = rng.binomial(n=1, p=np.full(stratum_size, pi_value)).astype(float)
+            selected_samples = rng.choice(stratum_indices, size=n_h, replace=False)
+            xi[selected_samples] = 1
 
-        return pi, xi
+        return xi

--- a/tests/functional/estimators/test_stratified_ppi.py
+++ b/tests/functional/estimators/test_stratified_ppi.py
@@ -147,7 +147,7 @@ def test_neyman_allocation_yields_narrower_ci_than_proportional():
     # Helper to run pipeline for a given strategy
     def pipeline(strategy: Literal["proportional", "neyman"]):
         # Sample using stratified sampler
-        _, xi = StratifiedSampler().sample(
+        xi = StratifiedSampler().sample(
             y_proxy_full, groups_full, budget=budget, strategy=strategy, random_seed=random_seed
         )
 

--- a/tests/functional/samplers/test_stratified.py
+++ b/tests/functional/samplers/test_stratified.py
@@ -18,13 +18,12 @@ def test_proportional_matches_uniform_equal_strata(sampler):
     sample_indices = np.tile(np.arange(n_per_stratum), n_strata)
     y_proxy = groups + sample_indices * 0.1
 
-    pi, _ = sampler.sample(y_proxy, groups, budget, strategy="proportional", random_seed=0)
+    xi = sampler.sample(y_proxy, groups, budget, strategy="proportional", random_seed=0)
 
-    # With equal-sized strata, proportional allocation gives uniform pi across all samples
-    total_size = len(y_proxy)
-    expected_pi = budget / total_size
-
-    np.testing.assert_allclose(pi, expected_pi)
+    # With equal-sized strata, proportional allocation gives each stratum the same number of annotations
+    expected_per_stratum = budget // n_strata
+    for stratum_id in np.unique(groups):
+        assert xi[groups == stratum_id].sum() == expected_per_stratum
 
 
 def test_sample_rounding_sums_to_budget(sampler):
@@ -32,15 +31,6 @@ def test_sample_rounding_sums_to_budget(sampler):
     groups = np.array(["s0", "s0", "s1", "s1", "s2", "s2", "s3", "s3", "s4", "s4"], dtype=object)
 
     for strategy in ["proportional", "neyman"]:
-        pi, _ = sampler.sample(y_proxy, groups, 7, strategy=strategy)
+        xi = sampler.sample(y_proxy, groups, 7, strategy=strategy, random_seed=0)
 
-        unique_groups, group_sizes = np.unique(groups, return_counts=True)
-
-        # Get first pi value for each unique group
-        group_pi = np.array([pi[groups == group][0] for group in unique_groups])
-
-        # Vectorized allocation calculation
-        allocations = np.minimum(group_pi * group_sizes, group_sizes)
-        total_allocation = np.sum(allocations)
-
-        assert total_allocation <= 7
+        assert xi.sum() <= 7

--- a/tests/unit/samplers/test_stratified.py
+++ b/tests/unit/samplers/test_stratified.py
@@ -66,14 +66,10 @@ def test_proportional_allocation_proportional_to_N_h(sampler):
 # --- sample ---
 
 
-def test_sample_returns_valid_arrays(sampler, y_proxy, groups):
-    pi, xi = sampler.sample(y_proxy, groups, 4, random_seed=0)
-    assert isinstance(pi, np.ndarray)
+def test_sample_returns_valid_array(sampler, y_proxy, groups):
+    xi = sampler.sample(y_proxy, groups, 4, random_seed=0)
     assert isinstance(xi, np.ndarray)
-    assert len(pi) == len(y_proxy)
     assert len(xi) == len(y_proxy)
-    assert np.all(pi > 0)
-    assert np.all(pi <= 1)
     assert np.isin(xi, [0, 1]).all()
 
 
@@ -108,17 +104,24 @@ def test_sample_raises_on_zero_allocation(sampler, y_proxy, groups):
 
 
 def test_sample_default_strategy_is_neyman(sampler, y_proxy, groups):
-    default_pi, _ = sampler.sample(y_proxy, groups, 8)
-    neyman_pi, _ = sampler.sample(y_proxy, groups, 8, strategy="neyman")
+    default_xi = sampler.sample(y_proxy, groups, 8, random_seed=0)
+    neyman_xi = sampler.sample(y_proxy, groups, 8, strategy="neyman", random_seed=0)
 
-    np.testing.assert_array_equal(default_pi, neyman_pi)
+    np.testing.assert_array_equal(default_xi, neyman_xi)
+
+
+def test_sample_proportional_strategy(sampler, y_proxy, groups):
+    xi = sampler.sample(y_proxy, groups, 8, strategy="proportional", random_seed=0)
+
+    expected_xi = np.ones(8)
+    np.testing.assert_array_equal(xi, expected_xi)
 
 
 def test_sample_neyman_strategy(sampler, y_proxy, groups):
-    pi, _ = sampler.sample(y_proxy, groups, 8, strategy="neyman")
+    xi = sampler.sample(y_proxy, groups, 8, strategy="neyman", random_seed=0)
 
-    assert pi[0] == pytest.approx(0.25)
-    assert pi[4] == pytest.approx(1.0)
+    expected_xi = np.array([0, 0, 0, 1, 1, 1, 1, 1])
+    np.testing.assert_array_equal(xi, expected_xi)
 
 
 def test_sample_invalid_strategy_raises(sampler, y_proxy, groups):
@@ -127,7 +130,7 @@ def test_sample_invalid_strategy_raises(sampler, y_proxy, groups):
 
 
 def test_sample_is_reproducible(sampler, y_proxy, groups):
-    _, xi1 = sampler.sample(y_proxy, groups, 4, random_seed=42)
-    _, xi2 = sampler.sample(y_proxy, groups, 4, random_seed=42)
+    xi1 = sampler.sample(y_proxy, groups, 4, random_seed=42)
+    xi2 = sampler.sample(y_proxy, groups, 4, random_seed=42)
 
     np.testing.assert_array_equal(xi1, xi2)

--- a/tests/unit/samplers/test_stratified.py
+++ b/tests/unit/samplers/test_stratified.py
@@ -111,9 +111,9 @@ def test_sample_default_strategy_is_neyman(sampler, y_proxy, groups):
 
 
 def test_sample_proportional_strategy(sampler, y_proxy, groups):
-    xi = sampler.sample(y_proxy, groups, 8, strategy="proportional", random_seed=0)
+    xi = sampler.sample(y_proxy, groups, 5, strategy="proportional", random_seed=0)
 
-    expected_xi = np.ones(8)
+    expected_xi = np.array([0, 1, 1, 1, 1, 0, 0, 1])
     np.testing.assert_array_equal(xi, expected_xi)
 
 


### PR DESCRIPTION
### Description

- What does this PR do?
See title
- Which issue does it close? (use `Closes #<number>`)
Deals with this [ticket](https://github.com/orgs/EmertonData/projects/26/views/2?pane=issue&itemId=184758328)
- Any noteworthy implementation decisions or trade-offs?

### Checklist

Quality gates that must be satisfied before requesting a review:

- [x] I have read `CONTRIBUTING.md`
- [x] `make lint` passes
- [x] `make type-check` passes
- [x] `make tests` passes
- [x] `make coverage` reports 100% coverage
- [x] `make test-notebooks` passes
- [ ] New public API has numpy-style docstrings
- [ ] New public API is inserted in the API reference section of the documentation
- [ ] Docs build without warnings (`make doc`)
- [ ] `CHANGELOG.md` updated if the change is user-facing

### LLM usage

Disclose if an LLM was used in writing this PR:
- [ ] No LLM used
- [x] I used an LLM and I went through and validated all the code myself