### PR TITLE
Simplify citation instructions in README

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -162,6 +162,21 @@ Remove debug cells, dead code, and stray blank lines before merging. This applie
 
 Information should appear exactly once. If two classes share logic (e.g., a validation raise), extract it rather than duplicating. If two doc sections say the same thing, remove one.
 
+### Commit Messages
+
+Use Conventional Commits prefixes:
+
+- `feat:` — new feature
+- `fix:` — bug fix
+- `doc:` — documentation only
+- `ref:` — code restructuring, no behaviour change
+- `test:` — adding or fixing tests
+- `chore:` — maintenance tasks (config, tooling, dependencies, CI)
+- `perf:` — performance improvement
+- `style:` — formatting, no logic change
+- `build:` — build system or dependency changes
+- `ci:` — CI/CD pipeline changes
+
 ### Consistency and Propagation
 
 Before adding a new class, function, or module, find the nearest equivalent already in the codebase and verify that the new code mirrors it in structure, naming, and block ordering. When a good pattern appears in new code that the existing code lacks, propagate it to the existing code in the same PR. When a rename or refactor touches one site, grep for all other sites that use the old name and update them before considering the work done.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,7 +6,10 @@
       "Bash(make *)",
       "Bash(git status)",
       "Bash(git diff*)",
-      "Bash(git log*)"
+      "Bash(git log*)",
+      "Bash(gh issue list*)",
+      "Bash(gh label list*)",
+      "Bash(gh pr list*)"
     ]
   },
   "enabledPlugins": {

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ branch:
 	git checkout main && git pull && git checkout -b $(name)
   
 test-notebooks:
-	@find docs -name "*.ipynb" | while read notebook; do \
+	@find docs -name "*.ipynb" ! -path "*/generated/*" | while read notebook; do \
 		echo "Testing $$notebook..."; \
 		if ! uv run papermill "$$notebook" /dev/null > /tmp/nb_$$.log 2>&1; then \
 			cat /tmp/nb_$$.log | grep -v -E "(UserWarning|Executing:|Output Notebook|warnings.warn)"; \

--- a/README.md
+++ b/README.md
@@ -69,19 +69,8 @@ This project follows [SPEC 0](https://scientific-python.org/specs/spec-0000/) fo
 ## 📄 License & Citation
 
 This project is licensed under the [Apache 2.0 License](https://raw.githubusercontent.com/EmertonData/glide/refs/heads/main/LICENSE).
-If you use Glide in your work, please cite our paper presented at the ICML 2026 Agentic Uncertainty workshop:
 
-```bibtex
-@misc{martinon2026glide,
-  author        = {Martinon, Grégoire and Merad, Ibrahim and Raki, Mohammed},
-  title         = {Industrializing Prediction-Powered Inference: The GLIDE Library for Reliable GenAI and Agentic Systems Evaluation},
-  year          = {2026},
-  eprint        = {2605.31278},
-  archivePrefix = {arXiv},
-  primaryClass  = {cs.AI},
-  doi           = {10.48550/arXiv.2605.31278},
-}
-```
+If you use GLIDE in your work, please cite us using the "Cite this repository" button on the GitHub repository page.
 
 ## 📰 Implemented Papers <a name="implemented-papers"></a>
 

--- a/docs/deep_dive/icml_case_study.ipynb
+++ b/docs/deep_dive/icml_case_study.ipynb
@@ -27,12 +27,12 @@
    "source": [
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",
-    "from datasets import load_dataset\n",
-    "from numpy.typing import NDArray\n",
+    "from datasets import DownloadConfig, load_dataset\n",
     "from sklearn.metrics import cohen_kappa_score\n",
     "\n",
     "from glide.estimators import ASIMeanEstimator, ClassicalMeanEstimator, PPIMeanEstimator, StratifiedPPIMeanEstimator\n",
     "from glide.samplers import ActiveSampler, StratifiedSampler, UniformSampler\n",
+    "from glide.scientific_validation import compute_hits, coverage_with_error_bar, run_monte_carlo\n",
     "from glide.simulators import simulate_annotation\n",
     "\n",
     "plt.rcParams.update(\n",
@@ -109,7 +109,7 @@
    "source": [
     "# Dataset published at https://huggingface.co/datasets/imerad-kv/r_judge_labelled\n",
     "# See the Annex for details on how proxy labels and confidence scores were generated.\n",
-    "dataset = load_dataset(\"imerad-kv/r_judge_labelled\")\n",
+    "dataset = load_dataset(\"imerad-kv/r_judge_labelled\", download_config=DownloadConfig(max_retries=10))\n",
     "dataset = dataset[\"train\"]\n",
     "\n",
     "y_true_oracle = np.array(dataset[\"label\"]).astype(float)\n",
@@ -232,7 +232,7 @@
     "\n",
     "The three GLIDE methods all use `N_LABELED` revealed labels and additionally incorporate the full proxy signal over all trajectories.\n",
     "\n",
-    "The `generate_estimate` function below runs a single workflow on one draw of the sampling mask and returns the mean estimate, standard deviation, and confidence interval."
+    "The `generate_estimates` function below runs all workflows on one draw of the sampling mask and returns the mean estimates, standard deviations, and confidence intervals."
    ]
   },
   {
@@ -242,18 +242,21 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def generate_estimate(y_true_oracle, y_proxy, groups, uncertainties, workflow, seed):\n",
-    "    \"\"\"Return mean, std, confidence interval, and effective sample size for a single estimation workflow.\"\"\"\n",
-    "    estimator = WORKFLOWS_ESTIMATORS[workflow]()\n",
-    "    data = preprocess_data(y_true_oracle, y_proxy, groups, uncertainties, workflow, seed)\n",
-    "    result = estimator.estimate(*data, confidence_level=CONFIDENCE_LEVEL)\n",
-    "    effective_sample_size = getattr(result, \"effective_sample_size\", None)\n",
-    "    return {\n",
-    "        \"mean\": result.mean,\n",
-    "        \"std\": result.std,\n",
-    "        \"confidence_interval\": result.confidence_interval,\n",
-    "        \"effective_sample_size\": effective_sample_size,\n",
-    "    }"
+    "def generate_estimates(y_true_oracle, y_proxy, groups, uncertainties, seed):\n",
+    "    \"\"\"Return mean, std, confidence interval, and effective sample size for all workflows.\"\"\"\n",
+    "    estimates = dict()\n",
+    "    for workflow in WORKFLOWS_ESTIMATORS:\n",
+    "        estimator = WORKFLOWS_ESTIMATORS[workflow]()\n",
+    "        data = preprocess_data(y_true_oracle, y_proxy, groups, uncertainties, workflow, seed)\n",
+    "        result = estimator.estimate(*data, confidence_level=CONFIDENCE_LEVEL)\n",
+    "        effective_sample_size = getattr(result, \"effective_sample_size\", None)\n",
+    "        estimates[workflow] = {\n",
+    "            \"mean\": result.mean,\n",
+    "            \"std\": result.std,\n",
+    "            \"confidence_interval\": result.confidence_interval,\n",
+    "            \"effective_sample_size\": effective_sample_size,\n",
+    "        }\n",
+    "    return estimates"
    ]
   },
   {
@@ -261,102 +264,24 @@
    "id": "12",
    "metadata": {},
    "source": [
-    "The three functions below implement the Monte Carlo evaluation:\n",
-    "- `monte_carlo_simulation` runs `N_SEEDS` draws and caches per-seed means and confidence interval bounds across all workflows and confidence levels.\n",
-    "\n",
-    "- `compute_hits` turns the cached bounds into hit indicators: for each seed it records whether the confidence interval contained the true mean.\n",
-    "\n",
-    "- `coverage_with_errbar` aggregates the hit indicators into an empirical coverage estimate with a confidence interval."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "13",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "def monte_carlo_simulation(confidence_levels: NDArray, n_seeds=N_SEEDS):\n",
-    "    \"\"\"Single Monte Carlo loop: cache per-seed mean, std, confidence interval bounds, and ESS.\"\"\"\n",
-    "    means = {workflow: np.zeros(n_seeds) for workflow in WORKFLOWS_ESTIMATORS}\n",
-    "    stds = {workflow: np.zeros(n_seeds) for workflow in WORKFLOWS_ESTIMATORS}\n",
-    "    lower_bounds = {\n",
-    "        workflow: {confidence_level: np.zeros(n_seeds) for confidence_level in confidence_levels}\n",
-    "        for workflow in WORKFLOWS_ESTIMATORS\n",
-    "    }\n",
-    "    upper_bounds = {\n",
-    "        workflow: {confidence_level: np.zeros(n_seeds) for confidence_level in confidence_levels}\n",
-    "        for workflow in WORKFLOWS_ESTIMATORS\n",
-    "    }\n",
-    "    ess_values = {workflow: np.zeros(n_seeds) for workflow in WORKFLOWS_ESTIMATORS}\n",
-    "\n",
-    "    for seed in range(n_seeds):\n",
-    "        estimates = {\n",
-    "            workflow: generate_estimate(y_true_oracle, y_proxy, groups, uncertainties, workflow, seed)\n",
-    "            for workflow in WORKFLOWS_ESTIMATORS\n",
-    "        }\n",
-    "\n",
-    "        for workflow in WORKFLOWS_ESTIMATORS:\n",
-    "            means[workflow][seed] = estimates[workflow][\"mean\"]\n",
-    "            stds[workflow][seed] = estimates[workflow][\"std\"]\n",
-    "            ess_value = estimates[workflow][\"effective_sample_size\"]\n",
-    "            if ess_value is not None:\n",
-    "                ess_values[workflow][seed] = ess_value\n",
-    "            for confidence_level in confidence_levels:\n",
-    "                confidence_interval = estimates[workflow][\"confidence_interval\"]\n",
-    "                confidence_interval.confidence_level = confidence_level\n",
-    "                lower_bounds[workflow][confidence_level][seed] = confidence_interval.lower_bound\n",
-    "                upper_bounds[workflow][confidence_level][seed] = confidence_interval.upper_bound\n",
-    "\n",
-    "    stats = {\n",
-    "        workflow: {\n",
-    "            \"means\": means[workflow],\n",
-    "            \"stds\": stds[workflow],\n",
-    "            \"lower_bounds\": lower_bounds[workflow],\n",
-    "            \"upper_bounds\": upper_bounds[workflow],\n",
-    "            \"ess_values\": ess_values[workflow],\n",
-    "        }\n",
-    "        for workflow in WORKFLOWS_ESTIMATORS\n",
-    "    }\n",
-    "    return stats\n",
-    "\n",
-    "\n",
-    "def compute_hits(workflow_stats, confidence_level):\n",
-    "    \"\"\"Return per-seed hit indicators for a single workflow at the given confidence level.\"\"\"\n",
-    "    lower_bounds = workflow_stats[\"lower_bounds\"][confidence_level]\n",
-    "    upper_bounds = workflow_stats[\"upper_bounds\"][confidence_level]\n",
-    "    hits = np.asarray((lower_bounds <= true_mean) & (true_mean <= upper_bounds), dtype=float)\n",
-    "    return hits\n",
-    "\n",
-    "\n",
-    "def coverage_with_errbar(hits, confidence_level):\n",
-    "    \"\"\"Estimate empirical coverage and confidence interval via ClassicalMeanEstimator.\"\"\"\n",
-    "    estimator = ClassicalMeanEstimator()\n",
-    "    r = estimator.estimate(hits, confidence_level=confidence_level)\n",
-    "    return r.mean, r.confidence_interval.lower_bound, r.confidence_interval.upper_bound"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "14",
-   "metadata": {},
-   "source": [
     "In the following sections we first verify that all labeled-data methods achieve valid coverage, then compare interval widths to assess efficiency."
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "15",
+   "id": "13",
    "metadata": {},
    "source": [
     "## Coverage Validity\n",
     "\n",
-    "A confidence interval is **valid** if it contains the true parameter at the stated rate. A 90% interval is valid when, across many independent draws of the sampling mask, roughly 90% of the resulting intervals contain the true mean $\\mu$. We measure this empirically via the Monte Carlo experiment."
+    "A confidence interval is **valid** if it contains the true parameter at the stated rate. A 90% interval is valid when, across many independent draws of the sampling mask, roughly 90% of the resulting intervals contain the true mean $\\mu$.\n",
+    "\n",
+    "We run a Monte Carlo experiment to verify this for each workflow. We check that the empirical coverage tracks the nominal level throughout. See the [Scientific Validation Methodology](scientific_validation.md) page for more details about the verification protocol."
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "16",
+   "id": "14",
    "metadata": {},
    "source": [
     "### Coverage vs target confidence level\n",
@@ -367,29 +292,31 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "17",
+   "id": "15",
    "metadata": {},
    "outputs": [],
    "source": [
     "confidence_levels = np.arange(0.55, 1.00, 0.05)\n",
     "confidence_levels = np.round(confidence_levels, 2)\n",
     "\n",
-    "raw_stats = monte_carlo_simulation(confidence_levels)\n",
+    "raw_stats = run_monte_carlo(\n",
+    "    confidence_levels, run_seed=lambda seed: generate_estimates(y_true_oracle, y_proxy, groups, uncertainties, seed)\n",
+    ")\n",
     "\n",
     "coverages_confidence_intervals = {}\n",
     "for confidence_level in confidence_levels:\n",
     "    coverages_confidence_intervals[confidence_level] = {}\n",
+    "    hits = compute_hits(raw_stats, confidence_level, true_mean)\n",
+    "    coverages_confidence_intervals[confidence_level] = dict()\n",
     "    for workflow in WORKFLOWS_ESTIMATORS:\n",
-    "        hits = compute_hits(raw_stats[workflow], confidence_level)\n",
-    "        coverages_confidence_intervals[confidence_level][workflow] = coverage_with_errbar(\n",
-    "            hits, confidence_level=CONFIDENCE_LEVEL\n",
-    "        )"
+    "        coverage_confidence_interval = coverage_with_error_bar(hits[workflow], confidence_level=CONFIDENCE_LEVEL)\n",
+    "        coverages_confidence_intervals[confidence_level][workflow] = coverage_confidence_interval"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "18",
+   "id": "16",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -416,7 +343,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "19",
+   "id": "17",
    "metadata": {},
    "source": [
     "All labeled-data methods show valid coverage except for `Proxy only` which is far below and not visible on this scale."
@@ -424,7 +351,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "20",
+   "id": "18",
    "metadata": {},
    "source": [
     "---\n",
@@ -437,7 +364,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "21",
+   "id": "19",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -453,7 +380,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "22",
+   "id": "20",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -480,7 +407,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "23",
+   "id": "21",
    "metadata": {},
    "source": [
     "We observe that GLIDE's estimation algorithms achieve variable improvements over the `True only` baseline in terms of confidence interval width. The ASI (Active) and PPI++ approaches show a sizable and similar benefit on interval width reduction which can be attributed to the information brought by proxy labels. ASI is slightly better, likely thanks to the uncertainty based active sampling. The stratified approach produces even narrower confidence intervals by exploiting the underlying data structure. `Proxy only`'s narrow intervals are misleading given its invalid coverage."
@@ -488,18 +415,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "24",
+   "id": "22",
    "metadata": {},
    "source": [
     "## Effective Sample Size\n",
     "\n",
-    "A natural summary of an estimator's efficiency gain is the **Effective Sample Size (ESS)**: *it is the number of human labels needed to achieve the same confidence interval width as the said estimator with the current budget.*\n",
+    "A natural summary of an estimator's efficiency gain is the **effective sample size (ESS)**: *the number of human labels needed to achieve the same confidence interval width as the said estimator with the current budget.*\n",
     "\n",
-    "Since confidence interval width $\\propto 1/\\sqrt{n}$, we can estimate ESS empirically as:\n",
-    "\n",
-    "$$\\text{ESS} = N_{\\text{labeled}} \\times \\left(\\frac{\\bar{w}_{\\text{human labels}}}{\\bar{w}_{\\text{est}}}\\right)^2,$$\n",
-    "\n",
-    "where $\\bar{w}_{\\text{est}}$ and $\\bar{w}_{\\text{human labels}}$ are the confidence interval widths for the given estimator and using human labels only respectively.\n",
+    "See the [Scientific Validation Methodology](scientific_validation.md) page for the formal definition and formula of ESS.\n",
     "\n",
     "Let us compute the average ESS of the best workflow, which is Stratified, over all runs:"
    ]
@@ -507,17 +430,17 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "25",
+   "id": "23",
    "metadata": {},
    "outputs": [],
    "source": [
-    "stratified_avg_ess = int(np.mean(raw_stats[\"Stratified\"][\"ess_values\"]))\n",
+    "stratified_avg_ess = int(np.mean(raw_stats[\"Stratified\"][\"effective_sample_sizes\"]))\n",
     "print(f\"Average ESS (Stratified): {stratified_avg_ess}\")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "26",
+   "id": "24",
    "metadata": {},
    "source": [
     "Thus, on average, the Stratified workflow estimate's precision is equivalent to that of the classical estimator built from more human-labeled samples, even though fewer labels were collected. This improvement is achieved by properly leveraging the proxy samples."
@@ -525,7 +448,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "27",
+   "id": "25",
    "metadata": {},
    "source": [
     "## Summary\n",
@@ -548,7 +471,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "28",
+   "id": "26",
    "metadata": {},
    "source": [
     "---\n",


### PR DESCRIPTION
### Description

- Removes the manual citation block from `README.md`. Citation details are already defined in `CITATION.cff`; GitHub's native "Cite this repository" button surfaces them automatically, so duplicating them in the README adds maintenance overhead.
- No issue.

### Checklist

Quality gates that must be satisfied before requesting a review:

- [x] I have read `CONTRIBUTING.md`
- [ ] `make lint` passes
- [ ] `make type-check` passes
- [ ] `make tests` passes
- [ ] `make coverage` reports 100% coverage
- [ ] `make test-notebooks` passes
- [ ] New public API has numpy-style docstrings
- [ ] New public API is inserted in the API reference section of the documentation
- [ ] Docs build without warnings (`make doc`)
- [ ] `CHANGELOG.md` updated if the change is user-facing

### LLM usage

Disclose if an LLM was used in writing this PR:
- [ ] No LLM used
- [x] I used an LLM and I went through and validated all the code myself