### PR TITLE
Enhance CLAUDE.md with detailed module descriptions and update settings.json permissions

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -30,15 +30,17 @@ Run a single test file: `uv run pytest tests/unit/test_foo.py -vsx`
 
 The package has multiple layers:
 
-**`glide/estimators/`** — Public API. Statistical estimators (classical, PPI, ASI, IPW, PTD, and their stratified variants).
+**`glide/estimators/`** — Public API. Statistical estimators (classical, PPI, ASI, IPW, PTD, and their stratified variants). Core computation modules (`ppi_core.py`, `ptd_core.py`, `stratified_core.py`) hold shared internals.
 
 **`glide/confidence_intervals/`** — Confidence interval implementations depending on statistical methods.
 
-**`glide/samplers/`** — Sampler object implementations for various strategies.
+**`glide/samplers/`** — Sampler object implementations (uniform, stratified, cost-optimal, cost-optimal-random, active).
 
-**`glide/mean_inference_results/`** — Result dataclasses returned by estimators (e.g. `MeanInferenceResult`).
+**`glide/mean_inference_results/`** — Result dataclasses returned by estimators. `base.py` defines `MeanInferenceResult`; `classical.py` and `prediction_powered.py` extend it.
 
-**`glide/utils.py`** — Shared internal helpers (e.g. `compute_effective_sample_size`).
+**`glide/core/`** — Centralized parameter validation helpers (`validation.py`). Import from here rather than duplicating checks across modules.
+
+**`glide/scientific_validation.py`** — `run_monte_carlo()` utility used by deep-dive validation notebooks.
 
 **`glide/simulators/`** — Synthetic dataset generators and annotation simulators for testing and validation.
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,7 +1,12 @@
 {
   "permissions": {
     "allow": [
-      "Bash(python3)"
+      "Bash(python3)",
+      "Bash(uv run *)",
+      "Bash(make *)",
+      "Bash(git status)",
+      "Bash(git diff*)",
+      "Bash(git log*)"
     ]
   },
   "enabledPlugins": {


### PR DESCRIPTION
### Description

Tried the Claude code setup plugin. End up doing quite few things actually. The main improvement is about skills we already have on the roadmap.

### Checklist

Quality gates that must be satisfied before requesting a review:

- [ ] I have read `CONTRIBUTING.md`
- [ ] `make lint` passes
- [ ] `make type-check` passes
- [ ] `make tests` passes
- [ ] `make coverage` reports 100% coverage
- [ ] `make test-notebooks` passes
- [ ] New public API has numpy-style docstrings
- [ ] New public API is inserted in the API reference section of the documentation
- [ ] Docs build without warnings (`make doc`)
- [ ] `CHANGELOG.md` updated if the change is user-facing

### LLM usage

Disclose if an LLM was used in writing this PR:
- [ ] No LLM used
- [x] I used an LLM and I went through and validated all the code myself