### PR TITLE
Migrate R-Judge dataset to Glide-py Hugging Face account

### DIFF
--- a/docs/deep_dive/icml_case_study.ipynb
+++ b/docs/deep_dive/icml_case_study.ipynb
@@ -107,9 +107,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Dataset published at https://huggingface.co/datasets/imerad-kv/r_judge_labelled\n",
+    "# Dataset published at https://huggingface.co/datasets/Glide-py/r_judge_labelled\n",
     "# See the Annex for details on how proxy labels and confidence scores were generated.\n",
-    "dataset = load_dataset(\"imerad-kv/r_judge_labelled\", download_config=DownloadConfig(max_retries=100))\n",
+    "dataset = load_dataset(\"Glide-py/r_judge_labelled\", download_config=DownloadConfig(max_retries=100))\n",
     "dataset = dataset[\"train\"]\n",
     "\n",
     "y_true_oracle = np.array(dataset[\"label\"]).astype(float)\n",
@@ -480,7 +480,7 @@
     "\n",
     "### Dataset\n",
     "\n",
-    "The labeled dataset used in this notebook is published on the Hugging Face Hub at [imerad-kv/r_judge_labelled](https://huggingface.co/datasets/imerad-kv/r_judge_labelled) together with scripts and instructions for reproducing it from the original R-Judge data.\n",
+    "The labeled dataset used in this notebook is published on the Hugging Face Hub at [Glide-py/r_judge_labelled](https://huggingface.co/datasets/Glide-py/r_judge_labelled) together with scripts and instructions for reproducing it from the original R-Judge data.\n",
     "\n",
     "### Model\n",
     "\n",
@@ -533,7 +533,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "glide-py",
+   "display_name": "glide-py (3.12.12)",
    "language": "python",
    "name": "python3"
   },


### PR DESCRIPTION
### Description

- Switches the R-Judge labelled dataset in the ICML case study deep-dive from the personal `imerad-kv` Hugging Face account to the corporate `Glide-py` account. The dataset (and its reproduction scripts) were copied verbatim to [Glide-py/r_judge_labelled](https://huggingface.co/datasets/Glide-py/r_judge_labelled); the notebook's `load_dataset` call, accompanying comment, and Annex link now point there.
- N/A (no tracking issue).

### Checklist

Quality gates that must be satisfied before requesting a review:

- [x] I have read `CONTRIBUTING.md`
- [ ] `make lint` passes
- [ ] `make type-check` passes
- [ ] `make tests` passes
- [ ] `make coverage` reports 100% coverage
- [ ] `make test-notebooks` passes
- [ ] New public API has numpy-style docstrings
- [ ] New public API is inserted in the API reference section of the documentation
- [ ] Docs build without warnings (`make doc`)
- [ ] `CHANGELOG.md` updated if the change is user-facing

### LLM usage

Disclose if an LLM was used in writing this PR:
- [ ] No LLM used
- [x] I used an LLM and I went through and validated all the code myself