### PR TITLE
Permission scopes in github workflows

### DIFF
--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   quality:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,10 +6,15 @@ on:
       - "v*"         # automated PyPi publish on tag push of the form vX.Y.Z
   workflow_dispatch: # manual TestPyPI publish
 
+permissions: {}
+
 jobs:
   build:
     name: Build distribution 📦
     runs-on: ubuntu-latest
+
+    permissions:
+        contents: read
 
     steps:
       - uses: actions/checkout@v6.0.2


### PR DESCRIPTION
### Description

- What does this PR do?
This PR integrates github's code scanning feedback by adding permission scopes to workflows
- Which issue does it close? (use `Closes #<number>`)
Settles this [ticket](https://github.com/orgs/EmertonData/projects/26/views/2?pane=issue&itemId=193102850)
- Any noteworthy implementation decisions or trade-offs?
- Claude assisted rationale :
This PR resolves medium-severity code scanning alerts flagging that workflow jobs ran with GitHub's broad default token permissions. A workflow-level `permissions: contents: read` block was added to `code_quality.yml`, and a top-level `permissions: {}` deny-all block was added to `release.yml`, with each job then declaring only what it needs: `contents: read` for the build job and `id-token: write` for the two PyPI publish jobs (required for OIDC Trusted Publishing).

Without explicit permission declarations, GitHub Actions grants jobs a default token with write access to repository contents and several other scopes. A compromised third-party action could abuse those grants. With these changes, any future job added without an explicit `permissions` block inherits `none` rather than broad defaults.

### Checklist

Quality gates that must be satisfied before requesting a review:

- [x] I have read `CONTRIBUTING.md`
- [ ] `make lint` passes
- [ ] `make type-check` passes
- [ ] `make tests` passes
- [ ] `make coverage` reports 100% coverage
- [ ] `make test-notebooks` passes
- [ ] New public API has numpy-style docstrings
- [ ] New public API is inserted in the API reference section of the documentation
- [ ] Docs build without warnings (`make doc`)
- [ ] `CHANGELOG.md` updated if the change is user-facing

### LLM usage

Disclose if an LLM was used in writing this PR:
- [ ] No LLM used
- [x] I used an LLM and I went through and validated all the code myself