### PR TITLE
Add SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,24 @@
+# Security Policy
+
+## Supported versions
+
+Only the latest version of `glide-py` published on PyPI receives security fixes.
+
+## Reporting a vulnerability
+
+Please **do not** open a public GitHub issue for security vulnerabilities, as this would disclose the issue before a fix is available.
+
+To report a vulnerability, use the **"Report a vulnerability"** button in the [Security tab](https://github.com/EmertonData/glide/security/advisories/new) of this repository. This opens a draft private advisory visible only to you and the maintainers.
+
+Please include as much of the following as possible: a description of the vulnerability, the affected version(s), steps to reproduce, and any proof-of-concept code.
+
+## Response timeline
+
+- **Acknowledgement:** within 5 business days of receiving your report.
+- **Triage and initial fix plan:** within 14 calendar days of acknowledgement.
+
+We will keep you informed as the fix progresses and will credit you in the security advisory unless you prefer to remain anonymous.
+
+## Out of scope
+
+Vulnerabilities in GLIDE's dependencies (NumPy, SciPy, etc.) should be reported directly to those projects. We will update our dependencies when upstream fixes are available.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,7 +8,7 @@ Only the latest version of `glide-py` published on PyPI receives security fixes.
 
 Please **do not** open a public GitHub issue for security vulnerabilities, as this would disclose the issue before a fix is available.
 
-To report a vulnerability, use the **"Report a vulnerability"** button in the [Security tab](https://github.com/EmertonData/glide/security/advisories/new) of this repository. This opens a draft private advisory visible only to you and the maintainers.
+To report a vulnerability, use the **"Report a vulnerability"** button in the [Security and Quality tab](https://github.com/EmertonData/glide/security/advisories/new) of this repository. This opens a draft private advisory visible only to you and the maintainers.
 
 Please include as much of the following as possible: a description of the vulnerability, the affected version(s), steps to reproduce, and any proof-of-concept code.
 


### PR DESCRIPTION
### Description

- What does this PR do?
Adds a SECURITY.md file specifying the repository's security policy
- Which issue does it close? (use `Closes #<number>`)
Settles this [ticket](https://github.com/orgs/EmertonData/projects/26/views/2?pane=issue&itemId=192574841)
- Any noteworthy implementation decisions or trade-offs?

### Checklist

Quality gates that must be satisfied before requesting a review:

- [x] I have read `CONTRIBUTING.md`
- [ ] `make lint` passes
- [ ] `make type-check` passes
- [ ] `make tests` passes
- [ ] `make coverage` reports 100% coverage
- [ ] `make test-notebooks` passes
- [ ] New public API has numpy-style docstrings
- [ ] New public API is inserted in the API reference section of the documentation
- [ ] Docs build without warnings (`make doc`)
- [ ] `CHANGELOG.md` updated if the change is user-facing

### LLM usage

Disclose if an LLM was used in writing this PR:
- [x] No LLM used
- [ ] I used an LLM and I went through and validated all the code myself