### PR TITLE
Add ClusterClassicalMeanEstimator for cluster-sampling-aware mean estimation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ## [Next release]
 
 ### ✨ Added
+- `ClusterClassicalMeanEstimator` for cluster-sampling-aware classical mean estimation with CLT-based confidence intervals.
 - `generate_clustered_binary_dataset` simulator for generating binary datasets with randomly sized clusters.
 - Image in the readme describing prediction-powered inference
 - Image in the user guide describing GLIDE's three-step workflow

--- a/docs/api/estimators.md
+++ b/docs/api/estimators.md
@@ -12,6 +12,10 @@
 
 ---
 
+::: glide.estimators.cluster_classical.ClusterClassicalMeanEstimator
+
+---
+
 ::: glide.estimators.ppi.PPIMeanEstimator
 
 ---

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -30,6 +30,7 @@
 | [`ClassicalMeanEstimator`](estimators.md#glide.estimators.classical.ClassicalMeanEstimator) | Classical sample mean without proxy labels |
 | [`StratifiedClassicalMeanEstimator`](estimators.md#glide.estimators.stratified_classical.StratifiedClassicalMeanEstimator) | Classical mean with population-proportional stratification |
 | [`IPWClassicalMeanEstimator`](estimators.md#glide.estimators.ipw_classical.IPWClassicalMeanEstimator) | Classical mean with inverse probability weighting |
+| [`ClusterClassicalMeanEstimator`](estimators.md#glide.estimators.cluster_classical.ClusterClassicalMeanEstimator) | Classical sample mean on clustered data |
 
 ### Prediction-Powered
 

--- a/glide/core/validation.py
+++ b/glide/core/validation.py
@@ -11,8 +11,12 @@ def _validate_non_constant(array: NDArray, error_message: str) -> None:
 
 
 def _validate_has_no_nan(array: NDArray, name: str) -> None:
-    if np.isnan(array).any():
-        raise ValueError(f"'{name}' contains NaN values.")
+    if np.issubdtype(array.dtype, np.number):
+        if np.isnan(array).any():
+            raise ValueError(f"'{name}' contains NaN values.")
+    else:
+        if any(v is None for v in array):
+            raise ValueError(f"'{name}' contains None values.")
 
 
 def _get_non_zero_mask(values: NDArray, warning_message: Optional[str] = None) -> NDArray:

--- a/glide/core/validation.py
+++ b/glide/core/validation.py
@@ -15,7 +15,7 @@ def _validate_has_no_nan(array: NDArray, name: str) -> None:
         if np.isnan(array).any():
             raise ValueError(f"'{name}' contains NaN values.")
     else:
-        if any(v is None for v in array):
+        if None in array:
             raise ValueError(f"'{name}' contains None values.")
 
 

--- a/glide/estimators/__init__.py
+++ b/glide/estimators/__init__.py
@@ -1,5 +1,6 @@
 from glide.estimators.asi import ASIMeanEstimator
 from glide.estimators.classical import ClassicalMeanEstimator
+from glide.estimators.cluster_classical import ClusterClassicalMeanEstimator
 from glide.estimators.ipw_classical import IPWClassicalMeanEstimator
 from glide.estimators.ipw_ptd import IPWPTDMeanEstimator
 from glide.estimators.ppi import PPIMeanEstimator
@@ -10,6 +11,7 @@ from glide.estimators.stratified_ptd import StratifiedPTDMeanEstimator
 
 __all__ = [
     "ClassicalMeanEstimator",
+    "ClusterClassicalMeanEstimator",
     "StratifiedClassicalMeanEstimator",
     "IPWClassicalMeanEstimator",
     "PPIMeanEstimator",

--- a/glide/estimators/__init__.py
+++ b/glide/estimators/__init__.py
@@ -11,9 +11,9 @@ from glide.estimators.stratified_ptd import StratifiedPTDMeanEstimator
 
 __all__ = [
     "ClassicalMeanEstimator",
-    "ClusterClassicalMeanEstimator",
     "StratifiedClassicalMeanEstimator",
     "IPWClassicalMeanEstimator",
+    "ClusterClassicalMeanEstimator",
     "PPIMeanEstimator",
     "StratifiedPPIMeanEstimator",
     "ASIMeanEstimator",

--- a/glide/estimators/classical.py
+++ b/glide/estimators/classical.py
@@ -29,9 +29,10 @@ class ClassicalMeanEstimator:
     """
 
     def _preprocess(self, y: NDArray) -> NDArray:
-        y_clean = y[~np.isnan(y)]
-        _validate_min_samples(y_clean, "y")
-        return y_clean
+        not_nan_mask = ~np.isnan(y)
+        y_valid = y[not_nan_mask]
+        _validate_min_samples(y_valid, "y")
+        return y_valid
 
     def estimate(
         self,
@@ -63,10 +64,10 @@ class ClassicalMeanEstimator:
         ValueError
             If ``y`` contains fewer than 2 non-NaN values.
         """
-        y_clean = self._preprocess(y)
-        n_samples = len(y_clean)
-        mean = np.mean(y_clean)
-        std = np.std(y_clean, ddof=1) / np.sqrt(n_samples)
+        y_valid = self._preprocess(y)
+        n_samples = len(y_valid)
+        mean = np.mean(y_valid)
+        std = np.std(y_valid, ddof=1) / np.sqrt(n_samples)
         ci = CLTConfidenceInterval(
             mean=mean,
             std=std,

--- a/glide/estimators/cluster_classical.py
+++ b/glide/estimators/cluster_classical.py
@@ -1,0 +1,120 @@
+from typing import List
+
+import numpy as np
+from numpy.typing import NDArray
+
+from glide.confidence_intervals import CLTConfidenceInterval
+from glide.core.validation import _validate_equal_lengths
+from glide.mean_inference_results import ClassicalMeanInferenceResult
+
+
+class ClusterClassicalMeanEstimator:
+    """Cluster classical estimator for population mean.
+
+    Extends mean estimation as in ``ClassicalMeanEstimator`` to datasets where
+    observations are grouped into clusters. Each cluster's size-weighted
+    contribution is treated as the sampling unit, which accounts for
+    within-cluster correlation and produces valid confidence intervals under
+    cluster sampling designs.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from glide.estimators import ClusterClassicalMeanEstimator
+    >>> y = np.array([5.0, 5.0, 7.0, 7.0])
+    >>> clusters = np.array(["A", "A", "B", "B"])
+    >>> estimator = ClusterClassicalMeanEstimator()
+    >>> result = estimator.estimate(y, clusters)
+    >>> print(result)
+    Metric: Metric
+    Point Estimate: 6.000
+    Confidence Interval (95%): [4.040, 7.960]
+    Estimator : ClusterClassicalMeanEstimator
+    n: 4
+    """
+
+    def estimate(
+        self,
+        y: NDArray,
+        clusters: NDArray,
+        metric_name: str = "Metric",
+        confidence_level: float = 0.95,
+    ) -> ClassicalMeanInferenceResult:
+        """Estimate the population mean using the cluster classical estimator.
+
+        Aggregates observations into cluster-level means weighted by cluster
+        size, then applies the CLT to the cluster sums as sampling units:
+
+            theta = sum_k  (n_k * mu_k) / N
+            sigma2 = K * Var(u_k, ddof=1) / N^2
+
+        where ``u_k = n_k * mu_k`` are the cluster sums, ``K`` is the number
+        of clusters, and ``N = sum_k n_k`` is the total number of observations.
+        NaN values in ``y`` are dropped per cluster before computing cluster
+        means. Clusters that contain only NaN are skipped.
+
+        Parameters
+        ----------
+        y : NDArray
+            Array of observations, shape ``(n_samples,)``. NaN values are
+            treated as missing and dropped per cluster.
+        clusters : NDArray
+            Array of cluster identifiers, shape ``(n_samples,)``.
+            Unique values define the clusters.
+        metric_name : str, optional
+            Human-readable label for the metric. Defaults to ``"Metric"``.
+        confidence_level : float, optional
+            Target coverage for the confidence interval. Defaults to ``0.95``.
+
+        Returns
+        -------
+        ClassicalMeanInferenceResult
+            Contains the CLT-based confidence interval, the metric name,
+            the estimator name (``"ClusterClassicalMeanEstimator"``), and ``n``
+            (total number of non-NaN observations across all clusters).
+
+        Raises
+        ------
+        ValueError
+            - If ``y`` and ``clusters`` do not have the same length.
+            - If fewer than 2 clusters have at least one non-NaN observation.
+        """
+        _validate_equal_lengths(y, clusters, names=["y", "clusters"])
+
+        cluster_means: List[float] = []
+        cluster_sizes: List[int] = []
+
+        for cluster_id in np.unique(clusters):
+            cluster_mask = clusters == cluster_id
+            cluster_y = y[cluster_mask]
+            cluster_y_valid = cluster_y[~np.isnan(cluster_y)]
+            if len(cluster_y_valid) == 0:
+                continue
+            cluster_means.append(np.mean(cluster_y_valid))
+            cluster_sizes.append(len(cluster_y_valid))
+
+        n_clusters = len(cluster_means)
+        if n_clusters < 2:
+            raise ValueError(f"Need at least 2 clusters with non-NaN observations; got {n_clusters}.")
+
+        means = np.array(cluster_means)
+        sizes = np.array(cluster_sizes)
+        cluster_sums = sizes * means
+        total_size = np.sum(sizes)
+
+        weighted_mean = np.sum(cluster_sums) / total_size
+        var = n_clusters * np.var(cluster_sums, ddof=1) / total_size**2
+        std = np.sqrt(var)
+
+        ci = CLTConfidenceInterval(
+            mean=weighted_mean,
+            std=std,
+            confidence_level=confidence_level,
+        )
+        result = ClassicalMeanInferenceResult(
+            confidence_interval=ci,
+            metric_name=metric_name,
+            estimator_name=self.__class__.__name__,
+            n=total_size,
+        )
+        return result

--- a/glide/estimators/cluster_classical.py
+++ b/glide/estimators/cluster_classical.py
@@ -39,8 +39,7 @@ class ClusterClassicalMeanEstimator:
         clusters: NDArray,
     ) -> Tuple[NDArray, NDArray, int]:
         _validate_equal_lengths(y, clusters, names=["y", "clusters"])
-        if np.issubdtype(clusters.dtype, np.number):
-            _validate_has_no_nan(clusters, "clusters")
+        _validate_has_no_nan(clusters, "clusters")
         not_nan_mask = ~np.isnan(y)
         y_valid = y[not_nan_mask]
         clusters_valid = clusters[not_nan_mask]
@@ -64,22 +63,22 @@ class ClusterClassicalMeanEstimator:
     ) -> ClassicalMeanInferenceResult:
         """Estimate the population mean using the cluster classical estimator.
 
-        Aggregates observations into cluster-level means weighted by cluster
-        size, then applies the CLT to the cluster sums as sampling units:
+        Computes within-cluster sums and uses them as sampling units to apply
+        the CLT:
 
-            theta = sum_l  (n_l * mu_l) / N
+            theta = (1 / N) * sum_l u_l
             sigma2 = L * Var(u_l, ddof=1) / N^2
 
-        where ``u_l = n_l * mu_l`` are the cluster sums, ``L`` is the number
-        of clusters, and ``N = sum_l n_l`` is the total number of observations.
-        NaN values in ``y`` are dropped before making the computations. Clusters
-        that contain only NaN are not used.
+        where ``u_l = sum_{i in l} y_i`` are the cluster sums, ``L`` is the
+        number of clusters, and ``N = sum_l n_l`` is the total number of
+        observations. NaN values in ``y`` are dropped before making the
+        computations. Clusters that contain only NaN are not used.
 
         Parameters
         ----------
         y : NDArray
             Array of observations, shape ``(n_samples,)``. NaN values are
-            treated as missing and dropped per cluster.
+            treated as missing and dropped.
         clusters : NDArray
             Array of cluster identifiers, shape ``(n_samples,)``.
             Unique values define the clusters.
@@ -99,7 +98,7 @@ class ClusterClassicalMeanEstimator:
         ------
         ValueError
             - If ``y`` and ``clusters`` do not have the same length.
-            - If ``clusters`` has a numeric dtype and contains NaN values.
+            - If ``clusters`` contains NaN values (numeric dtype) or None values (non-numeric dtype).
             - If fewer than 2 clusters have at least one non-NaN observation.
         """
         y_valid, cluster_indices, n_valid_clusters = self._preprocess(y, clusters)

--- a/glide/estimators/cluster_classical.py
+++ b/glide/estimators/cluster_classical.py
@@ -1,5 +1,3 @@
-from typing import List
-
 import numpy as np
 from numpy.typing import NDArray
 
@@ -80,34 +78,29 @@ class ClusterClassicalMeanEstimator:
             - If fewer than 2 clusters have at least one non-NaN observation.
         """
         _validate_equal_lengths(y, clusters, names=["y", "clusters"])
+        not_nan_mask = ~np.isnan(y)
+        y_valid, clusters_valid = y[not_nan_mask], clusters[not_nan_mask]
 
-        cluster_means: List[float] = []
-        cluster_sizes: List[int] = []
+        unique_clusters, sizes = np.unique_counts(clusters_valid)
+        n_valid_clusters = len(unique_clusters)
+        if n_valid_clusters < 2:
+            raise ValueError(f"Need at least 2 clusters with non-NaN observations; got {n_valid_clusters}.")
 
-        for cluster_id in np.unique(clusters):
-            cluster_mask = clusters == cluster_id
-            cluster_y = y[cluster_mask]
-            cluster_y_valid = cluster_y[~np.isnan(cluster_y)]
-            if len(cluster_y_valid) == 0:
-                continue
-            cluster_means.append(np.mean(cluster_y_valid))
-            cluster_sizes.append(len(cluster_y_valid))
+        sums = np.zeros(n_valid_clusters)
 
-        n_clusters = len(cluster_means)
-        if n_clusters < 2:
-            raise ValueError(f"Need at least 2 clusters with non-NaN observations; got {n_clusters}.")
+        for i, cluster_id in enumerate(unique_clusters):
+            cluster_mask = clusters_valid == cluster_id
+            cluster_y_valid = y_valid[cluster_mask]
+            sums[i] = np.sum(cluster_y_valid)
 
-        means = np.array(cluster_means)
-        sizes = np.array(cluster_sizes)
-        cluster_sums = sizes * means
-        total_size = np.sum(sizes)
+        total_size = len(y_valid)
 
-        weighted_mean = np.sum(cluster_sums) / total_size
-        var = n_clusters * np.var(cluster_sums, ddof=1) / total_size**2
+        mean = np.sum(sums) / total_size
+        var = n_valid_clusters * np.var(sums, ddof=1) / total_size**2
         std = np.sqrt(var)
 
         ci = CLTConfidenceInterval(
-            mean=weighted_mean,
+            mean=mean,
             std=std,
             confidence_level=confidence_level,
         )

--- a/glide/estimators/cluster_classical.py
+++ b/glide/estimators/cluster_classical.py
@@ -4,7 +4,7 @@ import numpy as np
 from numpy.typing import NDArray
 
 from glide.confidence_intervals import CLTConfidenceInterval
-from glide.core.validation import _validate_bounds, _validate_equal_lengths
+from glide.core.validation import _validate_bounds, _validate_equal_lengths, _validate_has_no_nan
 from glide.mean_inference_results import ClassicalMeanInferenceResult
 
 
@@ -37,13 +37,15 @@ class ClusterClassicalMeanEstimator:
         self,
         y: NDArray,
         clusters: NDArray,
-    ) -> Tuple[NDArray, NDArray, NDArray]:
+    ) -> Tuple[NDArray, NDArray, int]:
         _validate_equal_lengths(y, clusters, names=["y", "clusters"])
+        if np.issubdtype(clusters.dtype, np.number):
+            _validate_has_no_nan(clusters, "clusters")
         not_nan_mask = ~np.isnan(y)
         y_valid = y[not_nan_mask]
         clusters_valid = clusters[not_nan_mask]
 
-        unique_valid_clusters = np.unique(clusters_valid)
+        unique_valid_clusters, cluster_indices = np.unique(clusters_valid, return_inverse=True)
         n_valid_clusters = len(unique_valid_clusters)
         _validate_bounds(
             n_valid_clusters,
@@ -51,7 +53,7 @@ class ClusterClassicalMeanEstimator:
             lower=2,
             error_message=f"Need at least 2 clusters with non-NaN observations; got {n_valid_clusters}.",
         )
-        return y_valid, clusters_valid, unique_valid_clusters
+        return y_valid, cluster_indices, n_valid_clusters
 
     def estimate(
         self,
@@ -97,22 +99,16 @@ class ClusterClassicalMeanEstimator:
         ------
         ValueError
             - If ``y`` and ``clusters`` do not have the same length.
+            - If ``clusters`` has a numeric dtype and contains NaN values.
             - If fewer than 2 clusters have at least one non-NaN observation.
         """
-        y_valid, clusters_valid, unique_valid_clusters = self._preprocess(y, clusters)
-        n_valid_clusters = len(unique_valid_clusters)
-
-        sums = np.zeros(n_valid_clusters)
-
-        for i, cluster_id in enumerate(unique_valid_clusters):
-            cluster_mask = clusters_valid == cluster_id
-            cluster_y_valid = y_valid[cluster_mask]
-            sums[i] = np.sum(cluster_y_valid)
-
+        y_valid, cluster_indices, n_valid_clusters = self._preprocess(y, clusters)
         total_size = len(y_valid)
 
-        mean = np.sum(sums) / total_size
-        var = n_valid_clusters * np.var(sums, ddof=1) / total_size**2
+        cluster_sums = np.bincount(cluster_indices, weights=y_valid)
+
+        mean = np.sum(cluster_sums) / total_size
+        var = n_valid_clusters * np.var(cluster_sums, ddof=1) / total_size**2
         std = np.sqrt(var)
 
         ci = CLTConfidenceInterval(

--- a/glide/estimators/cluster_classical.py
+++ b/glide/estimators/cluster_classical.py
@@ -1,8 +1,10 @@
+from typing import Tuple
+
 import numpy as np
 from numpy.typing import NDArray
 
 from glide.confidence_intervals import CLTConfidenceInterval
-from glide.core.validation import _validate_equal_lengths
+from glide.core.validation import _validate_bounds, _validate_equal_lengths
 from glide.mean_inference_results import ClassicalMeanInferenceResult
 
 
@@ -31,6 +33,26 @@ class ClusterClassicalMeanEstimator:
     n: 4
     """
 
+    def _preprocess(
+        self,
+        y: NDArray,
+        clusters: NDArray,
+    ) -> Tuple[NDArray, NDArray, NDArray]:
+        _validate_equal_lengths(y, clusters, names=["y", "clusters"])
+        not_nan_mask = ~np.isnan(y)
+        y_valid = y[not_nan_mask]
+        clusters_valid = clusters[not_nan_mask]
+
+        unique_valid_clusters = np.unique(clusters_valid)
+        n_valid_clusters = len(unique_valid_clusters)
+        _validate_bounds(
+            n_valid_clusters,
+            "n_valid_clusters",
+            lower=2,
+            error_message=f"Need at least 2 clusters with non-NaN observations; got {n_valid_clusters}.",
+        )
+        return y_valid, clusters_valid, unique_valid_clusters
+
     def estimate(
         self,
         y: NDArray,
@@ -43,13 +65,13 @@ class ClusterClassicalMeanEstimator:
         Aggregates observations into cluster-level means weighted by cluster
         size, then applies the CLT to the cluster sums as sampling units:
 
-            theta = sum_k  (n_k * mu_k) / N
-            sigma2 = K * Var(u_k, ddof=1) / N^2
+            theta = sum_l  (n_l * mu_l) / N
+            sigma2 = L * Var(u_l, ddof=1) / N^2
 
-        where ``u_k = n_k * mu_k`` are the cluster sums, ``K`` is the number
-        of clusters, and ``N = sum_k n_k`` is the total number of observations.
-        NaN values in ``y`` are dropped per cluster before computing cluster
-        means. Clusters that contain only NaN are skipped.
+        where ``u_l = n_l * mu_l`` are the cluster sums, ``L`` is the number
+        of clusters, and ``N = sum_l n_l`` is the total number of observations.
+        NaN values in ``y`` are dropped before making the computations. Clusters
+        that contain only NaN are not used.
 
         Parameters
         ----------
@@ -77,18 +99,12 @@ class ClusterClassicalMeanEstimator:
             - If ``y`` and ``clusters`` do not have the same length.
             - If fewer than 2 clusters have at least one non-NaN observation.
         """
-        _validate_equal_lengths(y, clusters, names=["y", "clusters"])
-        not_nan_mask = ~np.isnan(y)
-        y_valid, clusters_valid = y[not_nan_mask], clusters[not_nan_mask]
-
-        unique_clusters, sizes = np.unique_counts(clusters_valid)
-        n_valid_clusters = len(unique_clusters)
-        if n_valid_clusters < 2:
-            raise ValueError(f"Need at least 2 clusters with non-NaN observations; got {n_valid_clusters}.")
+        y_valid, clusters_valid, unique_valid_clusters = self._preprocess(y, clusters)
+        n_valid_clusters = len(unique_valid_clusters)
 
         sums = np.zeros(n_valid_clusters)
 
-        for i, cluster_id in enumerate(unique_clusters):
+        for i, cluster_id in enumerate(unique_valid_clusters):
             cluster_mask = clusters_valid == cluster_id
             cluster_y_valid = y_valid[cluster_mask]
             sums[i] = np.sum(cluster_y_valid)

--- a/glide/estimators/stratified_classical.py
+++ b/glide/estimators/stratified_classical.py
@@ -4,7 +4,7 @@ import numpy as np
 from numpy.typing import NDArray
 
 from glide.confidence_intervals import CLTConfidenceInterval
-from glide.core.validation import _validate_min_samples
+from glide.core.validation import _validate_has_no_nan, _validate_min_samples
 from glide.mean_inference_results import ClassicalMeanInferenceResult
 
 
@@ -82,8 +82,10 @@ class StratifiedClassicalMeanEstimator:
         Raises
         ------
         ValueError
-            If any stratum contains fewer than 2 non-NaN values.
+            - If ``groups`` contains NaN values (numeric dtype) or None values (non-numeric dtype).
+            - If any stratum contains fewer than 2 non-NaN values.
         """
+        _validate_has_no_nan(groups, "groups")
         not_nan_mask = ~np.isnan(y)
         n_samples = np.sum(not_nan_mask)
         weighted_mean = 0.0

--- a/glide/estimators/stratified_classical.py
+++ b/glide/estimators/stratified_classical.py
@@ -4,7 +4,7 @@ import numpy as np
 from numpy.typing import NDArray
 
 from glide.confidence_intervals import CLTConfidenceInterval
-from glide.core.validation import _validate_bounds, _validate_has_no_nan
+from glide.core.validation import _validate_min_samples
 from glide.mean_inference_results import ClassicalMeanInferenceResult
 
 
@@ -82,37 +82,28 @@ class StratifiedClassicalMeanEstimator:
         Raises
         ------
         ValueError
-            - If ``groups`` contains NaN values (numeric dtype) or None values (non-numeric dtype).
-            - If any stratum contains fewer than 2 non-NaN values.
+            If any stratum contains fewer than 2 non-NaN values.
         """
-        _validate_has_no_nan(groups, "groups")
         not_nan_mask = ~np.isnan(y)
-        y_valid = y[not_nan_mask]
-        n_samples = len(y_valid)
+        n_samples = np.sum(not_nan_mask)
+        weighted_mean = 0.0
+        weighted_var = 0.0
 
-        unique_strata, stratum_indices = np.unique(groups, return_inverse=True)
-        stratum_sizes = np.bincount(stratum_indices, weights=not_nan_mask)
-        min_non_nans_per_stratum = int(np.min(stratum_sizes))
+        unique_strata = np.unique(groups)
+        for i, stratum_id in enumerate(unique_strata):
+            stratum_mask = groups == stratum_id
+            y_stratum = y[stratum_mask & not_nan_mask]
+            _validate_min_samples(y_stratum, "y", stratum_id)
 
-        _validate_bounds(
-            min_non_nans_per_stratum,
-            "min_non_nans_per_stratum",
-            lower=2,
-            error_message=f"'y' must have at least 2 non-NaN values per stratum; "
-            f"got {min_non_nans_per_stratum} in stratum '{unique_strata[np.argmin(stratum_sizes)]}'.",
-        )
-
-        valid_stratum_indices = stratum_indices[not_nan_mask]
-        stratum_sums = np.bincount(valid_stratum_indices, weights=y_valid)
-        means = stratum_sums / stratum_sizes
-        var_sums = np.bincount(valid_stratum_indices, weights=(y_valid - means[valid_stratum_indices]) ** 2)
-        vars = (var_sums / (stratum_sizes - 1)) / stratum_sizes
-
-        if stratum_weights is None:
-            stratum_weights = stratum_sizes / n_samples
-
-        weighted_mean = np.sum(means * stratum_weights)
-        weighted_var = np.sum(vars * stratum_weights**2)
+            n_samples_k = len(y_stratum)
+            if stratum_weights is not None:
+                w_k = stratum_weights[i]
+            else:
+                w_k = n_samples_k / n_samples
+            mean_k = np.mean(y_stratum)
+            var_k = np.var(y_stratum, ddof=1) / n_samples_k
+            weighted_mean += w_k * mean_k
+            weighted_var += w_k**2 * var_k
 
         std = np.sqrt(weighted_var)
         ci = CLTConfidenceInterval(

--- a/glide/estimators/stratified_classical.py
+++ b/glide/estimators/stratified_classical.py
@@ -4,7 +4,7 @@ import numpy as np
 from numpy.typing import NDArray
 
 from glide.confidence_intervals import CLTConfidenceInterval
-from glide.core.validation import _validate_min_samples
+from glide.core.validation import _validate_bounds, _validate_has_no_nan
 from glide.mean_inference_results import ClassicalMeanInferenceResult
 
 
@@ -82,28 +82,37 @@ class StratifiedClassicalMeanEstimator:
         Raises
         ------
         ValueError
-            If any stratum contains fewer than 2 non-NaN values.
+            - If ``groups`` contains NaN values (numeric dtype) or None values (non-numeric dtype).
+            - If any stratum contains fewer than 2 non-NaN values.
         """
+        _validate_has_no_nan(groups, "groups")
         not_nan_mask = ~np.isnan(y)
-        n_samples = np.sum(not_nan_mask)
-        weighted_mean = 0.0
-        weighted_var = 0.0
+        y_valid = y[not_nan_mask]
+        n_samples = len(y_valid)
 
-        unique_strata = np.unique(groups)
-        for i, stratum_id in enumerate(unique_strata):
-            stratum_mask = groups == stratum_id
-            y_stratum = y[stratum_mask & not_nan_mask]
-            _validate_min_samples(y_stratum, "y", stratum_id)
+        unique_strata, stratum_indices = np.unique(groups, return_inverse=True)
+        stratum_sizes = np.bincount(stratum_indices, weights=not_nan_mask)
+        min_non_nans_per_stratum = int(np.min(stratum_sizes))
 
-            n_samples_k = len(y_stratum)
-            if stratum_weights is not None:
-                w_k = stratum_weights[i]
-            else:
-                w_k = n_samples_k / n_samples
-            mean_k = np.mean(y_stratum)
-            var_k = np.var(y_stratum, ddof=1) / n_samples_k
-            weighted_mean += w_k * mean_k
-            weighted_var += w_k**2 * var_k
+        _validate_bounds(
+            min_non_nans_per_stratum,
+            "min_non_nans_per_stratum",
+            lower=2,
+            error_message=f"'y' must have at least 2 non-NaN values per stratum; "
+            f"got {min_non_nans_per_stratum} in stratum '{unique_strata[np.argmin(stratum_sizes)]}'.",
+        )
+
+        valid_stratum_indices = stratum_indices[not_nan_mask]
+        stratum_sums = np.bincount(valid_stratum_indices, weights=y_valid)
+        means = stratum_sums / stratum_sizes
+        var_sums = np.bincount(valid_stratum_indices, weights=(y_valid - means[valid_stratum_indices]) ** 2)
+        vars = (var_sums / (stratum_sizes - 1)) / stratum_sizes
+
+        if stratum_weights is None:
+            stratum_weights = stratum_sizes / n_samples
+
+        weighted_mean = np.sum(means * stratum_weights)
+        weighted_var = np.sum(vars * stratum_weights**2)
 
         std = np.sqrt(weighted_var)
         ci = CLTConfidenceInterval(

--- a/tests/functional/estimators/test_cluster_classical.py
+++ b/tests/functional/estimators/test_cluster_classical.py
@@ -1,0 +1,59 @@
+"""Functional tests for ClusterClassicalMeanEstimator.
+
+These tests verify end-to-end statistical properties rather than implementation
+details, and therefore require larger datasets to hold reliably.
+"""
+
+import numpy as np
+import pytest
+
+from glide.estimators import ClassicalMeanEstimator, ClusterClassicalMeanEstimator
+
+# ── tests ──────────────────────────────────────────────────────────────────────
+
+
+def test_single_observation_clusters_equals_classical():
+    """Single-observation clusters produce identical results to ClassicalMeanEstimator.
+
+    When every cluster contains exactly one observation, cluster sums equal y,
+    and Var(theta) = K * Var(y, ddof=1) / K^2 = Var(y, ddof=1) / K, which is
+    exactly what ClassicalMeanEstimator computes (std(y, ddof=1) / sqrt(K)).
+    """
+    y = np.array([5.0, 7.0, 4.0, 8.0, 6.0, 3.0, 9.0, 2.0])
+    clusters = np.array(["A", "B", "C", "D", "E", "F", "G", "H"])
+
+    cluster_result = ClusterClassicalMeanEstimator().estimate(y, clusters)
+    classical_result = ClassicalMeanEstimator().estimate(y)
+
+    assert cluster_result.confidence_interval.lower_bound == pytest.approx(
+        classical_result.confidence_interval.lower_bound, abs=1e-10
+    )
+    assert cluster_result.confidence_interval.upper_bound == pytest.approx(
+        classical_result.confidence_interval.upper_bound, abs=1e-10
+    )
+
+
+def test_equal_size_clusters_equals_classical():
+    """Equal-size clusters with equal cluster means equal the unweighted mean of cluster means.
+
+    When all clusters have the same size s, the cluster estimator simplifies to
+    Var(mu_k, ddof=1) / K, which is the standard mean-of-means estimator.
+    With single observations per cluster this is identical to ClassicalMeanEstimator.
+    With two observations per cluster the point estimate still equals the grand mean,
+    but the standard error reflects K effective sampling units rather than 2K.
+    """
+    rng = np.random.default_rng(42)
+    n_clusters = 6
+    cluster_size = 2
+
+    y_blocks = [rng.normal(loc=5.0, scale=0.1, size=cluster_size) for _ in range(n_clusters)]
+    y = np.hstack(y_blocks)
+    clusters = np.repeat(np.arange(n_clusters), cluster_size)
+
+    cluster_result = ClusterClassicalMeanEstimator().estimate(y, clusters)
+    cluster_means = np.array([block.mean() for block in y_blocks])
+    expected_mean = cluster_means.mean()
+    expected_std = cluster_means.std(ddof=1) / np.sqrt(n_clusters)
+
+    assert cluster_result.confidence_interval.mean == pytest.approx(expected_mean, abs=1e-10)
+    assert cluster_result.std == pytest.approx(expected_std, abs=1e-10)

--- a/tests/functional/estimators/test_cluster_classical.py
+++ b/tests/functional/estimators/test_cluster_classical.py
@@ -9,51 +9,17 @@ import pytest
 
 from glide.estimators import ClassicalMeanEstimator, ClusterClassicalMeanEstimator
 
-# ── tests ──────────────────────────────────────────────────────────────────────
-
 
 def test_single_observation_clusters_equals_classical():
-    """Single-observation clusters produce identical results to ClassicalMeanEstimator.
+    # Single-observation clusters produce identical results to ClassicalMeanEstimator.
 
-    When every cluster contains exactly one observation, cluster sums equal y,
-    and Var(theta) = K * Var(y, ddof=1) / K^2 = Var(y, ddof=1) / K, which is
-    exactly what ClassicalMeanEstimator computes (std(y, ddof=1) / sqrt(K)).
-    """
     y = np.array([5.0, 7.0, 4.0, 8.0, 6.0, 3.0, 9.0, 2.0])
     clusters = np.array(["A", "B", "C", "D", "E", "F", "G", "H"])
 
     cluster_result = ClusterClassicalMeanEstimator().estimate(y, clusters)
     classical_result = ClassicalMeanEstimator().estimate(y)
 
-    assert cluster_result.confidence_interval.lower_bound == pytest.approx(
-        classical_result.confidence_interval.lower_bound, abs=1e-10
+    assert cluster_result.confidence_interval.mean == pytest.approx(
+        classical_result.confidence_interval.mean, abs=1e-10
     )
-    assert cluster_result.confidence_interval.upper_bound == pytest.approx(
-        classical_result.confidence_interval.upper_bound, abs=1e-10
-    )
-
-
-def test_equal_size_clusters_equals_classical():
-    """Equal-size clusters with equal cluster means equal the unweighted mean of cluster means.
-
-    When all clusters have the same size s, the cluster estimator simplifies to
-    Var(mu_k, ddof=1) / K, which is the standard mean-of-means estimator.
-    With single observations per cluster this is identical to ClassicalMeanEstimator.
-    With two observations per cluster the point estimate still equals the grand mean,
-    but the standard error reflects K effective sampling units rather than 2K.
-    """
-    rng = np.random.default_rng(42)
-    n_clusters = 6
-    cluster_size = 2
-
-    y_blocks = [rng.normal(loc=5.0, scale=0.1, size=cluster_size) for _ in range(n_clusters)]
-    y = np.hstack(y_blocks)
-    clusters = np.repeat(np.arange(n_clusters), cluster_size)
-
-    cluster_result = ClusterClassicalMeanEstimator().estimate(y, clusters)
-    cluster_means = np.array([block.mean() for block in y_blocks])
-    expected_mean = cluster_means.mean()
-    expected_std = cluster_means.std(ddof=1) / np.sqrt(n_clusters)
-
-    assert cluster_result.confidence_interval.mean == pytest.approx(expected_mean, abs=1e-10)
-    assert cluster_result.std == pytest.approx(expected_std, abs=1e-10)
+    assert cluster_result.confidence_interval.std == pytest.approx(classical_result.confidence_interval.std, abs=1e-10)

--- a/tests/unit/core/test_validation.py
+++ b/tests/unit/core/test_validation.py
@@ -68,6 +68,15 @@ def test_validate_has_no_nan_raises():
         _validate_has_no_nan(np.array([1.0, float("nan")]), "x")
 
 
+def test_validate_has_no_nan_valid_non_numeric():
+    _validate_has_no_nan(np.array(["a", "b"]), "x")
+
+
+def test_validate_has_no_nan_raises_none_in_non_numeric():
+    with pytest.raises(ValueError, match="'x' contains None values"):
+        _validate_has_no_nan(np.array(["a", None], dtype=object), "x")
+
+
 # --- _get_non_zero_mask ---
 
 

--- a/tests/unit/estimators/test_classical.py
+++ b/tests/unit/estimators/test_classical.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 import numpy as np
 import pytest
 from numpy.typing import NDArray
@@ -27,9 +29,13 @@ def test_preprocess_removes_nan(estimator):
     np.testing.assert_array_equal(result, np.array([2.0, 4.0]))
 
 
-def test_preprocess_raises_when_fewer_than_two_non_nan_values(estimator):
-    with pytest.raises(ValueError):
-        estimator._preprocess(np.array([np.nan, 1.0]))
+def test_preprocess_delegate_to_validation(estimator):
+    y_valid = np.array([1.0])
+    with patch("glide.estimators.classical._validate_min_samples") as mock_validate_min_samples:
+        estimator._preprocess(y_valid)
+    mock_validate_min_samples.assert_called_once()
+    np.testing.assert_array_equal(mock_validate_min_samples.call_args[0][0], y_valid)
+    assert mock_validate_min_samples.call_args[0][1] == "y"
 
 
 # --- estimate ---

--- a/tests/unit/estimators/test_cluster_classical.py
+++ b/tests/unit/estimators/test_cluster_classical.py
@@ -1,21 +1,16 @@
+from unittest.mock import patch
+
 import numpy as np
 import pytest
 from numpy.typing import NDArray
 
+import glide.estimators.cluster_classical as cluster_classical_module
 from glide.estimators import ClusterClassicalMeanEstimator
 from glide.mean_inference_results import ClassicalMeanInferenceResult
-
-# ── helpers ────────────────────────────────────────────────────────────────────
 
 
 @pytest.fixture
 def y() -> NDArray:
-    """Observations for two clusters (A and B) with two samples each.
-
-    Cluster A: y=[5.0, 5.0]  → mean=5.0, sum=10.0
-    Cluster B: y=[7.0, 7.0]  → mean=7.0, sum=14.0
-    Weighted: mean=6.0, var=2*Var([10,14], ddof=1)/16=1.0, std=1.0, n=4.
-    """
     return np.array([5.0, 5.0, 7.0, 7.0])
 
 
@@ -27,6 +22,39 @@ def clusters() -> NDArray:
 @pytest.fixture
 def estimator() -> ClusterClassicalMeanEstimator:
     return ClusterClassicalMeanEstimator()
+
+
+# --- _preprocess ---
+
+
+def test_preprocess_delegates_to_validation(estimator, y, clusters):
+
+    with (
+        patch.object(cluster_classical_module, "_validate_equal_lengths") as mock_validate_equal_lengths,
+        patch.object(cluster_classical_module, "_validate_bounds") as mock_validate_bounds,
+    ):
+        estimator._preprocess(y, clusters)
+
+        mock_validate_equal_lengths.assert_called_once()
+        np.testing.assert_array_equal(mock_validate_equal_lengths.call_args[0][0], y)
+        np.testing.assert_array_equal(mock_validate_equal_lengths.call_args[0][1], clusters)
+        assert mock_validate_equal_lengths.call_args[1] == {"names": ["y", "clusters"]}
+
+        mock_validate_bounds.assert_called_once_with(
+            2,
+            "n_valid_clusters",
+            lower=2,
+            error_message="Need at least 2 clusters with non-NaN observations; got 2.",
+        )
+
+
+def test_preprocess_returns_filtered_arrays(estimator):
+    y = np.array([2.0, np.nan, 4.0, np.nan, np.nan])
+    clusters = np.array(["A", "A", "B", "C", "C"])
+    y_valid, clusters_valid, unique_valid_clusters = estimator._preprocess(y, clusters)
+    np.testing.assert_array_equal(y_valid, np.array([2.0, 4.0]))
+    np.testing.assert_array_equal(clusters_valid, np.array(["A", "B"]))
+    np.testing.assert_array_equal(unique_valid_clusters, np.array(["A", "B"]))
 
 
 # --- estimate ---
@@ -48,69 +76,19 @@ def test_estimate_metadata(estimator, y, clusters):
     assert result.n == 4
 
 
-def test_estimate_analytical_values(estimator, y, clusters):
-    result = estimator.estimate(y, clusters)
-
-    expected_mean = 6.0
-    expected_std = 1.0
-    expected_lower = 4.040
-    expected_upper = 7.960
-
-    assert result.confidence_interval.mean == pytest.approx(expected_mean)
-    assert result.std == pytest.approx(expected_std)
-    assert result.confidence_interval.lower_bound == pytest.approx(expected_lower, abs=0.001)
-    assert result.confidence_interval.upper_bound == pytest.approx(expected_upper, abs=0.001)
-
-
 def test_estimate_custom_confidence_level(estimator, y, clusters):
     result = estimator.estimate(y, clusters, confidence_level=0.85)
 
+    expected_mean = 6.0
+    expected_std = 1.0
     expected_lower = 4.560
     expected_upper = 7.440
 
+    assert result.confidence_interval.mean == pytest.approx(expected_mean)
+    assert result.std == pytest.approx(expected_std)
     assert result.confidence_interval.confidence_level == 0.85
     assert result.confidence_interval.lower_bound == pytest.approx(expected_lower, abs=0.001)
     assert result.confidence_interval.upper_bound == pytest.approx(expected_upper, abs=0.001)
-
-
-def test_estimate_ignores_nans(estimator, y, clusters):
-    y_with_nans = np.hstack([y, np.full(2, np.nan)])
-    clusters_with_nans = np.hstack([clusters, np.array(["A", "B"])])
-
-    result = estimator.estimate(y, clusters, metric_name="performance")
-    result_with_nans = estimator.estimate(y_with_nans, clusters_with_nans, metric_name="performance")
-    assert result == result_with_nans
-
-
-def test_estimate_n_counts_non_nan_observations(estimator, y, clusters):
-    y_with_nans = np.hstack([y, np.array([np.nan, np.nan])])
-    clusters_with_nans = np.hstack([clusters, np.array(["A", "B"])])
-
-    result = estimator.estimate(y_with_nans, clusters_with_nans)
-    assert result.n == 4
-
-
-def test_estimate_skips_all_nan_cluster(estimator, y, clusters):
-    y_augmented = np.hstack([y, np.array([np.nan, np.nan])])
-    clusters_augmented = np.hstack([clusters, np.array(["C", "C"])])
-
-    result_base = estimator.estimate(y, clusters)
-    result_augmented = estimator.estimate(y_augmented, clusters_augmented)
-    assert result_base == result_augmented
-
-
-def test_estimate_raises_for_fewer_than_two_valid_clusters(estimator):
-    y = np.array([5.0, 7.0, np.nan, np.nan])
-    clusters = np.array(["A", "A", "B", "B"])
-    with pytest.raises(ValueError, match="Need at least 2 clusters"):
-        estimator.estimate(y, clusters)
-
-
-def test_estimate_raises_when_y_and_clusters_have_different_lengths(estimator):
-    y = np.array([1.0, 2.0])
-    clusters = np.array(["A", "B", "C"])
-    with pytest.raises(ValueError, match="same length"):
-        estimator.estimate(y, clusters)
 
 
 # --- __str__ / __repr__ ---

--- a/tests/unit/estimators/test_cluster_classical.py
+++ b/tests/unit/estimators/test_cluster_classical.py
@@ -1,0 +1,134 @@
+import numpy as np
+import pytest
+from numpy.typing import NDArray
+
+from glide.estimators import ClusterClassicalMeanEstimator
+from glide.mean_inference_results import ClassicalMeanInferenceResult
+
+# ── helpers ────────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def y() -> NDArray:
+    """Observations for two clusters (A and B) with two samples each.
+
+    Cluster A: y=[5.0, 5.0]  → mean=5.0, sum=10.0
+    Cluster B: y=[7.0, 7.0]  → mean=7.0, sum=14.0
+    Weighted: mean=6.0, var=2*Var([10,14], ddof=1)/16=1.0, std=1.0, n=4.
+    """
+    return np.array([5.0, 5.0, 7.0, 7.0])
+
+
+@pytest.fixture
+def clusters() -> NDArray:
+    return np.array(["A", "A", "B", "B"])
+
+
+@pytest.fixture
+def estimator() -> ClusterClassicalMeanEstimator:
+    return ClusterClassicalMeanEstimator()
+
+
+# --- estimate ---
+
+
+def test_estimate_is_valid_inference_result(estimator, y, clusters):
+    result = estimator.estimate(y, clusters)
+    assert isinstance(result, ClassicalMeanInferenceResult)
+    assert np.isfinite(result.confidence_interval.lower_bound)
+    assert np.isfinite(result.confidence_interval.upper_bound)
+    assert result.confidence_interval.lower_bound < result.confidence_interval.upper_bound
+    assert result.estimator_name == "ClusterClassicalMeanEstimator"
+
+
+def test_estimate_metadata(estimator, y, clusters):
+    result = estimator.estimate(y, clusters, metric_name="performance")
+    assert result.metric_name == "performance"
+    assert result.estimator_name == estimator.__class__.__name__
+    assert result.n == 4
+
+
+def test_estimate_analytical_values(estimator, y, clusters):
+    result = estimator.estimate(y, clusters)
+
+    expected_mean = 6.0
+    expected_std = 1.0
+    expected_lower = 4.040
+    expected_upper = 7.960
+
+    assert result.confidence_interval.mean == pytest.approx(expected_mean)
+    assert result.std == pytest.approx(expected_std)
+    assert result.confidence_interval.lower_bound == pytest.approx(expected_lower, abs=0.001)
+    assert result.confidence_interval.upper_bound == pytest.approx(expected_upper, abs=0.001)
+
+
+def test_estimate_custom_confidence_level(estimator, y, clusters):
+    result = estimator.estimate(y, clusters, confidence_level=0.85)
+
+    expected_lower = 4.560
+    expected_upper = 7.440
+
+    assert result.confidence_interval.confidence_level == 0.85
+    assert result.confidence_interval.lower_bound == pytest.approx(expected_lower, abs=0.001)
+    assert result.confidence_interval.upper_bound == pytest.approx(expected_upper, abs=0.001)
+
+
+def test_estimate_ignores_nans(estimator, y, clusters):
+    y_with_nans = np.hstack([y, np.full(2, np.nan)])
+    clusters_with_nans = np.hstack([clusters, np.array(["A", "B"])])
+
+    result = estimator.estimate(y, clusters, metric_name="performance")
+    result_with_nans = estimator.estimate(y_with_nans, clusters_with_nans, metric_name="performance")
+    assert result == result_with_nans
+
+
+def test_estimate_n_counts_non_nan_observations(estimator, y, clusters):
+    y_with_nans = np.hstack([y, np.array([np.nan, np.nan])])
+    clusters_with_nans = np.hstack([clusters, np.array(["A", "B"])])
+
+    result = estimator.estimate(y_with_nans, clusters_with_nans)
+    assert result.n == 4
+
+
+def test_estimate_skips_all_nan_cluster(estimator, y, clusters):
+    y_augmented = np.hstack([y, np.array([np.nan, np.nan])])
+    clusters_augmented = np.hstack([clusters, np.array(["C", "C"])])
+
+    result_base = estimator.estimate(y, clusters)
+    result_augmented = estimator.estimate(y_augmented, clusters_augmented)
+    assert result_base == result_augmented
+
+
+def test_estimate_raises_for_fewer_than_two_valid_clusters(estimator):
+    y = np.array([5.0, 7.0, np.nan, np.nan])
+    clusters = np.array(["A", "A", "B", "B"])
+    with pytest.raises(ValueError, match="Need at least 2 clusters"):
+        estimator.estimate(y, clusters)
+
+
+def test_estimate_raises_when_y_and_clusters_have_different_lengths(estimator):
+    y = np.array([1.0, 2.0])
+    clusters = np.array(["A", "B", "C"])
+    with pytest.raises(ValueError, match="same length"):
+        estimator.estimate(y, clusters)
+
+
+# --- __str__ / __repr__ ---
+
+
+def test_str_format(estimator, y, clusters):
+    result = estimator.estimate(y, clusters, metric_name="performance")
+    output = str(result)
+    expected = (
+        "Metric: performance\n"
+        "Point Estimate: 6.000\n"
+        "Confidence Interval (95%): [4.040, 7.960]\n"
+        "Estimator : ClusterClassicalMeanEstimator\n"
+        "n: 4"
+    )
+    assert output == expected
+
+
+def test_repr_equals_str(estimator, y, clusters):
+    result = estimator.estimate(y, clusters, metric_name="perf")
+    assert repr(result) == str(result)

--- a/tests/unit/estimators/test_cluster_classical.py
+++ b/tests/unit/estimators/test_cluster_classical.py
@@ -20,11 +20,6 @@ def clusters() -> NDArray:
 
 
 @pytest.fixture
-def clusters_numerical() -> NDArray:
-    return np.array([0, 0, 1, 1])
-
-
-@pytest.fixture
 def estimator() -> ClusterClassicalMeanEstimator:
     return ClusterClassicalMeanEstimator()
 
@@ -32,22 +27,22 @@ def estimator() -> ClusterClassicalMeanEstimator:
 # --- _preprocess ---
 
 
-def test_preprocess_delegates_to_validation(estimator, y, clusters_numerical):
+def test_preprocess_delegates_to_validation(estimator, y, clusters):
 
     with (
         patch.object(cluster_classical_module, "_validate_equal_lengths") as mock_validate_equal_lengths,
         patch.object(cluster_classical_module, "_validate_has_no_nan") as mock_validate_has_no_nan,
         patch.object(cluster_classical_module, "_validate_bounds") as mock_validate_bounds,
     ):
-        estimator._preprocess(y, clusters_numerical)
+        estimator._preprocess(y, clusters)
 
         mock_validate_equal_lengths.assert_called_once()
         np.testing.assert_array_equal(mock_validate_equal_lengths.call_args[0][0], y)
-        np.testing.assert_array_equal(mock_validate_equal_lengths.call_args[0][1], clusters_numerical)
+        np.testing.assert_array_equal(mock_validate_equal_lengths.call_args[0][1], clusters)
         assert mock_validate_equal_lengths.call_args[1] == {"names": ["y", "clusters"]}
 
         mock_validate_has_no_nan.assert_called_once()
-        np.testing.assert_array_equal(mock_validate_has_no_nan.call_args[0][0], clusters_numerical)
+        np.testing.assert_array_equal(mock_validate_has_no_nan.call_args[0][0], clusters)
         assert mock_validate_has_no_nan.call_args[0][1] == "clusters"
 
         mock_validate_bounds.assert_called_once_with(

--- a/tests/unit/estimators/test_cluster_classical.py
+++ b/tests/unit/estimators/test_cluster_classical.py
@@ -20,6 +20,11 @@ def clusters() -> NDArray:
 
 
 @pytest.fixture
+def clusters_numerical() -> NDArray:
+    return np.array([0, 0, 1, 1])
+
+
+@pytest.fixture
 def estimator() -> ClusterClassicalMeanEstimator:
     return ClusterClassicalMeanEstimator()
 
@@ -27,18 +32,23 @@ def estimator() -> ClusterClassicalMeanEstimator:
 # --- _preprocess ---
 
 
-def test_preprocess_delegates_to_validation(estimator, y, clusters):
+def test_preprocess_delegates_to_validation(estimator, y, clusters_numerical):
 
     with (
         patch.object(cluster_classical_module, "_validate_equal_lengths") as mock_validate_equal_lengths,
+        patch.object(cluster_classical_module, "_validate_has_no_nan") as mock_validate_has_no_nan,
         patch.object(cluster_classical_module, "_validate_bounds") as mock_validate_bounds,
     ):
-        estimator._preprocess(y, clusters)
+        estimator._preprocess(y, clusters_numerical)
 
         mock_validate_equal_lengths.assert_called_once()
         np.testing.assert_array_equal(mock_validate_equal_lengths.call_args[0][0], y)
-        np.testing.assert_array_equal(mock_validate_equal_lengths.call_args[0][1], clusters)
+        np.testing.assert_array_equal(mock_validate_equal_lengths.call_args[0][1], clusters_numerical)
         assert mock_validate_equal_lengths.call_args[1] == {"names": ["y", "clusters"]}
+
+        mock_validate_has_no_nan.assert_called_once()
+        np.testing.assert_array_equal(mock_validate_has_no_nan.call_args[0][0], clusters_numerical)
+        assert mock_validate_has_no_nan.call_args[0][1] == "clusters"
 
         mock_validate_bounds.assert_called_once_with(
             2,
@@ -51,10 +61,10 @@ def test_preprocess_delegates_to_validation(estimator, y, clusters):
 def test_preprocess_returns_filtered_arrays(estimator):
     y = np.array([2.0, np.nan, 4.0, np.nan, np.nan])
     clusters = np.array(["A", "A", "B", "C", "C"])
-    y_valid, clusters_valid, unique_valid_clusters = estimator._preprocess(y, clusters)
+    y_valid, cluster_indices, n_valid_clusters = estimator._preprocess(y, clusters)
+    assert n_valid_clusters == 2
     np.testing.assert_array_equal(y_valid, np.array([2.0, 4.0]))
-    np.testing.assert_array_equal(clusters_valid, np.array(["A", "B"]))
-    np.testing.assert_array_equal(unique_valid_clusters, np.array(["A", "B"]))
+    np.testing.assert_array_equal(cluster_indices, np.array([0, 1]))
 
 
 # --- estimate ---

--- a/tests/unit/estimators/test_cluster_classical.py
+++ b/tests/unit/estimators/test_cluster_classical.py
@@ -53,7 +53,7 @@ def test_preprocess_delegates_to_validation(estimator, y, clusters):
         )
 
 
-def test_preprocess_returns_filtered_arrays(estimator):
+def test_preprocess_known_result(estimator):
     y = np.array([2.0, np.nan, 4.0, np.nan, np.nan])
     clusters = np.array(["A", "A", "B", "C", "C"])
     y_valid, cluster_indices, n_valid_clusters = estimator._preprocess(y, clusters)

--- a/tests/unit/estimators/test_stratified_classical.py
+++ b/tests/unit/estimators/test_stratified_classical.py
@@ -1,10 +1,7 @@
-from unittest.mock import patch
-
 import numpy as np
 import pytest
 from numpy.typing import NDArray
 
-import glide.estimators.stratified_classical as stratified_classical_module
 from glide.estimators import StratifiedClassicalMeanEstimator
 from glide.mean_inference_results import ClassicalMeanInferenceResult
 
@@ -82,23 +79,11 @@ def test_estimate_ignores_nans(estimator, y, groups):
     assert result == result_with_nans
 
 
-def test_estimate_delegates_to_validation(estimator, y, groups):
-    with (
-        patch.object(stratified_classical_module, "_validate_has_no_nan") as mock_validate_has_no_nan,
-        patch.object(stratified_classical_module, "_validate_bounds") as mock_validate_bounds,
-    ):
-        estimator.estimate(y, groups)
-
-        mock_validate_has_no_nan.assert_called_once()
-        np.testing.assert_array_equal(mock_validate_has_no_nan.call_args[0][0], groups)
-        assert mock_validate_has_no_nan.call_args[0][1] == "groups"
-
-        mock_validate_bounds.assert_called_once_with(
-            2.0,
-            "min_non_nans_per_stratum",
-            lower=2,
-            error_message="'y' must have at least 2 non-NaN values per stratum; got 2 in stratum 'A'.",
-        )
+def test_estimate_raises_for_stratum_with_fewer_than_two_non_nan_values(y, groups, estimator):
+    y_augmented = np.hstack([y, np.array([np.nan, 1.0])])
+    groups_augmented = np.hstack([groups, np.array(["C", "C"])])
+    with pytest.raises(ValueError):
+        estimator.estimate(y_augmented, groups_augmented)
 
 
 # --- __str__ / __repr__ ---

--- a/tests/unit/estimators/test_stratified_classical.py
+++ b/tests/unit/estimators/test_stratified_classical.py
@@ -1,7 +1,10 @@
+from unittest.mock import patch
+
 import numpy as np
 import pytest
 from numpy.typing import NDArray
 
+import glide.estimators.stratified_classical as stratified_classical_module
 from glide.estimators import StratifiedClassicalMeanEstimator
 from glide.mean_inference_results import ClassicalMeanInferenceResult
 
@@ -30,6 +33,26 @@ def estimator() -> StratifiedClassicalMeanEstimator:
 
 
 # --- estimate ---
+
+
+def test_estimate_delegates_to_validation(estimator, y, groups):
+    with (
+        patch.object(stratified_classical_module, "_validate_has_no_nan") as mock_validate_has_no_nan,
+        patch.object(stratified_classical_module, "_validate_min_samples") as mock_validate_min_samples,
+    ):
+        estimator.estimate(y, groups)
+
+        mock_validate_has_no_nan.assert_called_once()
+        np.testing.assert_array_equal(mock_validate_has_no_nan.call_args[0][0], groups)
+        assert mock_validate_has_no_nan.call_args[0][1] == "groups"
+
+        assert len(mock_validate_min_samples.call_args_list) == 2
+        np.testing.assert_array_equal(mock_validate_min_samples.call_args_list[0][0][0], np.array([1.0, 3.0]))
+        assert mock_validate_min_samples.call_args_list[0][0][1] == "y"
+        assert mock_validate_min_samples.call_args_list[0][0][2] == "A"
+        np.testing.assert_array_equal(mock_validate_min_samples.call_args_list[1][0][0], np.array([5.0, 7.0]))
+        assert mock_validate_min_samples.call_args_list[1][0][1] == "y"
+        assert mock_validate_min_samples.call_args_list[1][0][2] == "B"
 
 
 def test_estimate_is_valid_inference_result(estimator, y, groups):
@@ -77,13 +100,6 @@ def test_estimate_ignores_nans(estimator, y, groups):
     result = estimator.estimate(y, groups, metric_name="performance")
     result_with_nans = estimator.estimate(y_with_nans, groups_with_nans, metric_name="performance")
     assert result == result_with_nans
-
-
-def test_estimate_raises_for_stratum_with_fewer_than_two_non_nan_values(y, groups, estimator):
-    y_augmented = np.hstack([y, np.array([np.nan, 1.0])])
-    groups_augmented = np.hstack([groups, np.array(["C", "C"])])
-    with pytest.raises(ValueError):
-        estimator.estimate(y_augmented, groups_augmented)
 
 
 # --- __str__ / __repr__ ---

--- a/tests/unit/estimators/test_stratified_classical.py
+++ b/tests/unit/estimators/test_stratified_classical.py
@@ -1,7 +1,10 @@
+from unittest.mock import patch
+
 import numpy as np
 import pytest
 from numpy.typing import NDArray
 
+import glide.estimators.stratified_classical as stratified_classical_module
 from glide.estimators import StratifiedClassicalMeanEstimator
 from glide.mean_inference_results import ClassicalMeanInferenceResult
 
@@ -79,11 +82,23 @@ def test_estimate_ignores_nans(estimator, y, groups):
     assert result == result_with_nans
 
 
-def test_estimate_raises_for_stratum_with_fewer_than_two_non_nan_values(y, groups, estimator):
-    y_augmented = np.hstack([y, np.array([np.nan, 1.0])])
-    groups_augmented = np.hstack([groups, np.array(["C", "C"])])
-    with pytest.raises(ValueError):
-        estimator.estimate(y_augmented, groups_augmented)
+def test_estimate_delegates_to_validation(estimator, y, groups):
+    with (
+        patch.object(stratified_classical_module, "_validate_has_no_nan") as mock_validate_has_no_nan,
+        patch.object(stratified_classical_module, "_validate_bounds") as mock_validate_bounds,
+    ):
+        estimator.estimate(y, groups)
+
+        mock_validate_has_no_nan.assert_called_once()
+        np.testing.assert_array_equal(mock_validate_has_no_nan.call_args[0][0], groups)
+        assert mock_validate_has_no_nan.call_args[0][1] == "groups"
+
+        mock_validate_bounds.assert_called_once_with(
+            2.0,
+            "min_non_nans_per_stratum",
+            lower=2,
+            error_message="'y' must have at least 2 non-NaN values per stratum; got 2 in stratum 'A'.",
+        )
 
 
 # --- __str__ / __repr__ ---


### PR DESCRIPTION
### Description

- Implements `ClusterClassicalMeanEstimator`, a CLT-based classical mean estimator that treats each cluster as the sampling unit (via cluster sums) rather than individual observations, producing valid confidence intervals under cluster sampling designs.
- Closes #203
- Per-cluster computations use sums (`u_k = n_k * μ_k`) rather than means, so the variance formula `K * Var(u_k, ddof=1) / N²` is consistent with the unlabeled-part treatment in `ClusterPTDMeanEstimator`. The `_preprocess` method centralises all validation checks and unique cluster identification, following the same factorisation pattern as `StratifiedClassicalMeanEstimator`.

### Checklist

Quality gates that must be satisfied before requesting a review:

- [x] I have read `CONTRIBUTING.md`
- [x] `make lint` passes
- [x] `make type-check` passes
- [x] `make tests` passes
- [x] `make coverage` reports 100% coverage
- [ ] `make test-notebooks` passes
- [x] New public API has numpy-style docstrings
- [x] New public API is inserted in the API reference section of the documentation
- [x] Docs build without warnings (`make doc`)
- [x] `CHANGELOG.md` updated if the change is user-facing

### LLM usage

Disclose if an LLM was used in writing this PR:
- [ ] No LLM used
- [x] I used an LLM and I went through and validated all the code myself