### PR TITLE
Add MultiPPIMeanEstimator for inference with multiple proxies

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -14,6 +14,7 @@
       "Bash(git ls-remote*)",
       "Bash(grep *)",
       "Bash(rg *)",
+      "Bash(echo *)",
       "WebFetch"
     ]
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ## [Next release]
 
 ### ✨ Added
+- `MultiPPIMeanEstimator` for prediction-powered inference with multiple proxy models.
 - `generate_multi_binary_dataset` simulator for generating binary oracle datasets with multiple proxies.
 - Spider Text-to-SQL case study
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ If you use GLIDE in your work, please cite us using the "Cite this repository" b
 | Active Sampling | `samplers.ActiveSampler` | [[5]](#ref-5), [[6]](#ref-6) | [Link](https://github.com/kristinagligoric/confidence-driven-inference) |
 | Predict-Then-Debias | `estimators.PTDMeanEstimator`, `estimators.StratifiedPTDMeanEstimator`, `estimators.IPWPTDMeanEstimator` | [[7]](#ref-7) | [Link](https://github.com/DanKluger/PTDBoot) |
 | Cluster Prediction-Powered Inference | `estimators.ClusteredPPIMeanEstimator` | — | [Link](https://github.com/davidbroska/ppi_py) |
-| Multi-Proxy Prediction-Powered Inference | `estimators.MultiPPIMeanEstimator` | [[8]](#ref-8) | [Link](https://github.com/jw-shan/sada) |
+| ✨ Multi-Proxy Prediction-Powered Inference | `estimators.MultiPPIMeanEstimator` | [[8]](#ref-8) | [Link](https://github.com/jw-shan/sada) |
 
 ### References
 

--- a/README.md
+++ b/README.md
@@ -84,9 +84,9 @@ If you use GLIDE in your work, please cite us using the "Cite this repository" b
 | Active Sampling | `samplers.ActiveSampler` | [[5]](#ref-5), [[6]](#ref-6) | [Link](https://github.com/kristinagligoric/confidence-driven-inference) |
 | Predict-Then-Debias | `estimators.PTDMeanEstimator`, `estimators.StratifiedPTDMeanEstimator`, `estimators.IPWPTDMeanEstimator` | [[7]](#ref-7) | [Link](https://github.com/DanKluger/PTDBoot) |
 | Cluster Prediction-Powered Inference | `estimators.ClusteredPPIMeanEstimator` | — | [Link](https://github.com/davidbroska/ppi_py) |
-| ✨ Multi-Proxy Prediction-Powered Inference | `estimators.MultiPPIMeanEstimator` | [[8]](#ref-8) | [Link](https://github.com/jw-shan/sada) |
+| Multi-Proxy Prediction-Powered Inference | `estimators.MultiPPIMeanEstimator` | [[8]](#ref-8) | [Link](https://github.com/jw-shan/sada) |
 
-### References
+### 📖 References
 
 <a id="ref-1"></a>[1] <a href="https://www.science.org/doi/10.1126/science.adi6000">Angelopoulos, Anastasios N., Stephen Bates, Clara Fannjiang, Michael I. Jordan, and Tijana Zrnic. "Prediction-powered inference." Science 382, no. 6671 (2023): 669-674.</a>
 

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ If you use GLIDE in your work, please cite us using the "Cite this repository" b
 | Active Sampling | `samplers.ActiveSampler` | [[5]](#ref-5), [[6]](#ref-6) | [Link](https://github.com/kristinagligoric/confidence-driven-inference) |
 | Predict-Then-Debias | `estimators.PTDMeanEstimator`, `estimators.StratifiedPTDMeanEstimator`, `estimators.IPWPTDMeanEstimator` | [[7]](#ref-7) | [Link](https://github.com/DanKluger/PTDBoot) |
 | Cluster Prediction-Powered Inference | `estimators.ClusteredPPIMeanEstimator` | — | [Link](https://github.com/davidbroska/ppi_py) |
+| Multi-Proxy Prediction-Powered Inference | `estimators.MultiPPIMeanEstimator` | [[8]](#ref-8) | [Link](https://github.com/jw-shan/sada) |
 
 ### References
 
@@ -100,6 +101,8 @@ If you use GLIDE in your work, please cite us using the "Cite this repository" b
 <a id="ref-6"></a>[6] <a href="https://aclanthology.org/2025.naacl-long.179/">Gligorić, Kristina, Tijana Zrnic, Cinoo Lee, Emmanuel Candes, and Dan Jurafsky. "Can unconfident LLM annotations be used for confident conclusions?" In Proceedings of the 2025 Conference of the Nations of the Americas Chapter of the Association for Computational Linguistics: Human Language Technologies (Volume 1: Long Papers), pp. 3514-3533. 2025.</a>
 
 <a id="ref-7"></a>[7] <a href="https://arxiv.org/abs/2501.18577">Kluger, Dan M., Kerri Lu, Tijana Zrnic, Sherrie Wang, and Stephen Bates. "Prediction-powered inference with imputed covariates and nonuniform sampling." arXiv preprint arXiv:2501.18577 (2025).</a>
+
+<a id="ref-8"></a>[8] <a id="ref-8-link" href="https://arxiv.org/abs/2509.21707">Shan, Jiawei, Zhifeng Chen, Yiming Dong, Yazhen Wang, and Jiwei Zhao. "SADA: Safe and Adaptive Aggregation of Multiple Black-Box Predictions in Semi-Supervised Learning." arXiv preprint arXiv:2509.21707 (2025).</a>.
 
 ## 📬 Stay Updated
 

--- a/docs/api/estimators.md
+++ b/docs/api/estimators.md
@@ -32,6 +32,10 @@
 
 ---
 
+::: glide.estimators.multi_ppi.MultiPPIMeanEstimator
+
+---
+
 ::: glide.estimators.ptd.PTDMeanEstimator
 
 ---

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -42,6 +42,7 @@
 | [`StratifiedPPIMeanEstimator`](estimators.md#glide.estimators.stratified_ppi.StratifiedPPIMeanEstimator) | PPI with per-stratum optimal weighting |
 | [`ASIMeanEstimator`](estimators.md#glide.estimators.asi.ASIMeanEstimator) | Active statistical inference with non-uniform sampling |
 | [`ClusteredPPIMeanEstimator`](estimators.md#glide.estimators.clustered_ppi.ClusteredPPIMeanEstimator) | PPI for clustered data |
+| [`MultiPPIMeanEstimator`](estimators.md#glide.estimators.multi_ppi.MultiPPIMeanEstimator) | Combines labeled data with predictions from multiple proxies |
 | [`PTDMeanEstimator`](estimators.md#glide.estimators.ptd.PTDMeanEstimator) | Predict-then-debias with bootstrap confidence intervals |
 | [`StratifiedPTDMeanEstimator`](estimators.md#glide.estimators.stratified_ptd.StratifiedPTDMeanEstimator) | PTD with per-stratum optimal weighting |
 | [`IPWPTDMeanEstimator`](estimators.md#glide.estimators.ipw_ptd.IPWPTDMeanEstimator) | PTD with inverse probability weighting |

--- a/docs/deep_dive/spider_case_study.ipynb
+++ b/docs/deep_dive/spider_case_study.ipynb
@@ -479,7 +479,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "glide-py (3.12.12)",
+   "display_name": "glide-py",
    "language": "python",
    "name": "python3"
   },

--- a/docs/hooks.py
+++ b/docs/hooks.py
@@ -1,0 +1,15 @@
+import logging
+import os
+import re
+
+log = logging.getLogger("mkdocs")
+
+
+def on_page_content(html, page, config, **kwargs):
+    for src in re.findall(r'<img[^>]+src=["\']([^"\']+)["\']', html, re.IGNORECASE):
+        if src.startswith(("http://", "https://", "data:")):
+            continue
+        page_dir = os.path.dirname(page.file.src_path)
+        img_path = os.path.normpath(os.path.join(config["docs_dir"], page_dir, src))
+        if not os.path.exists(img_path):
+            log.warning("Image not found: '%s' in %s", src, page.file.src_path)

--- a/docs/user_guide/index.md
+++ b/docs/user_guide/index.md
@@ -15,7 +15,7 @@ GLIDE addresses this by combining large pools of cheap proxy labels with small s
 The workflow has three stages:
 
 <p align="center">
-  <img src="../../assets/glide-workflow.png" alt="GLIDE's workflow" width="90%">
+  <img src="../assets/glide-workflow.png" alt="GLIDE's workflow" width="90%">
 </p>
 
 ### Do you need a sampler?

--- a/glide/core/validation.py
+++ b/glide/core/validation.py
@@ -145,6 +145,18 @@ def _validate_sample_sizes(
         raise ValueError(f"Too few labeled or unlabeled samples in {stratum_part}.")
 
 
+def _validate_y_proxies(y_proxies: NDArray, stratum_id: Optional[Hashable] = None) -> None:
+    if y_proxies.ndim != 2:
+        raise ValueError(f"'y_proxies' must be a 2D array; got shape {y_proxies.shape!r}.")
+    _validate_has_no_nan(y_proxies, "y_proxies")
+    stratum_part = f" in stratum '{stratum_id}'" if stratum_id is not None else ""
+    for m in range(y_proxies.shape[1]):
+        _validate_non_constant(
+            y_proxies[:, m],
+            f"'y_proxies' column {m} values are constant{stratum_part}.",
+        )
+
+
 def _validate_binary_or_nan(array: NDArray, name: str) -> None:
     array_float = array.astype(float)
     if not (np.isnan(array_float) | np.isin(array_float, [0.0, 1.0])).all():

--- a/glide/estimators/__init__.py
+++ b/glide/estimators/__init__.py
@@ -4,6 +4,7 @@ from glide.estimators.clustered_classical import ClusteredClassicalMeanEstimator
 from glide.estimators.clustered_ppi import ClusteredPPIMeanEstimator
 from glide.estimators.ipw_classical import IPWClassicalMeanEstimator
 from glide.estimators.ipw_ptd import IPWPTDMeanEstimator
+from glide.estimators.multi_ppi import MultiPPIMeanEstimator
 from glide.estimators.ppi import PPIMeanEstimator
 from glide.estimators.ptd import PTDMeanEstimator
 from glide.estimators.stratified_classical import StratifiedClassicalMeanEstimator
@@ -15,6 +16,7 @@ __all__ = [
     "StratifiedClassicalMeanEstimator",
     "IPWClassicalMeanEstimator",
     "ClusteredClassicalMeanEstimator",
+    "MultiPPIMeanEstimator",
     "PPIMeanEstimator",
     "StratifiedPPIMeanEstimator",
     "ASIMeanEstimator",

--- a/glide/estimators/multi_ppi.py
+++ b/glide/estimators/multi_ppi.py
@@ -26,8 +26,9 @@ class MultiPPIMeanEstimator:
     This class extends PPIMeanEstimator to settings where M >= 1 proxy models are
     available. It finds the optimal tuning parameter vector lambda that minimises the mean
     squared error of the estimate, then applies the PPI correction with that combined
-    proxy. The estimator is always at least as efficient as the naive sample mean,
-    regardless of the quality or number of proxies.
+    proxy. This power tuning feature (enabled by default) ensures the estimator is
+    always at least as efficient as the naive sample mean, regardless of the quality
+    or number of proxies.
 
     When M = 1, the estimator is equivalent to PPIMeanEstimator with power_tuning=True.
 

--- a/glide/estimators/multi_ppi.py
+++ b/glide/estimators/multi_ppi.py
@@ -23,7 +23,7 @@ from glide.mean_inference_results import PredictionPoweredMeanInferenceResult
 class MultiPPIMeanEstimator:
     """Estimator for population mean using Prediction-Powered Inference with multiple proxies.
 
-    This class extends PPIMeanEstimator to settings where M >= 1 proxy models are
+    This class extends PPIMeanEstimator to settings where M >= 1 proxy predictors are
     available. It finds the optimal tuning parameter vector lambda that minimises the mean
     squared error of the estimate, then applies the PPI correction with that combined
     proxy. This power tuning feature (enabled by default) ensures the estimator is
@@ -82,7 +82,7 @@ class MultiPPIMeanEstimator:
         """Estimate the population mean using MultiPPI.
 
         Combines a small set of labeled samples with a large set of unlabeled samples,
-        leveraging M proxy models simultaneously. The optimal tuning parameter vector lambda
+        leveraging M proxy predictors simultaneously. The optimal tuning parameter vector lambda
         is estimated from the data and used to form a single combined proxy prediction before
         applying the PPI rectifier.
 

--- a/glide/estimators/multi_ppi.py
+++ b/glide/estimators/multi_ppi.py
@@ -1,0 +1,144 @@
+from math import floor
+from typing import Tuple
+
+import numpy as np
+from numpy.typing import NDArray
+
+from glide.confidence_intervals import CLTConfidenceInterval
+from glide.core.validation import (
+    _validate_equal_lengths,
+    _validate_sample_sizes,
+    _validate_y_proxies,
+    _validate_y_true,
+)
+from glide.estimators.classical import ClassicalMeanEstimator
+from glide.estimators.multi_ppi_core import (
+    _compute_mean_estimate,
+    _compute_std_estimate,
+    _compute_tuning_parameters,
+)
+from glide.mean_inference_results import PredictionPoweredMeanInferenceResult
+
+
+class MultiPPIMeanEstimator:
+    """Estimator for population mean using Prediction-Powered Inference with multiple proxies.
+
+    This class extends PPIMeanEstimator to settings where M >= 1 proxy models are
+    available. It finds the optimal tuning parameter vector lambda that minimises the mean
+    squared error of the estimate, then applies the PPI correction with that combined
+    proxy. The estimator is always at least as efficient as the naive sample mean,
+    regardless of the quality or number of proxies.
+
+    When M = 1, the estimator is equivalent to PPIMeanEstimator with power_tuning=True.
+
+    References
+    ----------
+    Shan, Jiawei, Zhifeng Chen, Yiming Dong, Yazhen Wang, and Jiwei Zhao.
+    "SADA: Safe and Adaptive Aggregation of Multiple Black-Box Predictions in Semi-Supervised Learning."
+    arXiv preprint arXiv:2509.21707 (2025).
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from glide.estimators import MultiPPIMeanEstimator
+    >>> y_true = np.array([5.0, 6.0, np.nan, np.nan])
+    >>> y_proxies = np.array([[4.9], [6.1], [5.2], [6.1]])
+    >>> estimator = MultiPPIMeanEstimator()
+    >>> result = estimator.estimate(y_true, y_proxies)
+    >>> print(result)
+    Metric: Metric
+    Point Estimate: 5.618
+    Confidence Interval (95%): [4.923, 6.312]
+    Estimator : MultiPPIMeanEstimator
+    n_true: 2
+    n_proxy: 4
+    Effective Sample Size: 3
+    """
+
+    def _preprocess(
+        self,
+        y_true_all: NDArray,
+        y_proxies_all: NDArray,
+    ) -> Tuple[NDArray, NDArray, NDArray]:
+        _validate_equal_lengths(y_true_all, y_proxies_all, names=["y_true", "y_proxies"])
+        _validate_y_proxies(y_proxies_all)
+        _validate_y_true(y_true_all)
+        labeled_mask = ~np.isnan(y_true_all)
+        _validate_sample_sizes(labeled_mask)
+        y_true = y_true_all[labeled_mask]
+        y_proxies_labeled = y_proxies_all[labeled_mask]
+        y_proxies_unlabeled = y_proxies_all[~labeled_mask]
+        return y_true, y_proxies_labeled, y_proxies_unlabeled
+
+    def estimate(
+        self,
+        y_true: NDArray,
+        y_proxies: NDArray,
+        metric_name: str = "Metric",
+        confidence_level: float = 0.95,
+        power_tuning: bool = True,
+    ) -> PredictionPoweredMeanInferenceResult:
+        """Estimate the population mean using MultiPPI.
+
+        Combines a small set of labeled samples with a large set of unlabeled samples,
+        leveraging M proxy models simultaneously. The optimal tuning parameter vector lambda
+        is estimated from the data and used to form a single combined proxy prediction before
+        applying the PPI rectifier.
+
+        Parameters
+        ----------
+        y_true : NDArray
+            Array of observations, shape ``(n_samples,)``.
+            Labeled entries are finite; unlabeled entries are ``np.nan``.
+        y_proxies : NDArray
+            2D array of proxy predictions, shape ``(n_samples, M)``.
+            Must be fully populated (no NaN). Each column must have nonzero variance.
+        metric_name : str, optional
+            Human-readable label for the metric. Defaults to ``"Metric"``.
+        confidence_level : float, optional
+            Target coverage for the confidence interval. Defaults to ``0.95``.
+        power_tuning : bool, optional
+            If ``True`` (default), compute the optimal lambda to minimise the confidence
+            interval width. If ``False``, set all tuning parameters to ``1/sqrt(M)``
+            to limit proxy variance contribution for large M.
+
+        Returns
+        -------
+        PredictionPoweredMeanInferenceResult
+            Contains the CLT-based confidence interval, the metric name,
+            the estimator name (``"MultiPPIMeanEstimator"``), and the counts
+            ``n_true`` (labeled observations) and ``n_proxy`` (all observations).
+
+        Raises
+        ------
+        ValueError
+            - If ``y_true`` and ``y_proxies`` have different lengths.
+            - If ``y_proxies`` is not a 2D array.
+            - If any value in ``y_proxies`` is NaN.
+            - If any column of ``y_proxies`` is constant.
+            - If ``y_true`` contains only NaN or its labeled values are constant.
+            - If there are fewer than 2 labeled or fewer than 2 unlabeled samples.
+            - If the proxy covariance matrix is singular.
+        """
+        y_true_filtered, y_proxies_labeled, y_proxies_unlabeled = self._preprocess(y_true, y_proxies)
+        n_labeled = len(y_true_filtered)
+        n_unlabeled = len(y_proxies_unlabeled)
+        lambdas_ = _compute_tuning_parameters(y_true_filtered, y_proxies_labeled, y_proxies_unlabeled, power_tuning)
+        mean = _compute_mean_estimate(y_true_filtered, y_proxies_labeled, y_proxies_unlabeled, lambdas_)
+        std = _compute_std_estimate(y_true_filtered, y_proxies_labeled, y_proxies_unlabeled, lambdas_)
+        confidence_interval = CLTConfidenceInterval(
+            mean=mean,
+            std=std,
+            confidence_level=confidence_level,
+        )
+        classical_confidence_interval = ClassicalMeanEstimator().estimate(y_true_filtered).confidence_interval
+        effective_sample_size = floor(n_labeled * classical_confidence_interval.var / confidence_interval.var)
+        result = PredictionPoweredMeanInferenceResult(
+            confidence_interval=confidence_interval,
+            metric_name=metric_name,
+            estimator_name=self.__class__.__name__,
+            n_true=n_labeled,
+            n_proxy=n_labeled + n_unlabeled,
+            effective_sample_size=effective_sample_size,
+        )
+        return result

--- a/glide/estimators/multi_ppi_core.py
+++ b/glide/estimators/multi_ppi_core.py
@@ -8,14 +8,14 @@ def _compute_tuning_parameters(
     y_proxies_unlabeled: NDArray,
     power_tuning: bool,
 ) -> NDArray:
+    n_proxies = y_proxies_labeled.shape[1]
+    if not power_tuning:
+        lambdas_ = np.full(n_proxies, 1 / np.sqrt(n_proxies))
+        return lambdas_
     n_labeled = len(y_true)
     n_unlabeled = len(y_proxies_unlabeled)
-    M = y_proxies_labeled.shape[1]
-    if not power_tuning:
-        lambdas_ = np.full(M, 1 / np.sqrt(M))
-        return lambdas_
     y_proxies_all = np.vstack([y_proxies_labeled, y_proxies_unlabeled])
-    proxy_cov_matrix = np.atleast_2d(np.cov(y_proxies_all.T, ddof=1))
+    proxy_cov_matrix = np.atleast_2d(np.cov(y_proxies_all, rowvar=False, ddof=1))
     centered_proxies_labeled = y_proxies_labeled - np.mean(y_proxies_labeled, axis=0)
     centered_true = y_true - np.mean(y_true)
     proxy_true_cov = centered_proxies_labeled.T @ centered_true / (n_labeled - 1)

--- a/glide/estimators/multi_ppi_core.py
+++ b/glide/estimators/multi_ppi_core.py
@@ -1,0 +1,58 @@
+import numpy as np
+from numpy.typing import NDArray
+
+
+def _compute_tuning_parameters(
+    y_true: NDArray,
+    y_proxies_labeled: NDArray,
+    y_proxies_unlabeled: NDArray,
+    power_tuning: bool,
+) -> NDArray:
+    n_labeled = len(y_true)
+    n_unlabeled = len(y_proxies_unlabeled)
+    M = y_proxies_labeled.shape[1]
+    if not power_tuning:
+        lambdas_ = np.full(M, 1 / np.sqrt(M))
+        return lambdas_
+    y_proxies_all = np.vstack([y_proxies_labeled, y_proxies_unlabeled])
+    proxy_cov_matrix = np.atleast_2d(np.cov(y_proxies_all.T, ddof=1))
+    centered_proxies_labeled = y_proxies_labeled - np.mean(y_proxies_labeled, axis=0)
+    centered_true = y_true - np.mean(y_true)
+    proxy_true_cov = centered_proxies_labeled.T @ centered_true / (n_labeled - 1)
+    try:
+        lambdas_ = n_unlabeled / (n_labeled + n_unlabeled) * np.linalg.solve(proxy_cov_matrix, proxy_true_cov)
+    except np.linalg.LinAlgError as exc:
+        raise ValueError(
+            "The proxy covariance matrix is singular. "
+            "This typically means two or more proxy columns are perfectly correlated."
+        ) from exc
+    return lambdas_
+
+
+def _compute_mean_estimate(
+    y_true: NDArray,
+    y_proxies_labeled: NDArray,
+    y_proxies_unlabeled: NDArray,
+    lambdas_: NDArray,
+) -> float:
+    rectifier = np.mean(y_true) - lambdas_ @ np.mean(y_proxies_labeled, axis=0)
+    proxy_mean = lambdas_ @ np.mean(y_proxies_unlabeled, axis=0)
+    mean_estimate = proxy_mean + rectifier
+    return mean_estimate
+
+
+def _compute_std_estimate(
+    y_true: NDArray,
+    y_proxies_labeled: NDArray,
+    y_proxies_unlabeled: NDArray,
+    lambdas_: NDArray,
+) -> float:
+    n_labeled = len(y_true)
+    n_unlabeled = len(y_proxies_unlabeled)
+    rectifier_residuals = y_true - y_proxies_labeled @ lambdas_
+    rectifier_var = np.var(rectifier_residuals, ddof=1) / n_labeled
+    proxy_projections = y_proxies_unlabeled @ lambdas_
+    proxy_var = np.var(proxy_projections, ddof=1) / n_unlabeled
+    var_estimate = rectifier_var + proxy_var
+    std_estimate = np.sqrt(var_estimate)
+    return std_estimate

--- a/glide/estimators/ppi_core.py
+++ b/glide/estimators/ppi_core.py
@@ -45,8 +45,10 @@ def _compute_std_estimate(
     lambda_: float,
 ) -> float:
     n_labeled, n_unlabeled = len(y_true), len(y_proxy_unlabeled)
-    rectifier_var = np.var(y_true - lambda_ * y_proxy_labeled, ddof=1) / n_labeled
-    proxy_var = lambda_**2 * np.var(y_proxy_unlabeled, ddof=1) / n_unlabeled
-    var_estimate = proxy_var + rectifier_var
+    rectifier_residuals = y_true - lambda_ * y_proxy_labeled
+    rectifier_var = np.var(rectifier_residuals, ddof=1) / n_labeled
+    proxy_projections = lambda_ * y_proxy_unlabeled
+    proxy_var = np.var(proxy_projections, ddof=1) / n_unlabeled
+    var_estimate = rectifier_var + proxy_var
     std_estimate = np.sqrt(var_estimate)
     return std_estimate

--- a/glide/estimators/ppi_core.py
+++ b/glide/estimators/ppi_core.py
@@ -11,7 +11,8 @@ def _compute_tuning_parameter(
     power_tuning: bool,
 ) -> float:
     if not power_tuning:
-        return 1.0
+        lambda_ = 1.0
+        return lambda_
     n_labeled = len(y_true)
     n_unlabeled = len(y_proxy_unlabeled)
     y_proxy_all = np.hstack([y_proxy_labeled, y_proxy_unlabeled])

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -39,6 +39,9 @@ theme:
 extra_css:
   - stylesheets/extra.css
 
+hooks:
+  - docs/hooks.py
+
 plugins:
   - search
   - mkdocstrings:

--- a/tests/functional/estimators/test_multi_ppi.py
+++ b/tests/functional/estimators/test_multi_ppi.py
@@ -1,0 +1,88 @@
+"""Functional tests for MultiPPIMeanEstimator.
+
+These tests verify end-to-end statistical properties rather than implementation
+details, and therefore require larger datasets to hold reliably.
+"""
+
+import numpy as np
+
+from glide.estimators import ClassicalMeanEstimator, MultiPPIMeanEstimator, PPIMeanEstimator
+from glide.simulators import generate_binary_dataset, generate_multi_binary_dataset, simulate_annotation
+
+# ── tests ──────────────────────────────────────────────────────────────────────
+
+
+def test_m1_equals_ppi_plus_plus():
+    """MultiPPI with M=1 and power_tuning=True reproduces PPI++ exactly.
+
+    When y_proxies has a single column, the optimal lambda vector reduces to
+    the scalar PPI++ tuning parameter. The point estimate, standard error, and
+    confidence interval bounds must match to floating-point precision.
+    """
+    y_true_oracle, y_proxy_1d = generate_binary_dataset(n_total=25, random_seed=0)
+    xi = np.hstack([np.ones(5), np.zeros(20)])
+    y_true = simulate_annotation(y_true_oracle, xi)
+    y_proxies_2d = y_proxy_1d[:, np.newaxis]
+
+    result_multi = MultiPPIMeanEstimator().estimate(y_true, y_proxies_2d, power_tuning=True)
+    result_ppi = PPIMeanEstimator().estimate(y_true, y_proxy_1d, power_tuning=True)
+
+    np.testing.assert_allclose(result_multi.confidence_interval.mean, result_ppi.confidence_interval.mean, atol=1e-12)
+    np.testing.assert_allclose(result_multi.std, result_ppi.std, atol=1e-12)
+    np.testing.assert_allclose(
+        result_multi.confidence_interval.lower_bound, result_ppi.confidence_interval.lower_bound, atol=1e-12
+    )
+
+
+def test_m1_power_tuning_false_equals_ppi_untuned():
+    """MultiPPI with M=1 and power_tuning=False reproduces untuned PPI exactly.
+
+    With a single proxy and power_tuning=False, lambda is set to 1/sqrt(1)=1,
+    which is identical to the classic PPI lambda=1.
+    """
+    y_true_oracle, y_proxy_1d = generate_binary_dataset(n_total=25, random_seed=0)
+    xi = np.hstack([np.ones(5), np.zeros(20)])
+    y_true = simulate_annotation(y_true_oracle, xi)
+    y_proxies_2d = y_proxy_1d[:, np.newaxis]
+
+    result_multi = MultiPPIMeanEstimator().estimate(y_true, y_proxies_2d, power_tuning=False)
+    result_ppi = PPIMeanEstimator().estimate(y_true, y_proxy_1d, power_tuning=False)
+
+    np.testing.assert_allclose(result_multi.confidence_interval.mean, result_ppi.confidence_interval.mean, atol=1e-12)
+    np.testing.assert_allclose(result_multi.std, result_ppi.std, atol=1e-12)
+
+
+def test_multi_ppi_tighter_than_classical_for_good_proxies():
+    """MultiPPI yields a tighter confidence interval than Classical when both proxies correlate well with y_true.
+
+    With strongly correlated proxies, the optimal lambda reduces the variance below
+    the classical estimator's variance, guaranteeing a narrower confidence interval.
+    """
+    y_true_oracle, y_proxies = generate_multi_binary_dataset(50, 0.6, [0.6, 0.65], [0.7, 0.7], random_seed=0)
+    xi = np.hstack([np.ones(10), np.zeros(40)])
+    y_true = simulate_annotation(y_true_oracle, xi)
+
+    result_multi = MultiPPIMeanEstimator().estimate(y_true, y_proxies)
+    result_classical = ClassicalMeanEstimator().estimate(y_true)
+
+    assert result_multi.std < result_classical.std
+
+
+def test_m2_tighter_than_single_ppi_for_independent_proxies():
+    """MultiPPI with M=2 yields a tighter confidence interval than single PPI with either proxy alone.
+
+    When two proxies carry independent information about the true label, the optimal
+    lambda vector exploits both signals simultaneously, reducing variance below what
+    any single proxy achieves. A large sample is required for the estimated lambdas
+    to be close enough to the true optimal values.
+    """
+    y_true_oracle, y_proxies = generate_multi_binary_dataset(200, 0.6, [0.6, 0.65], [0.7, 0.7], random_seed=0)
+    xi = np.hstack([np.ones(40), np.zeros(160)])
+    y_true = simulate_annotation(y_true_oracle, xi)
+
+    result_multi = MultiPPIMeanEstimator().estimate(y_true, y_proxies)
+    result_ppi_0 = PPIMeanEstimator().estimate(y_true, y_proxies[:, 0])
+    result_ppi_1 = PPIMeanEstimator().estimate(y_true, y_proxies[:, 1])
+
+    assert result_multi.std < result_ppi_0.std
+    assert result_multi.std < result_ppi_1.std

--- a/tests/functional/estimators/test_multi_ppi.py
+++ b/tests/functional/estimators/test_multi_ppi.py
@@ -6,7 +6,7 @@ details, and therefore require larger datasets to hold reliably.
 
 import numpy as np
 
-from glide.estimators import ClassicalMeanEstimator, MultiPPIMeanEstimator, PPIMeanEstimator
+from glide.estimators import MultiPPIMeanEstimator, PPIMeanEstimator
 from glide.simulators import generate_binary_dataset, generate_multi_binary_dataset, simulate_annotation
 
 # ── tests ──────────────────────────────────────────────────────────────────────
@@ -35,22 +35,6 @@ def test_single_proxy_equals_ppi():
     np.testing.assert_allclose(
         result_multi.confidence_interval.upper_bound, result_ppi.confidence_interval.upper_bound, atol=1e-12
     )
-
-
-def test_multi_ppi_tighter_than_classical():
-    """MultiPPI yields a tighter confidence interval than Classical when both proxies correlate well with y_true.
-
-    With strongly correlated proxies, the optimal lambda reduces the variance below
-    the classical estimator's variance, guaranteeing a narrower confidence interval.
-    """
-    y_true_oracle, y_proxies = generate_multi_binary_dataset(50, 0.6, [0.6, 0.65], [0.7, 0.7], random_seed=0)
-    xi = np.hstack([np.ones(10), np.zeros(40)])
-    y_true = simulate_annotation(y_true_oracle, xi)
-
-    result_multi = MultiPPIMeanEstimator().estimate(y_true, y_proxies)
-    result_classical = ClassicalMeanEstimator().estimate(y_true)
-
-    assert result_multi.std < result_classical.std
 
 
 def test_two_proxies_tighter_than_single_ppi():

--- a/tests/functional/estimators/test_multi_ppi.py
+++ b/tests/functional/estimators/test_multi_ppi.py
@@ -12,8 +12,8 @@ from glide.simulators import generate_binary_dataset, generate_multi_binary_data
 # ── tests ──────────────────────────────────────────────────────────────────────
 
 
-def test_m1_equals_ppi_plus_plus():
-    """MultiPPI with M=1 and power_tuning=True reproduces PPI++ exactly.
+def test_single_proxy_equals_ppi():
+    """MultiPPI with M=1 reproduces PPI++ exactly.
 
     When y_proxies has a single column, the optimal lambda vector reduces to
     the scalar PPI++ tuning parameter. The point estimate, standard error, and
@@ -24,35 +24,20 @@ def test_m1_equals_ppi_plus_plus():
     y_true = simulate_annotation(y_true_oracle, xi)
     y_proxies_2d = y_proxy_1d[:, np.newaxis]
 
-    result_multi = MultiPPIMeanEstimator().estimate(y_true, y_proxies_2d, power_tuning=True)
-    result_ppi = PPIMeanEstimator().estimate(y_true, y_proxy_1d, power_tuning=True)
+    result_multi = MultiPPIMeanEstimator().estimate(y_true, y_proxies_2d)
+    result_ppi = PPIMeanEstimator().estimate(y_true, y_proxy_1d)
 
     np.testing.assert_allclose(result_multi.confidence_interval.mean, result_ppi.confidence_interval.mean, atol=1e-12)
     np.testing.assert_allclose(result_multi.std, result_ppi.std, atol=1e-12)
     np.testing.assert_allclose(
         result_multi.confidence_interval.lower_bound, result_ppi.confidence_interval.lower_bound, atol=1e-12
     )
+    np.testing.assert_allclose(
+        result_multi.confidence_interval.upper_bound, result_ppi.confidence_interval.upper_bound, atol=1e-12
+    )
 
 
-def test_m1_power_tuning_false_equals_ppi_untuned():
-    """MultiPPI with M=1 and power_tuning=False reproduces untuned PPI exactly.
-
-    With a single proxy and power_tuning=False, lambda is set to 1/sqrt(1)=1,
-    which is identical to the classic PPI lambda=1.
-    """
-    y_true_oracle, y_proxy_1d = generate_binary_dataset(n_total=25, random_seed=0)
-    xi = np.hstack([np.ones(5), np.zeros(20)])
-    y_true = simulate_annotation(y_true_oracle, xi)
-    y_proxies_2d = y_proxy_1d[:, np.newaxis]
-
-    result_multi = MultiPPIMeanEstimator().estimate(y_true, y_proxies_2d, power_tuning=False)
-    result_ppi = PPIMeanEstimator().estimate(y_true, y_proxy_1d, power_tuning=False)
-
-    np.testing.assert_allclose(result_multi.confidence_interval.mean, result_ppi.confidence_interval.mean, atol=1e-12)
-    np.testing.assert_allclose(result_multi.std, result_ppi.std, atol=1e-12)
-
-
-def test_multi_ppi_tighter_than_classical_for_good_proxies():
+def test_multi_ppi_tighter_than_classical():
     """MultiPPI yields a tighter confidence interval than Classical when both proxies correlate well with y_true.
 
     With strongly correlated proxies, the optimal lambda reduces the variance below
@@ -68,13 +53,12 @@ def test_multi_ppi_tighter_than_classical_for_good_proxies():
     assert result_multi.std < result_classical.std
 
 
-def test_m2_tighter_than_single_ppi_for_independent_proxies():
+def test_two_proxies_tighter_than_single_ppi():
     """MultiPPI with M=2 yields a tighter confidence interval than single PPI with either proxy alone.
 
     When two proxies carry independent information about the true label, the optimal
     lambda vector exploits both signals simultaneously, reducing variance below what
-    any single proxy achieves. A large sample is required for the estimated lambdas
-    to be close enough to the true optimal values.
+    any single proxy achieves.
     """
     y_true_oracle, y_proxies = generate_multi_binary_dataset(200, 0.6, [0.6, 0.65], [0.7, 0.7], random_seed=0)
     xi = np.hstack([np.ones(40), np.zeros(160)])

--- a/tests/unit/core/test_validation.py
+++ b/tests/unit/core/test_validation.py
@@ -22,6 +22,7 @@ from glide.core.validation import (
     _validate_strictly_positive,
     _validate_uncertainties,
     _validate_unique_clusters,
+    _validate_y_proxies,
     _validate_y_proxy,
     _validate_y_true,
     _validate_y_true_burn_in,
@@ -92,6 +93,35 @@ def test_get_non_zero_mask_with_zero_emits_warning():
     with pytest.warns(UserWarning, match=warning_message):
         result = _get_non_zero_mask(np.array([0.0, 0.5]), warning_message=warning_message)
     np.testing.assert_array_equal(result, expected)
+
+
+# --- _validate_y_proxies ---
+
+
+def test_validate_y_proxies_valid():
+    _validate_y_proxies(np.array([[1.0, 2.0], [3.0, 4.0]]))
+
+
+def test_validate_y_proxies_1d_raises():
+    with pytest.raises(ValueError, match="'y_proxies' must be a 2D array"):
+        _validate_y_proxies(np.array([1.0, 2.0]))
+
+
+def test_validate_y_proxies_delegates_to_validation():
+    with (
+        patch("glide.core.validation._validate_has_no_nan") as mock_validate_has_no_nan,
+        patch("glide.core.validation._validate_non_constant") as mock_validate_non_constant,
+    ):
+        arr = np.array([[1.0, 2.0], [3.0, 4.0]])
+        _validate_y_proxies(arr)
+        mock_validate_has_no_nan.assert_called_once()
+        np.testing.assert_array_equal(mock_validate_has_no_nan.call_args[0][0], arr)
+        assert mock_validate_has_no_nan.call_args[0][1] == "y_proxies"
+        assert mock_validate_non_constant.call_count == 2
+        np.testing.assert_array_equal(mock_validate_non_constant.call_args_list[0][0][0], arr[:, 0])
+        assert mock_validate_non_constant.call_args_list[0][0][1] == "'y_proxies' column 0 values are constant."
+        np.testing.assert_array_equal(mock_validate_non_constant.call_args_list[1][0][0], arr[:, 1])
+        assert mock_validate_non_constant.call_args_list[1][0][1] == "'y_proxies' column 1 values are constant."
 
 
 # --- _validate_y_proxy ---

--- a/tests/unit/estimators/test_multi_ppi.py
+++ b/tests/unit/estimators/test_multi_ppi.py
@@ -1,0 +1,96 @@
+from typing import Tuple
+from unittest.mock import patch
+
+import numpy as np
+import pytest
+from numpy.typing import NDArray
+
+import glide.estimators.multi_ppi as multi_ppi_module
+from glide.confidence_intervals import CLTConfidenceInterval
+from glide.estimators import MultiPPIMeanEstimator
+from glide.mean_inference_results import PredictionPoweredMeanInferenceResult
+
+# ── helpers ────────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def y_arrays() -> Tuple[NDArray, NDArray]:
+    y_true = np.array([1.0, 2.0, np.nan, np.nan])
+    y_proxies = np.array([[1.0, 0.0], [2.0, 2.0], [3.0, 1.0], [4.0, 3.0]])
+    return y_true, y_proxies
+
+
+@pytest.fixture
+def estimator() -> MultiPPIMeanEstimator:
+    return MultiPPIMeanEstimator()
+
+
+# --- _preprocess ---
+
+
+def test_preprocess_delegates_to_validation(estimator, y_arrays):
+    y_true, y_proxies = y_arrays
+    with (
+        patch.object(multi_ppi_module, "_validate_equal_lengths") as mock_validate_equal_lengths,
+        patch.object(multi_ppi_module, "_validate_y_proxies") as mock_validate_y_proxies,
+        patch.object(multi_ppi_module, "_validate_y_true") as mock_validate_y_true,
+        patch.object(multi_ppi_module, "_validate_sample_sizes") as mock_validate_sample_sizes,
+    ):
+        estimator._preprocess(y_true, y_proxies)
+
+        mock_validate_equal_lengths.assert_called_once_with(y_true, y_proxies, names=["y_true", "y_proxies"])
+        mock_validate_y_proxies.assert_called_once_with(y_proxies)
+        mock_validate_y_true.assert_called_once_with(y_true)
+        mock_validate_sample_sizes.assert_called_once()
+        labeled_mask_arg = mock_validate_sample_sizes.call_args[0][0]
+        np.testing.assert_array_equal(labeled_mask_arg, np.array([True, True, False, False]))
+
+
+def test_preprocess_valid_output(estimator, y_arrays):
+    y_true_all, y_proxies_all = y_arrays
+    y_true, y_proxies_labeled, y_proxies_unlabeled = estimator._preprocess(y_true_all, y_proxies_all)
+    np.testing.assert_array_equal(y_true, np.array([1.0, 2.0]))
+    np.testing.assert_array_equal(y_proxies_labeled, np.array([[1.0, 0.0], [2.0, 2.0]]))
+    np.testing.assert_array_equal(y_proxies_unlabeled, np.array([[3.0, 1.0], [4.0, 3.0]]))
+
+
+# --- estimate ---
+
+
+def test_estimate_is_valid_inference_result(estimator, y_arrays):
+    y_true, y_proxies = y_arrays
+    result = estimator.estimate(y_true, y_proxies)
+    assert isinstance(result, PredictionPoweredMeanInferenceResult)
+    assert isinstance(result.confidence_interval, CLTConfidenceInterval)
+    assert np.isfinite(result.confidence_interval.lower_bound)
+    assert np.isfinite(result.confidence_interval.upper_bound)
+    assert result.confidence_interval.lower_bound < result.confidence_interval.upper_bound
+    assert result.estimator_name == "MultiPPIMeanEstimator"
+
+
+def test_estimate_metadata(estimator, y_arrays):
+    y_true, y_proxies = y_arrays
+    result = estimator.estimate(y_true, y_proxies, metric_name="accuracy")
+    assert result.metric_name == "accuracy"
+    assert result.estimator_name == "MultiPPIMeanEstimator"
+    assert result.n_true == 2
+    assert result.n_proxy == 4
+    assert result.effective_sample_size == 3
+
+
+def test_estimate_known_values(estimator, y_arrays):
+    y_true, y_proxies = y_arrays
+    result = estimator.estimate(y_true, y_proxies, confidence_level=0.95)
+    assert result.confidence_interval.mean == pytest.approx(1.5, abs=1e-10)
+    assert result.std == pytest.approx(np.sqrt(0.15625), abs=1e-10)
+    assert result.confidence_interval.lower_bound == pytest.approx(0.725, abs=0.01)
+    assert result.confidence_interval.upper_bound == pytest.approx(2.275, abs=0.01)
+
+
+def test_estimate_power_tuning_false(estimator, y_arrays):
+    y_true, y_proxies = y_arrays
+    result_tuned = estimator.estimate(y_true, y_proxies, power_tuning=True)
+    result_untuned = estimator.estimate(y_true, y_proxies, power_tuning=False)
+    assert isinstance(result_untuned, PredictionPoweredMeanInferenceResult)
+    assert result_untuned.estimator_name == "MultiPPIMeanEstimator"
+    assert result_untuned.confidence_interval.mean != pytest.approx(result_tuned.confidence_interval.mean, abs=1e-10)

--- a/tests/unit/estimators/test_multi_ppi.py
+++ b/tests/unit/estimators/test_multi_ppi.py
@@ -83,9 +83,9 @@ def test_estimate_custom_confidence_level(estimator, y_arrays):
     result = estimator.estimate(y_true, y_proxies, confidence_level=0.85)
 
     expected_mean = 1.5
-    expected_std = 0.250
-    expected_lower = 5.257
-    expected_upper = 5.978
+    expected_std = 0.395
+    expected_lower = 0.931
+    expected_upper = 2.069
 
     assert result.confidence_interval.confidence_level == 0.85
     assert result.confidence_interval.mean == pytest.approx(expected_mean, abs=0.01)
@@ -104,12 +104,12 @@ def test_str_format(estimator, y_arrays):
     output = str(result)
     expected = (
         "Metric: performance\n"
-        "Point Estimate: 5.618\n"
-        "Confidence Interval (95%): [5.127, 6.108]\n"
-        "Estimator : StratifiedPPIMeanEstimator\n"
-        "n_true: 4\n"
-        "n_proxy: 8\n"
-        "Effective Sample Size: 7"
+        "Point Estimate: 1.500\n"
+        "Confidence Interval (95%): [0.725, 2.275]\n"
+        "Estimator : MultiPPIMeanEstimator\n"
+        "n_true: 2\n"
+        "n_proxy: 4\n"
+        "Effective Sample Size: 3"
     )
     assert output == expected
 

--- a/tests/unit/estimators/test_multi_ppi.py
+++ b/tests/unit/estimators/test_multi_ppi.py
@@ -78,19 +78,43 @@ def test_estimate_metadata(estimator, y_arrays):
     assert result.effective_sample_size == 3
 
 
-def test_estimate_known_values(estimator, y_arrays):
+def test_estimate_custom_confidence_level(estimator, y_arrays):
     y_true, y_proxies = y_arrays
-    result = estimator.estimate(y_true, y_proxies, confidence_level=0.95)
-    assert result.confidence_interval.mean == pytest.approx(1.5, abs=1e-10)
-    assert result.std == pytest.approx(np.sqrt(0.15625), abs=1e-10)
-    assert result.confidence_interval.lower_bound == pytest.approx(0.725, abs=0.01)
-    assert result.confidence_interval.upper_bound == pytest.approx(2.275, abs=0.01)
+    result = estimator.estimate(y_true, y_proxies, confidence_level=0.85)
+
+    expected_mean = 1.5
+    expected_std = 0.250
+    expected_lower = 5.257
+    expected_upper = 5.978
+
+    assert result.confidence_interval.confidence_level == 0.85
+    assert result.confidence_interval.mean == pytest.approx(expected_mean, abs=0.01)
+    assert result.std == pytest.approx(expected_std, abs=0.01)
+    assert result.confidence_interval.lower_bound == pytest.approx(expected_lower, abs=0.01)
+    assert result.confidence_interval.upper_bound == pytest.approx(expected_upper, abs=0.01)
 
 
-def test_estimate_power_tuning_false(estimator, y_arrays):
+# --- __str__ / __repr__ ---
+
+
+def test_str_format(estimator, y_arrays):
     y_true, y_proxies = y_arrays
-    result_tuned = estimator.estimate(y_true, y_proxies, power_tuning=True)
-    result_untuned = estimator.estimate(y_true, y_proxies, power_tuning=False)
-    assert isinstance(result_untuned, PredictionPoweredMeanInferenceResult)
-    assert result_untuned.estimator_name == "MultiPPIMeanEstimator"
-    assert result_untuned.confidence_interval.mean != pytest.approx(result_tuned.confidence_interval.mean, abs=1e-10)
+    result = estimator.estimate(y_true, y_proxies, metric_name="performance")
+
+    output = str(result)
+    expected = (
+        "Metric: performance\n"
+        "Point Estimate: 5.618\n"
+        "Confidence Interval (95%): [5.127, 6.108]\n"
+        "Estimator : StratifiedPPIMeanEstimator\n"
+        "n_true: 4\n"
+        "n_proxy: 8\n"
+        "Effective Sample Size: 7"
+    )
+    assert output == expected
+
+
+def test_repr_equals_str(estimator, y_arrays):
+    y_true, y_proxies = y_arrays
+    result = estimator.estimate(y_true, y_proxies, metric_name="perf")
+    assert repr(result) == str(result)

--- a/tests/unit/estimators/test_multi_ppi_core.py
+++ b/tests/unit/estimators/test_multi_ppi_core.py
@@ -1,0 +1,75 @@
+import numpy as np
+import pytest
+from numpy.typing import NDArray
+
+from glide.estimators.multi_ppi_core import (
+    _compute_mean_estimate,
+    _compute_std_estimate,
+    _compute_tuning_parameters,
+)
+
+
+@pytest.fixture
+def y_true() -> NDArray:
+    return np.array([2.0, 4.0])
+
+
+@pytest.fixture
+def y_proxies_labeled() -> NDArray:
+    return np.array([[1.0, 2.0], [3.0, 2.0]])
+
+
+@pytest.fixture
+def y_proxies_unlabeled() -> NDArray:
+    return np.array([[1.5, 3.0], [3.5, 3.0]])
+
+
+# --- _compute_tuning_parameters ---
+
+
+def test_compute_tuning_parameters_power_tuning_false(y_true, y_proxies_labeled, y_proxies_unlabeled):
+    expected = np.array([1 / np.sqrt(2), 1 / np.sqrt(2)])
+    result = _compute_tuning_parameters(y_true, y_proxies_labeled, y_proxies_unlabeled, power_tuning=False)
+    np.testing.assert_allclose(result, expected)
+
+
+def test_compute_tuning_parameters_power_tuning_true_m1():
+    y_true_3 = np.array([5.0, 6.0, 7.0])
+    y_proxies_labeled_1d = np.array([[4.5], [5.5], [6.5]])
+    y_proxies_unlabeled_1d = np.array([[6.0], [7.0], [8.0]])
+    expected = np.array([0.339])
+    result = _compute_tuning_parameters(y_true_3, y_proxies_labeled_1d, y_proxies_unlabeled_1d, power_tuning=True)
+    np.testing.assert_allclose(result, expected, atol=0.01)
+
+
+def test_compute_tuning_parameters_power_tuning_true_m2(y_true, y_proxies_labeled, y_proxies_unlabeled):
+    expected = np.array([0.75, -0.375])
+    result = _compute_tuning_parameters(y_true, y_proxies_labeled, y_proxies_unlabeled, power_tuning=True)
+    np.testing.assert_allclose(result, expected, atol=1e-10)
+
+
+def test_compute_tuning_parameters_singular_matrix_raises(y_true, y_proxies_labeled, y_proxies_unlabeled):
+    identical_labeled = np.column_stack([y_proxies_labeled[:, 0], y_proxies_labeled[:, 0]])
+    identical_unlabeled = np.column_stack([y_proxies_unlabeled[:, 0], y_proxies_unlabeled[:, 0]])
+    with pytest.raises(ValueError, match="singular"):
+        _compute_tuning_parameters(y_true, identical_labeled, identical_unlabeled, power_tuning=True)
+
+
+# --- _compute_mean_estimate ---
+
+
+def test_compute_mean_estimate_known_values(y_true, y_proxies_labeled, y_proxies_unlabeled):
+    lambdas_ = np.array([0.5, 0.5])
+    expected = 3.75
+    result = _compute_mean_estimate(y_true, y_proxies_labeled, y_proxies_unlabeled, lambdas_)
+    assert result == pytest.approx(expected)
+
+
+# --- _compute_std_estimate ---
+
+
+def test_compute_std_estimate_known_values(y_true, y_proxies_labeled, y_proxies_unlabeled):
+    lambdas_ = np.array([0.5, 0.5])
+    expected = np.sqrt(0.5)
+    result = _compute_std_estimate(y_true, y_proxies_labeled, y_proxies_unlabeled, lambdas_)
+    assert result == pytest.approx(expected, abs=1e-10)

--- a/tests/unit/estimators/test_multi_ppi_core.py
+++ b/tests/unit/estimators/test_multi_ppi_core.py
@@ -33,16 +33,7 @@ def test_compute_tuning_parameters_power_tuning_false(y_true, y_proxies_labeled,
     np.testing.assert_allclose(result, expected)
 
 
-def test_compute_tuning_parameters_power_tuning_true_m1():
-    y_true_3 = np.array([5.0, 6.0, 7.0])
-    y_proxies_labeled_1d = np.array([[4.5], [5.5], [6.5]])
-    y_proxies_unlabeled_1d = np.array([[6.0], [7.0], [8.0]])
-    expected = np.array([0.339])
-    result = _compute_tuning_parameters(y_true_3, y_proxies_labeled_1d, y_proxies_unlabeled_1d, power_tuning=True)
-    np.testing.assert_allclose(result, expected, atol=0.01)
-
-
-def test_compute_tuning_parameters_power_tuning_true_m2(y_true, y_proxies_labeled, y_proxies_unlabeled):
+def test_compute_tuning_parameters_known_value(y_true, y_proxies_labeled, y_proxies_unlabeled):
     expected = np.array([0.75, -0.375])
     result = _compute_tuning_parameters(y_true, y_proxies_labeled, y_proxies_unlabeled, power_tuning=True)
     np.testing.assert_allclose(result, expected, atol=1e-10)


### PR DESCRIPTION
### Description

Adds `MultiPPIMeanEstimator`, which generalises PPI to M ≥ 1 proxy models by finding the optimal linear combination of proxies before applying the PPI correction. Also refactors `ppi_core._compute_std_estimate` to name intermediate arrays consistently with the new `multi_ppi_core` implementation.

Deals with this [ticket](https://github.com/orgs/EmertonData/projects/26/views/2?pane=issue&itemId=176217871&issue=EmertonData%7Cglide%7C272)
Closes #272

### Checklist

Quality gates that must be satisfied before requesting a review:

- [x] I have read `CONTRIBUTING.md`
- [x] `make lint` passes
- [x] `make type-check` passes
- [x] `make tests` passes
- [x] `make coverage` reports 100% coverage
- [x] `make test-notebooks` passes
- [x] New public API has numpy-style docstrings
- [x] New public API is inserted in the API reference section of the documentation
- [x] Docs build without warnings (`make doc`)
- [x] `CHANGELOG.md` updated if the change is user-facing

### LLM usage

Disclose if an LLM was used in writing this PR:
- [ ] No LLM used
- [x] I used an LLM and I went through and validated all the code myself