### PR TITLE
Release v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,24 +9,28 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ## [Next release]
 
 ### ✨ Added
-- `ClusterPPIMeanEstimator` for prediction-powered inference on clustered data
-- `ClusterClassicalMeanEstimator` for cluster-sampling-aware classical mean estimation with CLT-based confidence intervals.
-- `UniformClusterSampler` for cluster-level annotation selection using uniform sampling
-- `generate_clustered_binary_dataset` simulator for generating binary datasets with randomly sized clusters.
-- Image in the readme describing prediction-powered inference
-- Image in the user guide describing GLIDE's three-step workflow
+
+### 🔄 Changed
+
+### 🐛 Fixed
+
+### 💛 Contributors
+
+## [0.7.0] – 2026-06-12
+
+### ✨ Added
+- Cluster-level inference support: `ClusterPPIMeanEstimator`, `ClusterClassicalMeanEstimator`, `UniformClusterSampler`, and `generate_clustered_binary_dataset` for end-to-end prediction-powered inference on clustered data.
+- Diagrams in the README and user guide illustrating prediction-powered inference and GLIDE's three-step workflow.
 
 ### 🔄 Changed
 - `generate_gaussian_dataset` now accepts `n_total` instead of `n_labeled` and `n_unlabeled`.
-- Renamed `budget` parameter to `n_samples` in `UniformSampler.sample`, `StratifiedSampler.sample`, and `ActiveSampler.sample`. Renamed `n_samples` (pool size) to `n_total` in `UniformSampler.sample`.
-- Renamed `budget` parameter to `max_cost` in `CostOptimalSampler.sample` and `CostOptimalRandomSampler.sample` to make clear it represents a cost amount, not a count.
-- Removed image from User Guide explaining PPI
+- Renamed sampler parameters for clarity: `budget` → `n_samples` in `UniformSampler`, `StratifiedSampler`, and `ActiveSampler`; `budget` → `max_cost` in `CostOptimalSampler` and `CostOptimalRandomSampler`.
 
 ### 🐛 Fixed
-- Fixed broken quickstart link in README (replaced relative path with absolute ReadTheDocs URL)
+- Fixed broken quickstart link in README.
 
 ### 💛 Contributors
-- Thank you to everyone who contributed to this release: @gmartinon-ed, @imerad
+Thank you to everyone who contributed to this release: @gmartinon-ed, @imerad
 
 ## [0.6.0] – 2026-06-01
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,7 +12,7 @@ authors:
 repository-code: "https://github.com/EmertonData/glide"
 url: "https://glide-py.readthedocs.io"
 license: Apache-2.0
-version: 0.6.0
+version: 0.7.0
 date-released: 2026-06-01
 preferred-citation:
   type: article

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "glide-py"
-version = "0.6.0"
+version = "0.7.0"
 authors = [
   {name = "Grégoire Martinon", email = "gregoire.martinon@emerton-data.com"},
   {name = "Ibrahim Merad", email = "ibrahim.merad@kaukana-ventures.com"},
@@ -83,7 +83,7 @@ respect-type-ignore-comments = true
 addopts = "--import-mode=importlib --doctest-modules"
 
 [tool.bumpversion]
-current_version = "0.6.0"
+current_version = "0.7.0"
 commit = false
 tag = false
 

--- a/uv.lock
+++ b/uv.lock
@@ -866,7 +866,7 @@ wheels = [
 
 [[package]]
 name = "glide-py"
-version = "0.6.0"
+version = "0.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "scipy" },


### PR DESCRIPTION
### Description

Bumps the version to `v0.7.0` and updates the changelog.

Handles this [ticket](https://github.com/orgs/EmertonData/projects/26/views/2?pane=issue&itemId=197750840)

---

## [0.7.0] – 2026-06-12

### ✨ Added
- Cluster-level inference support: `ClusterPPIMeanEstimator`, `ClusterClassicalMeanEstimator`, `UniformClusterSampler`, and `generate_clustered_binary_dataset` for end-to-end prediction-powered inference on clustered data.
- Diagrams in the README and user guide illustrating prediction-powered inference and GLIDE's three-step workflow.

### 🔄 Changed
- `generate_gaussian_dataset` now accepts `n_total` instead of `n_labeled` and `n_unlabeled`.
- Renamed sampler parameters for clarity: `budget` → `n_samples` in `UniformSampler`, `StratifiedSampler`, and `ActiveSampler`; `budget` → `max_cost` in `CostOptimalSampler` and `CostOptimalRandomSampler`.

### 🐛 Fixed
- Fixed broken quickstart link in README.

### 💛 Contributors
Thank you to everyone who contributed to this release: @gmartinon-ed, @imerad

### Checklist

Quality gates that must be satisfied before requesting a review:

- [x] I have read `CONTRIBUTING.md`
- [ ] `make lint` passes
- [ ] `make type-check` passes
- [ ] `make tests` passes
- [ ] `make coverage` reports 100% coverage
- [ ] `make test-notebooks` passes
- [ ] New public API has numpy-style docstrings
- [ ] New public API is inserted in the API reference section of the documentation
- [ ] Docs build without warnings (`make doc`)
- [x] `CHANGELOG.md` updated if the change is user-facing

### LLM usage

Disclose if an LLM was used in writing this PR:
- [ ] No LLM used
- [x] I used an LLM and I went through and validated all the code myself