### PR TITLE
add grep to permissions

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -12,6 +12,8 @@
       "Bash(gh label list*)",
       "Bash(gh pr list*)",
       "Bash(git ls-remote*)",
+      "Bash(grep *)",
+      "Bash(rg *)",
       "WebFetch"
     ]
   },


### PR DESCRIPTION
### Description
Just add grep to permissions. rg is a modern grep used internally by Claude.

### Checklist

Quality gates that must be satisfied before requesting a review:

- [ ] I have read `CONTRIBUTING.md`
- [ ] `make lint` passes
- [ ] `make type-check` passes
- [ ] `make tests` passes
- [ ] `make coverage` reports 100% coverage
- [ ] `make test-notebooks` passes
- [ ] New public API has numpy-style docstrings
- [ ] New public API is inserted in the API reference section of the documentation
- [ ] Docs build without warnings (`make doc`)
- [ ] `CHANGELOG.md` updated if the change is user-facing

### LLM usage

Disclose if an LLM was used in writing this PR:
- [ ] No LLM used
- [x] I used an LLM and I went through and validated all the code myself