### PR TITLE
Implement ClusteredPTDMeanEstimator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ## [Next release]
 
 ### ✨ Added
-- `ClusteredPTDMeanEstimator`: cluster-robust Predict-Then-Debias estimator for clsutered data.
+- `ClusteredPTDMeanEstimator`: cluster-robust Predict-Then-Debias estimator for clustered data.
 - `MultiPPIMeanEstimator` for prediction-powered inference with multiple proxy models.
 - `generate_multi_binary_dataset` simulator for generating binary oracle datasets with multiple proxies.
 - Spider Text-to-SQL case study

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ## [Next release]
 
 ### ✨ Added
-- `ClusteredPTDMeanEstimator`: cluster-robust Predict-Then-Debias estimator that resamples whole clusters to account for within-cluster correlation.
+- `ClusteredPTDMeanEstimator`: cluster-robust Predict-Then-Debias estimator for clsutered data.
 - `generate_multi_binary_dataset` simulator for generating binary oracle datasets with multiple proxies.
 - Spider Text-to-SQL case study
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ## [Next release]
 
 ### ✨ Added
+- `ClusteredPTDMeanEstimator`: cluster-robust Predict-Then-Debias estimator that resamples whole clusters to account for within-cluster correlation.
 - `generate_multi_binary_dataset` simulator for generating binary oracle datasets with multiple proxies.
 - Spider Text-to-SQL case study
 

--- a/README.md
+++ b/README.md
@@ -79,12 +79,14 @@ If you use GLIDE in your work, please cite us using the "Cite this repository" b
 | Prediction-Powered Inference | `estimators.PPIMeanEstimator` (with `power_tuning=False`) | [[1]](#ref-1) | [Link](https://github.com/aangelopoulos/ppi_py/) |
 | PPI++ | `estimators.PPIMeanEstimator` | [[2]](#ref-2) | [Link](https://github.com/aangelopoulos/ppi_py/tree/ppi++) |
 | Stratified Prediction-Powered Inference | `estimators.StratifiedPPIMeanEstimator` | [[3]](#ref-3) | — |
+| Clustered Prediction-Powered Inference | `estimators.ClusteredPPIMeanEstimator` | — | [Link](https://github.com/davidbroska/ppi_py) |
 | Stratified Sampling | `samplers.StratifiedSampler` | [[4]](#ref-4) | [Link](https://github.com/amazon-science/ssepy) |
 | Active Statistical Inference | `estimators.ASIMeanEstimator` | [[5]](#ref-5), [[6]](#ref-6) | [Link](https://github.com/tijana-zrnic/active-inference) |
 | Active Sampling | `samplers.ActiveSampler` | [[5]](#ref-5), [[6]](#ref-6) | [Link](https://github.com/kristinagligoric/confidence-driven-inference) |
-| Predict-Then-Debias | `estimators.PTDMeanEstimator`, `estimators.StratifiedPTDMeanEstimator`, `estimators.IPWPTDMeanEstimator` | [[7]](#ref-7) | [Link](https://github.com/DanKluger/PTDBoot) |
-| Cluster Prediction-Powered Inference | `estimators.ClusteredPPIMeanEstimator` | — | [Link](https://github.com/davidbroska/ppi_py) |
+| Predict-Then-Debias | `estimators.PTDMeanEstimator` | [[7]](#ref-7) | [Link](https://github.com/DanKluger/PTDBoot) |
+| Stratified Predict-Then-Debias | `estimators.StratifiedPTDMeanEstimator` | [[7]](#ref-7) | [Link](https://github.com/DanKluger/PTDBoot) |
 | Clustered Predict-Then-Debias | `estimators.ClusteredPTDMeanEstimator` | [[7]](#ref-7) | [Link](https://github.com/DanKluger/PTDBoot) |
+| IPW Predict-Then-Debias | `estimators.IPWPTDMeanEstimator` | [[7]](#ref-7) | [Link](https://github.com/DanKluger/PTDBoot) |
 
 ### References
 

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ If you use GLIDE in your work, please cite us using the "Cite this repository" b
 | Active Sampling | `samplers.ActiveSampler` | [[5]](#ref-5), [[6]](#ref-6) | [Link](https://github.com/kristinagligoric/confidence-driven-inference) |
 | Predict-Then-Debias | `estimators.PTDMeanEstimator`, `estimators.StratifiedPTDMeanEstimator`, `estimators.IPWPTDMeanEstimator` | [[7]](#ref-7) | [Link](https://github.com/DanKluger/PTDBoot) |
 | Cluster Prediction-Powered Inference | `estimators.ClusteredPPIMeanEstimator` | — | [Link](https://github.com/davidbroska/ppi_py) |
+| Clustered Predict-Then-Debias | `estimators.ClusteredPTDMeanEstimator` | [[7]](#ref-7) | [Link](https://github.com/DanKluger/PTDBoot) |
 
 ### References
 

--- a/docs/api/estimators.md
+++ b/docs/api/estimators.md
@@ -41,3 +41,7 @@
 ---
 
 ::: glide.estimators.stratified_ptd.StratifiedPTDMeanEstimator
+
+---
+
+::: glide.estimators.clustered_ptd.ClusteredPTDMeanEstimator

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -45,6 +45,7 @@
 | [`PTDMeanEstimator`](estimators.md#glide.estimators.ptd.PTDMeanEstimator) | Predict-then-debias with bootstrap confidence intervals |
 | [`StratifiedPTDMeanEstimator`](estimators.md#glide.estimators.stratified_ptd.StratifiedPTDMeanEstimator) | PTD with per-stratum optimal weighting |
 | [`IPWPTDMeanEstimator`](estimators.md#glide.estimators.ipw_ptd.IPWPTDMeanEstimator) | PTD with inverse probability weighting |
+| [`ClusteredPTDMeanEstimator`](estimators.md#glide.estimators.clusterd_ptd.ClusterdPTDMeanEstimator) | PTD for clustered data |
 
 ## Confidence Intervals
 

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -40,12 +40,12 @@
 |-------|-------------|
 | [`PPIMeanEstimator`](estimators.md#glide.estimators.ppi.PPIMeanEstimator) | Combines labeled data with proxy predictions |
 | [`StratifiedPPIMeanEstimator`](estimators.md#glide.estimators.stratified_ppi.StratifiedPPIMeanEstimator) | PPI with per-stratum optimal weighting |
-| [`ASIMeanEstimator`](estimators.md#glide.estimators.asi.ASIMeanEstimator) | Active statistical inference with non-uniform sampling |
 | [`ClusteredPPIMeanEstimator`](estimators.md#glide.estimators.clustered_ppi.ClusteredPPIMeanEstimator) | PPI for clustered data |
+| [`ASIMeanEstimator`](estimators.md#glide.estimators.asi.ASIMeanEstimator) | Active statistical inference with non-uniform sampling |
 | [`PTDMeanEstimator`](estimators.md#glide.estimators.ptd.PTDMeanEstimator) | Predict-then-debias with bootstrap confidence intervals |
 | [`StratifiedPTDMeanEstimator`](estimators.md#glide.estimators.stratified_ptd.StratifiedPTDMeanEstimator) | PTD with per-stratum optimal weighting |
-| [`IPWPTDMeanEstimator`](estimators.md#glide.estimators.ipw_ptd.IPWPTDMeanEstimator) | PTD with inverse probability weighting |
 | [`ClusteredPTDMeanEstimator`](estimators.md#glide.estimators.clustered_ptd.ClusteredPTDMeanEstimator) | PTD for clustered data |
+| [`IPWPTDMeanEstimator`](estimators.md#glide.estimators.ipw_ptd.IPWPTDMeanEstimator) | PTD with inverse probability weighting |
 
 ## Confidence Intervals
 

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -45,7 +45,7 @@
 | [`PTDMeanEstimator`](estimators.md#glide.estimators.ptd.PTDMeanEstimator) | Predict-then-debias with bootstrap confidence intervals |
 | [`StratifiedPTDMeanEstimator`](estimators.md#glide.estimators.stratified_ptd.StratifiedPTDMeanEstimator) | PTD with per-stratum optimal weighting |
 | [`IPWPTDMeanEstimator`](estimators.md#glide.estimators.ipw_ptd.IPWPTDMeanEstimator) | PTD with inverse probability weighting |
-| [`ClusteredPTDMeanEstimator`](estimators.md#glide.estimators.clusterd_ptd.ClusterdPTDMeanEstimator) | PTD for clustered data |
+| [`ClusteredPTDMeanEstimator`](estimators.md#glide.estimators.clustered_ptd.ClusteredPTDMeanEstimator) | PTD for clustered data |
 
 ## Confidence Intervals
 

--- a/glide/estimators/__init__.py
+++ b/glide/estimators/__init__.py
@@ -2,6 +2,7 @@ from glide.estimators.asi import ASIMeanEstimator
 from glide.estimators.classical import ClassicalMeanEstimator
 from glide.estimators.clustered_classical import ClusteredClassicalMeanEstimator
 from glide.estimators.clustered_ppi import ClusteredPPIMeanEstimator
+from glide.estimators.clustered_ptd import ClusteredPTDMeanEstimator
 from glide.estimators.ipw_classical import IPWClassicalMeanEstimator
 from glide.estimators.ipw_ptd import IPWPTDMeanEstimator
 from glide.estimators.ppi import PPIMeanEstimator
@@ -22,4 +23,5 @@ __all__ = [
     "PTDMeanEstimator",
     "StratifiedPTDMeanEstimator",
     "IPWPTDMeanEstimator",
+    "ClusteredPTDMeanEstimator",
 ]

--- a/glide/estimators/clustered_core.py
+++ b/glide/estimators/clustered_core.py
@@ -1,0 +1,58 @@
+from typing import Tuple
+
+import numpy as np
+from numpy.typing import NDArray
+
+from glide.core.validation import (
+    _validate_bounds,
+    _validate_equal_lengths,
+    _validate_has_no_nan,
+    _validate_unique_clusters,
+)
+
+
+def _preprocess(
+    y_true: NDArray,
+    y_proxy: NDArray,
+    clusters: NDArray,
+) -> Tuple[NDArray, NDArray, NDArray]:
+    _validate_equal_lengths(y_true, y_proxy, clusters, names=["y_true", "y_proxy", "clusters"])
+    _validate_has_no_nan(y_proxy, "y_proxy")
+    _validate_has_no_nan(clusters, "clusters")
+
+    labeled_mask = ~np.isnan(y_true)
+    labeled_clusters = clusters[labeled_mask]
+    unlabeled_clusters = clusters[~labeled_mask]
+
+    unique_labeled_clusters, labeled_cluster_indices = np.unique(labeled_clusters, return_inverse=True)
+    unique_unlabeled_clusters, unlabeled_cluster_indices = np.unique(unlabeled_clusters, return_inverse=True)
+
+    _validate_unique_clusters(unique_labeled_clusters, unique_unlabeled_clusters)
+
+    n_labeled_clusters = len(unique_labeled_clusters)
+    n_unlabeled_clusters = len(unique_unlabeled_clusters)
+
+    _validate_bounds(
+        n_labeled_clusters,
+        "n_labeled_clusters",
+        lower=2,
+        error_message=f"Need at least 2 fully labeled clusters; got {n_labeled_clusters}.",
+    )
+    _validate_bounds(
+        n_unlabeled_clusters,
+        "n_unlabeled_clusters",
+        lower=2,
+        error_message=f"Need at least 2 fully unlabeled clusters; got {n_unlabeled_clusters}.",
+    )
+
+    labeled_true_sums = np.bincount(labeled_cluster_indices, weights=y_true[labeled_mask])
+    labeled_proxy_sums = np.bincount(labeled_cluster_indices, weights=y_proxy[labeled_mask])
+    unlabeled_proxy_sums = np.bincount(unlabeled_cluster_indices, weights=y_proxy[~labeled_mask])
+    labeled_sizes = np.bincount(labeled_cluster_indices)
+    unlabeled_sizes = np.bincount(unlabeled_cluster_indices)
+
+    labeled_true_means = labeled_true_sums / labeled_sizes
+    labeled_proxy_means = labeled_proxy_sums / labeled_sizes
+    unlabeled_proxy_means = unlabeled_proxy_sums / unlabeled_sizes
+
+    return labeled_true_means, labeled_proxy_means, unlabeled_proxy_means

--- a/glide/estimators/clustered_core.py
+++ b/glide/estimators/clustered_core.py
@@ -8,6 +8,7 @@ from glide.core.validation import (
     _validate_equal_lengths,
     _validate_has_no_nan,
     _validate_unique_clusters,
+    _validate_y_true,
 )
 
 
@@ -17,6 +18,7 @@ def _preprocess(
     clusters: NDArray,
 ) -> Tuple[NDArray, NDArray, NDArray]:
     _validate_equal_lengths(y_true, y_proxy, clusters, names=["y_true", "y_proxy", "clusters"])
+    _validate_y_true(y_true)
     _validate_has_no_nan(y_proxy, "y_proxy")
     _validate_has_no_nan(clusters, "clusters")
 

--- a/glide/estimators/clustered_ppi.py
+++ b/glide/estimators/clustered_ppi.py
@@ -106,6 +106,7 @@ class ClusteredPPIMeanEstimator:
         ValueError
             - If ``y_true``, ``y_proxy``, and ``clusters`` do not all have the
               same length.
+            - If labeled ``y_true`` values are constant.
             - If any proxy value is NaN.
             - If ``clusters`` contains NaN values (numeric dtype) or None values (non-numeric dtype).
             - If any cluster contains both labeled and unlabeled observations.

--- a/glide/estimators/clustered_ppi.py
+++ b/glide/estimators/clustered_ppi.py
@@ -1,17 +1,11 @@
 from math import floor
-from typing import Tuple
 
 import numpy as np
 from numpy.typing import NDArray
 
 from glide.confidence_intervals import CLTConfidenceInterval
-from glide.core.validation import (
-    _validate_bounds,
-    _validate_equal_lengths,
-    _validate_has_no_nan,
-    _validate_unique_clusters,
-)
 from glide.estimators.clustered_classical import ClusteredClassicalMeanEstimator
+from glide.estimators.clustered_core import _preprocess
 from glide.estimators.ppi_core import _compute_mean_estimate, _compute_std_estimate, _compute_tuning_parameter
 from glide.mean_inference_results import PredictionPoweredMeanInferenceResult
 
@@ -48,57 +42,6 @@ class ClusteredPPIMeanEstimator:
     n_proxy: 8
     Effective Sample Size: 5
     """
-
-    def _preprocess(
-        self,
-        y_true: NDArray,
-        y_proxy: NDArray,
-        clusters: NDArray,
-    ) -> Tuple[NDArray, NDArray, NDArray]:
-        _validate_equal_lengths(y_true, y_proxy, clusters, names=["y_true", "y_proxy", "clusters"])
-        _validate_has_no_nan(y_proxy, "y_proxy")
-        _validate_has_no_nan(clusters, "clusters")
-
-        labeled_mask = ~np.isnan(y_true)
-        labeled_clusters = clusters[labeled_mask]
-        unlabeled_clusters = clusters[~labeled_mask]
-
-        unique_labeled_clusters, labeled_cluster_indices = np.unique(labeled_clusters, return_inverse=True)
-        unique_unlabeled_clusters, unlabeled_cluster_indices = np.unique(unlabeled_clusters, return_inverse=True)
-
-        _validate_unique_clusters(unique_labeled_clusters, unique_unlabeled_clusters)
-
-        labeled_true_sums = np.bincount(labeled_cluster_indices, weights=y_true[labeled_mask])
-        labeled_proxy_sums = np.bincount(labeled_cluster_indices, weights=y_proxy[labeled_mask])
-        unlabeled_proxy_sums = np.bincount(unlabeled_cluster_indices, weights=y_proxy[~labeled_mask])
-        labeled_sizes = np.bincount(labeled_cluster_indices)
-        unlabeled_sizes = np.bincount(unlabeled_cluster_indices)
-
-        labeled_true_means = labeled_true_sums / labeled_sizes
-        labeled_proxy_means = labeled_proxy_sums / labeled_sizes
-        unlabeled_proxy_means = unlabeled_proxy_sums / unlabeled_sizes
-
-        n_labeled_clusters = len(unique_labeled_clusters)
-        n_unlabeled_clusters = len(unique_unlabeled_clusters)
-
-        _validate_bounds(
-            n_labeled_clusters,
-            "n_labeled_clusters",
-            lower=2,
-            error_message=f"Need at least 2 fully labeled clusters; got {n_labeled_clusters}.",
-        )
-        _validate_bounds(
-            n_unlabeled_clusters,
-            "n_unlabeled_clusters",
-            lower=2,
-            error_message=f"Need at least 2 fully unlabeled clusters; got {n_unlabeled_clusters}.",
-        )
-
-        return (
-            labeled_true_means,
-            labeled_proxy_means,
-            unlabeled_proxy_means,
-        )
 
     def estimate(
         self,
@@ -175,7 +118,7 @@ class ClusteredPPIMeanEstimator:
             labeled_true_means,
             labeled_proxy_means,
             unlabeled_proxy_means,
-        ) = self._preprocess(y_true, y_proxy, clusters)
+        ) = _preprocess(y_true, y_proxy, clusters)
 
         _lambda = _compute_tuning_parameter(
             labeled_true_means, labeled_proxy_means, unlabeled_proxy_means, power_tuning

--- a/glide/estimators/clustered_ptd.py
+++ b/glide/estimators/clustered_ptd.py
@@ -1,0 +1,167 @@
+from math import floor
+from typing import Optional
+
+import numpy as np
+from numpy.typing import NDArray
+
+from glide.confidence_intervals import BootstrapConfidenceInterval
+from glide.estimators.clustered_classical import ClusteredClassicalMeanEstimator
+from glide.estimators.clustered_core import _preprocess
+from glide.estimators.ptd_core import (
+    _compute_bootstrap_labeled_means,
+    _compute_bootstrap_mean_estimates,
+    _compute_tuning_parameter,
+)
+from glide.mean_inference_results import PredictionPoweredMeanInferenceResult
+
+
+class ClusteredPTDMeanEstimator:
+    """Clustered Predict-Then-Debias estimator for population mean.
+
+    Extends PTD to datasets where observations are grouped into clusters and
+    each cluster is either entirely labeled or entirely unlabeled. The bootstrap
+    resamples whole clusters rather than individual observations, which accounts
+    for within-cluster correlation and produces valid confidence intervals under
+    cluster sampling designs.
+
+    A power-tuning parameter λ is estimated from the joint bootstrap covariance
+    of the labeled cluster means and labeled cluster proxy means. The final
+    confidence interval is a percentile interval over B bootstrap replicates of:
+
+        θ_b = mean(y_true_b) + λ * (mean(y_proxy_unlabeled_b) - mean(y_proxy_labeled_b))
+
+    where each _b subscript denotes a size-weighted resample of cluster-level means.
+
+    References
+    ----------
+    Kluger, Dan M., Kerri Lu, Tijana Zrnic, Sherrie Wang, and Stephen Bates.
+    "Prediction-powered inference with imputed covariates and nonuniform sampling."
+    arXiv preprint arXiv:2501.18577 (2025).
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from glide.estimators import ClusteredPTDMeanEstimator
+    >>> y_true = np.array([1.0, 2.0, 3.0, 4.0, np.nan, np.nan, np.nan, np.nan])
+    >>> y_proxy = np.array([1.1, 2.2, 3.1, 3.9, 1.5, 1.8, 4.5, 4.8])
+    >>> clusters = np.array(["A", "A", "B", "B", "C", "C", "D", "D"])
+    >>> estimator = ClusteredPTDMeanEstimator()
+    >>> result = estimator.estimate(y_true, y_proxy, clusters, n_bootstrap=5, random_seed=0)
+    >>> print(result)
+    Metric: Metric
+    Point Estimate: 2.517
+    Confidence Interval (95%): [1.657, 3.497]
+    Estimator : ClusteredPTDMeanEstimator
+    n_true: 4
+    n_proxy: 8
+    Effective Sample Size: 6
+    """
+
+    def estimate(
+        self,
+        y_true: NDArray,
+        y_proxy: NDArray,
+        clusters: NDArray,
+        metric_name: str = "Metric",
+        confidence_level: float = 0.95,
+        n_bootstrap: int = 2000,
+        power_tuning: bool = True,
+        random_seed: Optional[int] = None,
+    ) -> PredictionPoweredMeanInferenceResult:
+        """Estimate the population mean using the Clustered Predict-Then-Debias bootstrap.
+
+        Aggregates observations into cluster-level means, bootstraps labeled cluster
+        means with size-weighting, and assembles per-replicate PTD estimates to form
+        a percentile confidence interval. The unlabeled proxy mean's sampling
+        variability is approximated by a Gaussian draw per replicate, computed from
+        cluster sums so that larger clusters contribute proportionally more.
+
+        Labeled and unlabeled clusters are distinguished by the NaN pattern in
+        ``y_true``: a cluster is labeled if every one of its ``y_true`` entries is
+        finite, and unlabeled if every entry is ``np.nan``. Partially labeled clusters
+        are not supported.
+
+        Parameters
+        ----------
+        y_true : NDArray
+            Array of observations, shape ``(n_samples,)``.
+            Labeled entries are finite; unlabeled entries are ``np.nan``.
+            All observations in the same cluster must share the same label status.
+        y_proxy : NDArray
+            Array of proxy predictions, shape ``(n_samples,)``.
+            Must be fully populated (no NaN).
+        clusters : NDArray
+            Array of cluster identifiers, shape ``(n_samples,)``.
+            Unique values define the clusters.
+        metric_name : str, optional
+            Human-readable label for the metric. Defaults to ``"Metric"``.
+        confidence_level : float, optional
+            Target coverage for the confidence interval. Defaults to ``0.95``.
+        n_bootstrap : int, optional
+            Number of bootstrap resamples. Defaults to ``2000``.
+        power_tuning : bool, optional
+            If ``True`` (default), estimate the optimal power-tuning parameter
+            λ from the bootstrap covariances. If ``False``, use λ = 1.0.
+        random_seed : int, optional
+            Seed for the random number generator. Defaults to ``None``.
+
+        Returns
+        -------
+        PredictionPoweredMeanInferenceResult
+            Contains the bootstrap-based confidence interval, the metric name,
+            the estimator name (``"ClusteredPTDMeanEstimator"``), and the counts
+            ``n_true`` (total labeled observations) and ``n_proxy`` (total dataset size).
+
+        Raises
+        ------
+        ValueError
+            - If ``y_true``, ``y_proxy``, and ``clusters`` do not all have the same length.
+            - If any proxy value is NaN.
+            - If ``clusters`` contains NaN values (numeric dtype) or None values (non-numeric dtype).
+            - If any cluster contains both labeled and unlabeled observations.
+            - If fewer than 2 clusters are fully labeled.
+            - If fewer than 2 clusters are fully unlabeled.
+        """
+        (
+            labeled_true_means,
+            labeled_proxy_means,
+            unlabeled_proxy_means,
+        ) = _preprocess(y_true, y_proxy, clusters)
+
+        n_unlabeled_clusters = len(unlabeled_proxy_means)
+        mean_proxy_unlabeled = np.mean(unlabeled_proxy_means)
+        var_proxy_unlabeled = np.var(unlabeled_proxy_means, ddof=1) / n_unlabeled_clusters
+
+        rng = np.random.default_rng(random_seed)
+
+        bootstrap_y_true_means, bootstrap_y_proxy_labeled_means = _compute_bootstrap_labeled_means(
+            labeled_true_means, labeled_proxy_means, n_bootstrap, rng
+        )
+        lambda_ = _compute_tuning_parameter(
+            bootstrap_y_true_means, bootstrap_y_proxy_labeled_means, var_proxy_unlabeled, power_tuning
+        )
+        bootstrap_estimates = _compute_bootstrap_mean_estimates(
+            bootstrap_y_true_means,
+            bootstrap_y_proxy_labeled_means,
+            mean_proxy_unlabeled,
+            var_proxy_unlabeled,
+            lambda_,
+            rng,
+        )
+
+        confidence_interval = BootstrapConfidenceInterval(
+            bootstrap_estimates=bootstrap_estimates,
+            confidence_level=confidence_level,
+        )
+        n_labeled = int(np.sum(~np.isnan(y_true)))
+        classical_confidence_interval = ClusteredClassicalMeanEstimator().estimate(y_true, clusters).confidence_interval
+        effective_sample_size = floor(n_labeled * classical_confidence_interval.var / confidence_interval.var)
+        result = PredictionPoweredMeanInferenceResult(
+            confidence_interval=confidence_interval,
+            metric_name=metric_name,
+            estimator_name=self.__class__.__name__,
+            n_true=n_labeled,
+            n_proxy=len(y_true),
+            effective_sample_size=effective_sample_size,
+        )
+        return result

--- a/glide/estimators/clustered_ptd.py
+++ b/glide/estimators/clustered_ptd.py
@@ -153,7 +153,7 @@ class ClusteredPTDMeanEstimator:
             bootstrap_estimates=bootstrap_estimates,
             confidence_level=confidence_level,
         )
-        n_labeled = int(np.sum(~np.isnan(y_true)))
+        n_labeled = np.sum(~np.isnan(y_true))
         classical_confidence_interval = ClusteredClassicalMeanEstimator().estimate(y_true, clusters).confidence_interval
         effective_sample_size = floor(n_labeled * classical_confidence_interval.var / confidence_interval.var)
         result = PredictionPoweredMeanInferenceResult(
@@ -161,7 +161,7 @@ class ClusteredPTDMeanEstimator:
             metric_name=metric_name,
             estimator_name=self.__class__.__name__,
             n_true=n_labeled,
-            n_proxy=len(y_true),
+            n_proxy=len(y_proxy),
             effective_sample_size=effective_sample_size,
         )
         return result

--- a/glide/estimators/clustered_ptd.py
+++ b/glide/estimators/clustered_ptd.py
@@ -25,12 +25,9 @@ class ClusteredPTDMeanEstimator:
     cluster sampling designs.
 
     A power-tuning parameter λ is estimated from the joint bootstrap covariance
-    of the labeled cluster means and labeled cluster proxy means. The final
-    confidence interval is a percentile interval over B bootstrap replicates of:
-
-        θ_b = mean(y_true_b) + λ * (mean(y_proxy_unlabeled_b) - mean(y_proxy_labeled_b))
-
-    where each _b subscript denotes a size-weighted resample of cluster-level means.
+    of the labeled cluster means and labeled cluster proxy means. At each bootstrap
+    iteration, clusters are resampled with replacement and their means are averaged,
+    producing bootstrap replicates of the PTD estimate.
 
     References
     ----------
@@ -70,11 +67,12 @@ class ClusteredPTDMeanEstimator:
     ) -> PredictionPoweredMeanInferenceResult:
         """Estimate the population mean using the Clustered Predict-Then-Debias bootstrap.
 
-        Aggregates observations into cluster-level means, bootstraps labeled cluster
-        means with size-weighting, and assembles per-replicate PTD estimates to form
-        a percentile confidence interval. The unlabeled proxy mean's sampling
-        variability is approximated by a Gaussian draw per replicate, computed from
-        cluster sums so that larger clusters contribute proportionally more.
+        Computes cluster means for labeled and unlabeled clusters and uses them as
+        sampling units to run the PTD bootstrap. The tuning parameter λ and the
+        confidence interval are both derived from a bootstrap over the labeled clusters
+        only. The sampling variability of the unlabeled proxy mean is approximated by
+        a single Gaussian draw per iteration, keeping the per-iteration cost O(M_L),
+        where M_L is the number of labeled clusters.
 
         Labeled and unlabeled clusters are distinguished by the NaN pattern in
         ``y_true``: a cluster is labeled if every one of its ``y_true`` entries is
@@ -116,6 +114,7 @@ class ClusteredPTDMeanEstimator:
         ------
         ValueError
             - If ``y_true``, ``y_proxy``, and ``clusters`` do not all have the same length.
+            - If labeled ``y_true`` values are constant.
             - If any proxy value is NaN.
             - If ``clusters`` contains NaN values (numeric dtype) or None values (non-numeric dtype).
             - If any cluster contains both labeled and unlabeled observations.

--- a/glide/estimators/ipw_ptd.py
+++ b/glide/estimators/ipw_ptd.py
@@ -137,6 +137,7 @@ class IPWPTDMeanEstimator:
             - If ``y_true``, ``y_proxy``, and ``pi`` do not all have the same length.
             - If any proxy value is NaN.
             - If all proxy values are identical.
+            - If labeled ``y_true`` values are constant.
             - If any sampling probability is not in [0, 1].
             - If any labeled sample (non-NaN ``y_true``) has a labeling probability of 0.
             - If any unlabeled sample (NaN ``y_true``) has a labeling probability of 1.

--- a/glide/estimators/ppi.py
+++ b/glide/estimators/ppi.py
@@ -118,6 +118,7 @@ class PPIMeanEstimator:
             - If ``y_true`` and ``y_proxy`` have different lengths.
             - If any proxy value is NaN.
             - If all proxy values are identical.
+            - If labeled ``y_true`` values are constant.
             - If there are fewer than 2 labeled or fewer than 2 unlabeled samples.
         """
         y_true_filtered, y_proxy_labeled, y_proxy_unlabeled = self._preprocess(y_true, y_proxy)

--- a/glide/estimators/ptd.py
+++ b/glide/estimators/ptd.py
@@ -127,6 +127,7 @@ class PTDMeanEstimator:
             - If ``y_true`` and ``y_proxy`` have different lengths.
             - If any proxy value is NaN.
             - If all proxy values are identical.
+            - If labeled ``y_true`` values are constant.
             - If there are fewer than 2 labeled or fewer than 2 unlabeled samples.
         """
         y_true_filtered, y_proxy_labeled, y_proxy_unlabeled = self._preprocess(y_true, y_proxy)

--- a/glide/estimators/stratified_ppi.py
+++ b/glide/estimators/stratified_ppi.py
@@ -117,6 +117,7 @@ class StratifiedPPIMeanEstimator:
             - If ``groups`` contains NaN values (numeric dtype) or None values (non-numeric dtype).
             - If ``y_true``, ``y_proxy``, and ``groups`` do not all have the same length.
             - If any proxy value is NaN.
+            - If labeled ``y_true`` values are constant.
             - If all proxy values within a stratum are identical.
             - If any stratum has fewer than 2 labeled or fewer than 2 unlabeled samples.
         """

--- a/glide/estimators/stratified_ptd.py
+++ b/glide/estimators/stratified_ptd.py
@@ -120,6 +120,7 @@ class StratifiedPTDMeanEstimator:
             - If ``groups`` contains NaN values (numeric dtype) or None values (non-numeric dtype).
             - If ``y_true``, ``y_proxy``, and ``groups`` do not all have the same length.
             - If any proxy value is NaN.
+            - If labeled ``y_true`` values are constant.
             - If all proxy values within a stratum are identical (zero variance), which would
               cause a division by zero when computing the power-tuning parameter.
             - If any stratum has fewer than 2 labeled or fewer than 2 unlabeled samples.

--- a/tests/functional/estimators/test_clustered_ptd.py
+++ b/tests/functional/estimators/test_clustered_ptd.py
@@ -1,0 +1,38 @@
+import numpy as np
+import pytest
+
+from glide.estimators import ClusteredPTDMeanEstimator, PTDMeanEstimator
+
+
+def test_point_estimate_lambda_one_with_identical_clusters():
+    # Labeled clusters have constant y_true=5.0 and y_proxy=4.8.
+    # Unlabeled clusters have slightly different proxy values so var_proxy_unlabeled > 0.
+    # mean_proxy_unlabeled = (2*5.2 + 2*5.4) / 4 = 5.3, so PTD mean = 5.0 + (5.3 - 4.8) = 5.5.
+    # With n_bootstrap=2000 the bootstrap mean converges to 5.5 within tolerance.
+    y_true = np.array([5.0, 5.0, 5.0, 5.0, np.nan, np.nan, np.nan, np.nan])
+    y_proxy = np.array([4.8, 4.8, 4.8, 4.8, 5.2, 5.2, 5.4, 5.4])
+    clusters = np.array(["A", "A", "B", "B", "C", "C", "D", "D"])
+
+    result = ClusteredPTDMeanEstimator().estimate(
+        y_true, y_proxy, clusters, power_tuning=False, n_bootstrap=2000, random_seed=0
+    )
+
+    assert result.confidence_interval.mean == pytest.approx(5.5, abs=0.02)
+
+
+def test_single_observation_clusters_equals_ptd():
+    y_true = np.array([5.0, 6.0, np.nan, np.nan])
+    y_proxy = np.array([4.9, 6.1, 5.2, 6.1])
+    clusters = np.array(["A", "B", "C", "D"])
+
+    cluster_result = ClusteredPTDMeanEstimator().estimate(
+        y_true, y_proxy, clusters, power_tuning=False, n_bootstrap=50, random_seed=0
+    )
+    ptd_result = PTDMeanEstimator().estimate(y_true, y_proxy, power_tuning=False, n_bootstrap=50, random_seed=0)
+
+    assert cluster_result.confidence_interval.lower_bound == pytest.approx(
+        ptd_result.confidence_interval.lower_bound, abs=1e-10
+    )
+    assert cluster_result.confidence_interval.upper_bound == pytest.approx(
+        ptd_result.confidence_interval.upper_bound, abs=1e-10
+    )

--- a/tests/functional/estimators/test_clustered_ptd.py
+++ b/tests/functional/estimators/test_clustered_ptd.py
@@ -4,31 +4,16 @@ import pytest
 from glide.estimators import ClusteredPTDMeanEstimator, PTDMeanEstimator
 
 
-def test_point_estimate_lambda_one_with_identical_clusters():
-    # Labeled clusters have constant y_true=5.0 and y_proxy=4.8.
-    # Unlabeled clusters have slightly different proxy values so var_proxy_unlabeled > 0.
-    # mean_proxy_unlabeled = (2*5.2 + 2*5.4) / 4 = 5.3, so PTD mean = 5.0 + (5.3 - 4.8) = 5.5.
-    # With n_bootstrap=2000 the bootstrap mean converges to 5.5 within tolerance.
-    y_true = np.array([5.0, 5.0, 5.0, 5.0, np.nan, np.nan, np.nan, np.nan])
-    y_proxy = np.array([4.8, 4.8, 4.8, 4.8, 5.2, 5.2, 5.4, 5.4])
-    clusters = np.array(["A", "A", "B", "B", "C", "C", "D", "D"])
-
-    result = ClusteredPTDMeanEstimator().estimate(
-        y_true, y_proxy, clusters, power_tuning=False, n_bootstrap=2000, random_seed=0
-    )
-
-    assert result.confidence_interval.mean == pytest.approx(5.5, abs=0.02)
-
-
-def test_single_observation_clusters_equals_ptd():
+@pytest.mark.parametrize("power_tuning", [False, True])
+def test_single_observation_clusters_equals_ptd(power_tuning):
     y_true = np.array([5.0, 6.0, np.nan, np.nan])
     y_proxy = np.array([4.9, 6.1, 5.2, 6.1])
     clusters = np.array(["A", "B", "C", "D"])
 
     cluster_result = ClusteredPTDMeanEstimator().estimate(
-        y_true, y_proxy, clusters, power_tuning=False, n_bootstrap=50, random_seed=0
+        y_true, y_proxy, clusters, power_tuning=power_tuning, n_bootstrap=50, random_seed=0
     )
-    ptd_result = PTDMeanEstimator().estimate(y_true, y_proxy, power_tuning=False, n_bootstrap=50, random_seed=0)
+    ptd_result = PTDMeanEstimator().estimate(y_true, y_proxy, power_tuning=power_tuning, n_bootstrap=50, random_seed=0)
 
     assert cluster_result.confidence_interval.lower_bound == pytest.approx(
         ptd_result.confidence_interval.lower_bound, abs=1e-10

--- a/tests/unit/estimators/test_clustered_core.py
+++ b/tests/unit/estimators/test_clustered_core.py
@@ -29,6 +29,7 @@ def clusters() -> NDArray:
 def test_preprocess_delegates_to_validation(y_true, y_proxy, clusters):
     with (
         patch.object(clustered_core_module, "_validate_equal_lengths") as mock_validate_equal_lengths,
+        patch.object(clustered_core_module, "_validate_y_true") as mock_validate_y_true,
         patch.object(clustered_core_module, "_validate_has_no_nan") as mock_validate_has_no_nan,
         patch.object(clustered_core_module, "_validate_unique_clusters") as mock_validate_unique_clusters,
         patch.object(clustered_core_module, "_validate_bounds") as mock_validate_bounds,
@@ -40,6 +41,9 @@ def test_preprocess_delegates_to_validation(y_true, y_proxy, clusters):
         np.testing.assert_array_equal(mock_validate_equal_lengths.call_args[0][1], y_proxy)
         np.testing.assert_array_equal(mock_validate_equal_lengths.call_args[0][2], clusters)
         assert mock_validate_equal_lengths.call_args[1] == {"names": ["y_true", "y_proxy", "clusters"]}
+
+        mock_validate_y_true.assert_called_once()
+        np.testing.assert_array_equal(mock_validate_y_true.call_args[0][0], y_true)
 
         assert len(mock_validate_has_no_nan.call_args_list) == 2
         np.testing.assert_array_equal(mock_validate_has_no_nan.call_args_list[0][0][0], y_proxy)

--- a/tests/unit/estimators/test_clustered_core.py
+++ b/tests/unit/estimators/test_clustered_core.py
@@ -1,0 +1,69 @@
+from unittest.mock import call, patch
+
+import numpy as np
+import pytest
+from numpy.typing import NDArray
+
+import glide.estimators.clustered_core as clustered_core_module
+from glide.estimators.clustered_core import _preprocess
+
+
+@pytest.fixture
+def y_true() -> NDArray:
+    return np.array([4.0, np.nan, 6.0, np.nan])
+
+
+@pytest.fixture
+def y_proxy() -> NDArray:
+    return np.array([2.0, 4.0, 6.0, 6.0])
+
+
+@pytest.fixture
+def clusters() -> NDArray:
+    return np.array(["A", "B", "C", "D"])
+
+
+# --- _preprocess ---
+
+
+def test_preprocess_delegates_to_validation(y_true, y_proxy, clusters):
+    with (
+        patch.object(clustered_core_module, "_validate_equal_lengths") as mock_validate_equal_lengths,
+        patch.object(clustered_core_module, "_validate_has_no_nan") as mock_validate_has_no_nan,
+        patch.object(clustered_core_module, "_validate_unique_clusters") as mock_validate_unique_clusters,
+        patch.object(clustered_core_module, "_validate_bounds") as mock_validate_bounds,
+    ):
+        _preprocess(y_true, y_proxy, clusters)
+
+        mock_validate_equal_lengths.assert_called_once()
+        np.testing.assert_array_equal(mock_validate_equal_lengths.call_args[0][0], y_true)
+        np.testing.assert_array_equal(mock_validate_equal_lengths.call_args[0][1], y_proxy)
+        np.testing.assert_array_equal(mock_validate_equal_lengths.call_args[0][2], clusters)
+        assert mock_validate_equal_lengths.call_args[1] == {"names": ["y_true", "y_proxy", "clusters"]}
+
+        assert len(mock_validate_has_no_nan.call_args_list) == 2
+        np.testing.assert_array_equal(mock_validate_has_no_nan.call_args_list[0][0][0], y_proxy)
+        assert mock_validate_has_no_nan.call_args_list[0][0][1] == "y_proxy"
+        np.testing.assert_array_equal(mock_validate_has_no_nan.call_args_list[1][0][0], clusters)
+        assert mock_validate_has_no_nan.call_args_list[1][0][1] == "clusters"
+
+        mock_validate_unique_clusters.assert_called_once()
+        np.testing.assert_array_equal(mock_validate_unique_clusters.call_args[0][0], np.array(["A", "C"]))
+        np.testing.assert_array_equal(mock_validate_unique_clusters.call_args[0][1], np.array(["B", "D"]))
+
+        mock_validate_bounds.assert_has_calls(
+            [
+                call(2, "n_labeled_clusters", lower=2, error_message="Need at least 2 fully labeled clusters; got 2."),
+                call(
+                    2, "n_unlabeled_clusters", lower=2, error_message="Need at least 2 fully unlabeled clusters; got 2."
+                ),
+            ]
+        )
+
+
+def test_preprocess_valid_output(y_true, y_proxy, clusters):
+    labeled_true_means, labeled_proxy_means, unlabeled_proxy_means = _preprocess(y_true, y_proxy, clusters)
+
+    np.testing.assert_array_equal(labeled_true_means, np.array([4.0, 6.0]))
+    np.testing.assert_array_equal(labeled_proxy_means, np.array([2.0, 6.0]))
+    np.testing.assert_array_equal(unlabeled_proxy_means, np.array([4.0, 6.0]))

--- a/tests/unit/estimators/test_clustered_ppi.py
+++ b/tests/unit/estimators/test_clustered_ppi.py
@@ -1,10 +1,7 @@
-from unittest.mock import call, patch
-
 import numpy as np
 import pytest
 from numpy.typing import NDArray
 
-import glide.estimators.clustered_ppi as clustered_ppi_module
 from glide.confidence_intervals import CLTConfidenceInterval
 from glide.estimators import ClusteredPPIMeanEstimator
 from glide.mean_inference_results import PredictionPoweredMeanInferenceResult
@@ -28,52 +25,6 @@ def clusters() -> NDArray:
 @pytest.fixture
 def estimator() -> ClusteredPPIMeanEstimator:
     return ClusteredPPIMeanEstimator()
-
-
-# --- _preprocess ---
-
-
-def test_preprocess_delegates_to_validation(estimator, y_true, y_proxy, clusters):
-    with (
-        patch.object(clustered_ppi_module, "_validate_equal_lengths") as mock_validate_equal_lengths,
-        patch.object(clustered_ppi_module, "_validate_has_no_nan") as mock_validate_has_no_nan,
-        patch.object(clustered_ppi_module, "_validate_unique_clusters") as mock_validate_unique_clusters,
-        patch.object(clustered_ppi_module, "_validate_bounds") as mock_validate_bounds,
-    ):
-        estimator._preprocess(y_true, y_proxy, clusters)
-
-        mock_validate_equal_lengths.assert_called_once()
-        np.testing.assert_array_equal(mock_validate_equal_lengths.call_args[0][0], y_true)
-        np.testing.assert_array_equal(mock_validate_equal_lengths.call_args[0][1], y_proxy)
-        np.testing.assert_array_equal(mock_validate_equal_lengths.call_args[0][2], clusters)
-        assert mock_validate_equal_lengths.call_args[1] == {"names": ["y_true", "y_proxy", "clusters"]}
-
-        assert len(mock_validate_has_no_nan.call_args_list) == 2
-        np.testing.assert_array_equal(mock_validate_has_no_nan.call_args_list[0][0][0], y_proxy)
-        assert mock_validate_has_no_nan.call_args_list[0][0][1] == "y_proxy"
-        np.testing.assert_array_equal(mock_validate_has_no_nan.call_args_list[1][0][0], clusters)
-        assert mock_validate_has_no_nan.call_args_list[1][0][1] == "clusters"
-
-        mock_validate_unique_clusters.assert_called_once()
-        np.testing.assert_array_equal(mock_validate_unique_clusters.call_args[0][0], np.array(["A", "C"]))
-        np.testing.assert_array_equal(mock_validate_unique_clusters.call_args[0][1], np.array(["B", "D"]))
-
-        mock_validate_bounds.assert_has_calls(
-            [
-                call(2, "n_labeled_clusters", lower=2, error_message="Need at least 2 fully labeled clusters; got 2."),
-                call(
-                    2, "n_unlabeled_clusters", lower=2, error_message="Need at least 2 fully unlabeled clusters; got 2."
-                ),
-            ]
-        )
-
-
-def test_preprocess_valid_output(estimator, y_true, y_proxy, clusters):
-    labeled_true_means, labeled_proxy_means, unlabeled_proxy_means = estimator._preprocess(y_true, y_proxy, clusters)
-
-    np.testing.assert_array_equal(labeled_true_means, np.array([4.0, 6.0]))
-    np.testing.assert_array_equal(labeled_proxy_means, np.array([2.0, 6.0]))
-    np.testing.assert_array_equal(unlabeled_proxy_means, np.array([4.0, 6.0]))
 
 
 # --- estimate ---

--- a/tests/unit/estimators/test_clustered_ptd.py
+++ b/tests/unit/estimators/test_clustered_ptd.py
@@ -43,7 +43,7 @@ def test_estimate_returns_valid_inference_result(estimator, y_true, y_proxy, clu
 def test_estimate_metadata(estimator, y_true, y_proxy, clusters):
     result = estimator.estimate(y_true, y_proxy, clusters, metric_name="accuracy", n_bootstrap=5, random_seed=0)
     assert result.metric_name == "accuracy"
-    assert result.estimator_name == "ClusteredPTDMeanEstimator"
+    assert result.estimator_name == estimator.__class__.__name__
     assert result.n_true == 4
     assert result.n_proxy == 8
     assert result.effective_sample_size == 6

--- a/tests/unit/estimators/test_clustered_ptd.py
+++ b/tests/unit/estimators/test_clustered_ptd.py
@@ -49,6 +49,21 @@ def test_estimate_metadata(estimator, y_true, y_proxy, clusters):
     assert result.effective_sample_size == 6
 
 
+def test_estimate_custom_confidence_level(estimator, y_true, y_proxy, clusters):
+    result = estimator.estimate(y_true, y_proxy, clusters, n_bootstrap=5, confidence_level=0.85, random_seed=0)
+
+    expected_mean = 2.516
+    expected_std = 0.779
+    expected_lower = 1.769
+    expected_upper = 3.403
+
+    assert result.confidence_interval.confidence_level == 0.85
+    assert result.confidence_interval.mean == pytest.approx(expected_mean, abs=0.01)
+    assert result.std == pytest.approx(expected_std, abs=0.01)
+    assert result.confidence_interval.lower_bound == pytest.approx(expected_lower, abs=0.01)
+    assert result.confidence_interval.upper_bound == pytest.approx(expected_upper, abs=0.01)
+
+
 def test_estimate_reproducibility(estimator, y_true, y_proxy, clusters):
     result_a = estimator.estimate(y_true, y_proxy, clusters, n_bootstrap=5, random_seed=7)
     result_b = estimator.estimate(y_true, y_proxy, clusters, n_bootstrap=5, random_seed=7)
@@ -63,46 +78,6 @@ def test_estimate_different_seeds_results_differ(estimator, y_true, y_proxy, clu
         result_a.confidence_interval.lower_bound != result_b.confidence_interval.lower_bound
         or result_a.confidence_interval.upper_bound != result_b.confidence_interval.upper_bound
     )
-
-
-def test_estimate_mismatched_lengths_raises(estimator):
-    y_true = np.array([1.0, np.nan, np.nan])
-    y_proxy = np.array([1.1, 1.5])
-    clusters = np.array(["A", "B", "C"])
-    with pytest.raises(ValueError):
-        estimator.estimate(y_true, y_proxy, clusters)
-
-
-def test_estimate_nan_in_proxy_raises(estimator):
-    y_true = np.array([1.0, 2.0, np.nan, np.nan])
-    y_proxy = np.array([1.1, np.nan, 1.5, 1.8])
-    clusters = np.array(["A", "B", "C", "D"])
-    with pytest.raises(ValueError):
-        estimator.estimate(y_true, y_proxy, clusters)
-
-
-def test_estimate_partially_labeled_cluster_raises(estimator):
-    y_true = np.array([1.0, np.nan, 3.0, np.nan])
-    y_proxy = np.array([1.1, 2.2, 3.1, 3.9])
-    clusters = np.array(["A", "A", "B", "C"])
-    with pytest.raises(ValueError, match="Cluster 'A'"):
-        estimator.estimate(y_true, y_proxy, clusters)
-
-
-def test_estimate_too_few_labeled_clusters_raises(estimator):
-    y_true = np.array([1.0, np.nan, np.nan, np.nan])
-    y_proxy = np.array([1.1, 2.2, 3.1, 3.9])
-    clusters = np.array(["A", "B", "C", "D"])
-    with pytest.raises(ValueError, match="2 fully labeled"):
-        estimator.estimate(y_true, y_proxy, clusters)
-
-
-def test_estimate_too_few_unlabeled_clusters_raises(estimator):
-    y_true = np.array([1.0, 2.0, 3.0, np.nan])
-    y_proxy = np.array([1.1, 2.2, 3.1, 3.9])
-    clusters = np.array(["A", "B", "C", "D"])
-    with pytest.raises(ValueError, match="2 fully unlabeled"):
-        estimator.estimate(y_true, y_proxy, clusters)
 
 
 # --- __str__ / __repr__ ---

--- a/tests/unit/estimators/test_clustered_ptd.py
+++ b/tests/unit/estimators/test_clustered_ptd.py
@@ -1,0 +1,128 @@
+import numpy as np
+import pytest
+from numpy.typing import NDArray
+
+from glide.confidence_intervals import BootstrapConfidenceInterval
+from glide.estimators import ClusteredPTDMeanEstimator
+from glide.mean_inference_results import PredictionPoweredMeanInferenceResult
+
+
+@pytest.fixture
+def y_true() -> NDArray:
+    return np.array([1.0, 2.0, 3.0, 4.0, np.nan, np.nan, np.nan, np.nan])
+
+
+@pytest.fixture
+def y_proxy() -> NDArray:
+    return np.array([1.1, 2.2, 3.1, 3.9, 1.5, 1.8, 4.5, 4.8])
+
+
+@pytest.fixture
+def clusters() -> NDArray:
+    return np.array(["A", "A", "B", "B", "C", "C", "D", "D"])
+
+
+@pytest.fixture
+def estimator() -> ClusteredPTDMeanEstimator:
+    return ClusteredPTDMeanEstimator()
+
+
+# --- estimate ---
+
+
+def test_estimate_returns_valid_inference_result(estimator, y_true, y_proxy, clusters):
+    result = estimator.estimate(y_true, y_proxy, clusters, n_bootstrap=5, random_seed=0)
+    assert isinstance(result, PredictionPoweredMeanInferenceResult)
+    assert isinstance(result.confidence_interval, BootstrapConfidenceInterval)
+    assert np.isfinite(result.confidence_interval.lower_bound)
+    assert np.isfinite(result.confidence_interval.upper_bound)
+    assert result.confidence_interval.lower_bound < result.confidence_interval.upper_bound
+    assert result.estimator_name == "ClusteredPTDMeanEstimator"
+
+
+def test_estimate_metadata(estimator, y_true, y_proxy, clusters):
+    result = estimator.estimate(y_true, y_proxy, clusters, metric_name="accuracy", n_bootstrap=5, random_seed=0)
+    assert result.metric_name == "accuracy"
+    assert result.estimator_name == "ClusteredPTDMeanEstimator"
+    assert result.n_true == 4
+    assert result.n_proxy == 8
+    assert result.effective_sample_size == 6
+
+
+def test_estimate_reproducibility(estimator, y_true, y_proxy, clusters):
+    result_a = estimator.estimate(y_true, y_proxy, clusters, n_bootstrap=5, random_seed=7)
+    result_b = estimator.estimate(y_true, y_proxy, clusters, n_bootstrap=5, random_seed=7)
+    assert result_a.confidence_interval.lower_bound == result_b.confidence_interval.lower_bound
+    assert result_a.confidence_interval.upper_bound == result_b.confidence_interval.upper_bound
+
+
+def test_estimate_different_seeds_results_differ(estimator, y_true, y_proxy, clusters):
+    result_a = estimator.estimate(y_true, y_proxy, clusters, n_bootstrap=5, random_seed=0)
+    result_b = estimator.estimate(y_true, y_proxy, clusters, n_bootstrap=5, random_seed=1)
+    assert (
+        result_a.confidence_interval.lower_bound != result_b.confidence_interval.lower_bound
+        or result_a.confidence_interval.upper_bound != result_b.confidence_interval.upper_bound
+    )
+
+
+def test_estimate_mismatched_lengths_raises(estimator):
+    y_true = np.array([1.0, np.nan, np.nan])
+    y_proxy = np.array([1.1, 1.5])
+    clusters = np.array(["A", "B", "C"])
+    with pytest.raises(ValueError):
+        estimator.estimate(y_true, y_proxy, clusters)
+
+
+def test_estimate_nan_in_proxy_raises(estimator):
+    y_true = np.array([1.0, 2.0, np.nan, np.nan])
+    y_proxy = np.array([1.1, np.nan, 1.5, 1.8])
+    clusters = np.array(["A", "B", "C", "D"])
+    with pytest.raises(ValueError):
+        estimator.estimate(y_true, y_proxy, clusters)
+
+
+def test_estimate_partially_labeled_cluster_raises(estimator):
+    y_true = np.array([1.0, np.nan, 3.0, np.nan])
+    y_proxy = np.array([1.1, 2.2, 3.1, 3.9])
+    clusters = np.array(["A", "A", "B", "C"])
+    with pytest.raises(ValueError, match="Cluster 'A'"):
+        estimator.estimate(y_true, y_proxy, clusters)
+
+
+def test_estimate_too_few_labeled_clusters_raises(estimator):
+    y_true = np.array([1.0, np.nan, np.nan, np.nan])
+    y_proxy = np.array([1.1, 2.2, 3.1, 3.9])
+    clusters = np.array(["A", "B", "C", "D"])
+    with pytest.raises(ValueError, match="2 fully labeled"):
+        estimator.estimate(y_true, y_proxy, clusters)
+
+
+def test_estimate_too_few_unlabeled_clusters_raises(estimator):
+    y_true = np.array([1.0, 2.0, 3.0, np.nan])
+    y_proxy = np.array([1.1, 2.2, 3.1, 3.9])
+    clusters = np.array(["A", "B", "C", "D"])
+    with pytest.raises(ValueError, match="2 fully unlabeled"):
+        estimator.estimate(y_true, y_proxy, clusters)
+
+
+# --- __str__ / __repr__ ---
+
+
+def test_str_format(estimator, y_true, y_proxy, clusters):
+    result = estimator.estimate(y_true, y_proxy, clusters, n_bootstrap=5, random_seed=0)
+    output = str(result)
+    expected = (
+        "Metric: Metric\n"
+        "Point Estimate: 2.517\n"
+        "Confidence Interval (95%): [1.657, 3.497]\n"
+        "Estimator : ClusteredPTDMeanEstimator\n"
+        "n_true: 4\n"
+        "n_proxy: 8\n"
+        "Effective Sample Size: 6"
+    )
+    assert output == expected
+
+
+def test_repr_equals_str(estimator, y_true, y_proxy, clusters):
+    result = estimator.estimate(y_true, y_proxy, clusters, n_bootstrap=5, random_seed=0)
+    assert repr(result) == str(result)


### PR DESCRIPTION
### Description

Adds `ClusteredPTDMeanEstimator`, a cluster-robust Predict-Then-Debias estimator that resamples whole clusters to account for within-cluster correlation. The clustered preprocessing logic (`_preprocess`, `_compute_bootstrap_labeled_cluster_means`) has been factored into a new shared module `clustered_core.py`, and `ClusteredPPIMeanEstimator` has been updated to delegate to it.

Handles this [ticket](https://github.com/orgs/EmertonData/projects/26/views/2?pane=issue&itemId=171055706&issue=EmertonData%7Cglide%7C202) Closes #202

### Checklist

Quality gates that must be satisfied before requesting a review:

- [x] I have read `CONTRIBUTING.md`
- [x] `make lint` passes
- [x] `make type-check` passes
- [x] `make tests` passes
- [x] `make coverage` reports 100% coverage
- [ ] `make test-notebooks` passes
- [x] New public API has numpy-style docstrings
- [x] New public API is inserted in the API reference section of the documentation
- [x] Docs build without warnings (`make doc`)
- [x] `CHANGELOG.md` updated if the change is user-facing

### LLM usage

Disclose if an LLM was used in writing this PR:
- [ ] No LLM used
- [x] I used an LLM and I went through and validated all the code myself