### PR TITLE
Update ticket skill: tighten templates and support updating existing tickets

### DIFF
--- a/.claude/skills/ticket/SKILL.md
+++ b/.claude/skills/ticket/SKILL.md
@@ -9,6 +9,8 @@ This skill produces a single markdown file in `tickets/` that a junior Python de
 
 There are four ticket types, each with its own template. The workflow is the same for all of them.
 
+This skill also handles **updating an existing ticket** that has diverged from the current code since it was written — for example when the referenced classes or files have been renamed, restructured, or the relevant logic has moved. When the user points to an existing ticket file, re-read both the ticket and the current codebase, then update the ticket in place to reflect the current state.
+
 ---
 
 ## Workflow
@@ -66,7 +68,7 @@ Load the template for the ticket type from `references/`:
 | Documentation | `references/template-documentation.md` |
 | Repository | `references/template-repository.md` |
 
-Follow the template exactly. Acceptance criteria must be specific to this ticket. Never include items already covered by the team's PR template (`.github/PULL_REQUEST_TEMPLATE.md`) — the following are required on every PR and must not appear in ticket-specific criteria:
+Follow the template exactly. Keep the overall ticket concise: the **Background** and **Design choices** sections in particular must be brief and synthetic — a few tight sentences per paragraph at most, not exhaustive write-ups. Avoid restating the paper, the full codebase context, or rationale that can be inferred from the code. Acceptance criteria must be specific to this ticket. Never include items already covered by the team's PR template (`.github/PULL_REQUEST_TEMPLATE.md`) — the following are required on every PR and must not appear in ticket-specific criteria:
 
 - `make lint` passes
 - `make type-check` passes

--- a/.claude/skills/ticket/SKILL.md
+++ b/.claude/skills/ticket/SKILL.md
@@ -9,7 +9,7 @@ This skill produces a single markdown file in `tickets/` that a junior Python de
 
 There are four ticket types, each with its own template. The workflow is the same for all of them.
 
-This skill also handles **updating an existing ticket** that has diverged from the current code since it was written — for example when the referenced classes or files have been renamed, restructured, or the relevant logic has moved. When the user points to an existing ticket file, re-read both the ticket and the current codebase, then update the ticket in place to reflect the current state.
+This skill also handles **updating an existing ticket** that has diverged from the current code since it was written — for example when the referenced classes or files have been renamed, restructured, or the relevant logic has moved. When the user points to an existing ticket file, re-read both the ticket and the current codebase, then update the ticket in place to reflect the current state. The user may also explicitly describe the changes that have occurred (e.g. a rename, a refactor, a new module) — treat that description as the starting point for understanding what in the ticket needs updating, then verify against the codebase.
 
 ---
 

--- a/.claude/skills/ticket/references/template-documentation.md
+++ b/.claude/skills/ticket/references/template-documentation.md
@@ -3,6 +3,10 @@
 ```markdown
 # [Documentation title: what is being written or improved]
 
+## TODO
+
+- [ ] <!-- placeholder for refinement actions: update, split, convert to issue, etc. -->
+
 ## Background
 
 [1–2 paragraphs. What is missing, inconsistent, or unclear in the current documentation. Be specific — point to the relevant files, sections, or docstrings. Explain why this matters for users or contributors (e.g. "the API reference omits the `alpha` parameter", "the user guide for samplers was never written", "three different notebooks use different notation for the same quantity").]

--- a/.claude/skills/ticket/references/template-feature.md
+++ b/.claude/skills/ticket/references/template-feature.md
@@ -3,15 +3,17 @@
 ```markdown
 # [Feature title: algorithm name and brief purpose]
 
+## TODO
+
+- [ ] <!-- placeholder for refinement actions: update, split, convert to issue, etc. -->
+
 ## Background
 
-[2–4 paragraphs. Answer: what problem does this solve, what is the core mathematical idea, why does it matter for GLIDE's goal of evaluating GenAI systems with hybrid annotations, and what assumptions does it make.
-
-Write as if explaining to a smart developer who just graduated: comfortable with Python and NumPy, but no statistics background. Use plain analogies. Introduce any formula with a sentence like "In math notation this is written as..." before showing it. Never assume the reader has seen the paper.]
+[2–3 tight sentences per paragraph, 2 paragraphs max. Answer: what problem does this solve, what is the core mathematical idea, and why it matters for GLIDE. Write for a developer with no statistics background — define any term that is not common Python knowledge. One formula at most, introduced with "In math notation this is written as...". Never summarise the full paper.]
 
 ## Design choices
 
-[2–3 paragraphs. Cover: where in the codebase this lives and why, how it relates to existing classes (inherits from X, mirrors Y, extends Z), any deliberate departures from the paper (scope restrictions, Python-idiomatic adaptations), and key interface decisions (constructor arguments, method names, return types). Explain the reasoning behind each choice — developers should understand the intent, not just the rule.]
+[1–2 paragraphs, strictly synthetic. Cover only: where in the codebase this lives and why, how it relates to existing classes (inherits from X, mirrors Y), and any key interface decisions. One sentence of reasoning per choice is enough. Skip anything the code already makes obvious.]
 
 ## Implementation
 

--- a/.claude/skills/ticket/references/template-refactoring.md
+++ b/.claude/skills/ticket/references/template-refactoring.md
@@ -3,13 +3,17 @@
 ```markdown
 # [Refactoring title: what is changing and why]
 
+## TODO
+
+- [ ] <!-- placeholder for refinement actions: update, split, convert to issue, etc. -->
+
 ## Background
 
-[2–3 paragraphs. Explain what the current code does (with file and line pointers), why it needs to change (inconsistency, duplication, API mismatch, naming confusion), and what the goal state looks like. Be concrete — name the specific classes, methods, or files involved. A developer who has never touched this code should understand both the current problem and the intended result.]
+[1–2 tight paragraphs. Name the specific files, classes, and methods involved. State the current problem (inconsistency, duplication, naming confusion) and the goal state in one sentence each. Skip context that the Implementation section already makes obvious.]
 
 ## Design choices
 
-[How the refactored code will be structured. What gets renamed, moved, merged, or split. Explain the reasoning behind each choice. If an alternative was considered and rejected, say why. Keep it honest — "we chose X over Y because Z" is more useful than just "we chose X".
+[1 paragraph max, strictly synthetic. What gets renamed, moved, merged, or split, and the key reason for each choice. One sentence per decision is enough — "chose X over Y because Z".
 
 **On extractions:** when shared logic is pulled into a new function or module, callers should call it directly — not wrap it in a one-liner delegate method. One-liner delegates duplicate test surface and add indirection without any benefit. Remove the original method and update every caller to use the new function.]
 

--- a/.claude/skills/ticket/references/template-repository.md
+++ b/.claude/skills/ticket/references/template-repository.md
@@ -3,6 +3,10 @@
 ```markdown
 # [Repository title: what is being improved and why]
 
+## TODO
+
+- [ ] <!-- placeholder for refinement actions: update, split, convert to issue, etc. -->
+
 ## Background
 
 [1–2 paragraphs. What is the current problem or gap: a missing CI check, a slow test suite, a flaky pipeline, an outdated dependency, missing pre-commit hooks. Be concrete — link to the relevant config files, CI runs, or failing steps. Explain the impact (e.g. "coverage is not enforced on PRs", "the type-checker runs but its output is ignored", "notebook outputs are committed to the repository").]


### PR DESCRIPTION
### Description

- What does this PR do?
Tightens the Background and Design choices section guidelines across all ticket templates to require concise, synthetic write-ups, and adds a `## TODO` section to each template. Also extends the ticket skill to support updating existing ticket files that have diverged from the current codebase.
- Which issue does it close? (use `Closes #<number>`)
Handles this [ticket](https://github.com/orgs/EmertonData/projects/26/views/2?pane=issue&itemId=188971934)
- Any noteworthy implementation decisions or trade-offs?

### Checklist

Quality gates that must be satisfied before requesting a review:

- [x] I have read `CONTRIBUTING.md`
- [x] `make lint` passes
- [x] `make type-check` passes
- [x] `make tests` passes
- [x] `make coverage` reports 100% coverage
- [ ] `make test-notebooks` passes
- [ ] New public API has numpy-style docstrings
- [ ] New public API is inserted in the API reference section of the documentation
- [x] Docs build without warnings (`make doc`)
- [ ] `CHANGELOG.md` updated if the change is user-facing

### LLM usage

Disclose if an LLM was used in writing this PR:
- [ ] No LLM used
- [x] I used an LLM and I went through and validated all the code myself