### PR TITLE
Remove redundant field declarations from MeanInferenceResult subclasses

### DIFF
--- a/glide/io/export.py
+++ b/glide/io/export.py
@@ -42,7 +42,7 @@ def to_json(result: MeanInferenceResult) -> str:
     data = asdict(result)
     data["mean"] = result.mean
     data["std"] = result.std
-    # Reconstruct confidence_interval dict in desired field order
+
     ci_dict = {
         "confidence_level": result.confidence_interval.confidence_level,
         "lower_bound": result.confidence_interval.lower_bound,

--- a/glide/io/export.py
+++ b/glide/io/export.py
@@ -27,14 +27,14 @@ def to_json(result: MeanInferenceResult) -> str:
     metric_name="metric", estimator_name="none")
     >>> print(to_json(inference_result))  # doctest: +ELLIPSIS
     {
+      "metric_name": "metric",
+      "estimator_name": "none",
       "confidence_interval": {
         "confidence_level": 0.95,
         "lower_bound": -1.95...,
         "upper_bound": 1.95...,
         "width": 3.91...
       },
-      "metric_name": "metric",
-      "estimator_name": "none",
       "mean": 0,
       "std": 1
     }

--- a/glide/mean_inference_results/base.py
+++ b/glide/mean_inference_results/base.py
@@ -7,9 +7,9 @@ from glide.confidence_intervals import ConfidenceInterval
 class MeanInferenceResult:
     """Base class for mean inference results."""
 
-    confidence_interval: ConfidenceInterval
     metric_name: str
     estimator_name: str
+    confidence_interval: ConfidenceInterval
 
     @property
     def width(self) -> float:

--- a/glide/mean_inference_results/base.py
+++ b/glide/mean_inference_results/base.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from typing import List
 
 from glide.confidence_intervals import ConfidenceInterval
 
@@ -24,7 +25,7 @@ class MeanInferenceResult:
     def std(self) -> float:
         return self.confidence_interval.std
 
-    def _common_lines(self) -> list:
+    def _common_lines(self) -> List[str]:
         lower_bound = self.confidence_interval.lower_bound
         upper_bound = self.confidence_interval.upper_bound
         confidence_level_pct = self.confidence_interval.confidence_level * 100

--- a/glide/mean_inference_results/classical.py
+++ b/glide/mean_inference_results/classical.py
@@ -1,6 +1,5 @@
 from dataclasses import dataclass
 
-from glide.confidence_intervals import ConfidenceInterval
 from glide.mean_inference_results import MeanInferenceResult
 
 
@@ -8,9 +7,6 @@ from glide.mean_inference_results import MeanInferenceResult
 class ClassicalMeanInferenceResult(MeanInferenceResult):
     """Mean inference result for classical (non-bootstrap) methods."""
 
-    confidence_interval: ConfidenceInterval
-    metric_name: str
-    estimator_name: str
     n: int = 0
 
     def __str__(self) -> str:

--- a/glide/mean_inference_results/prediction_powered.py
+++ b/glide/mean_inference_results/prediction_powered.py
@@ -1,6 +1,5 @@
 from dataclasses import dataclass
 
-from glide.confidence_intervals import ConfidenceInterval
 from glide.mean_inference_results import MeanInferenceResult
 
 
@@ -8,9 +7,6 @@ from glide.mean_inference_results import MeanInferenceResult
 class PredictionPoweredMeanInferenceResult(MeanInferenceResult):
     """Mean inference result for prediction-powered methods."""
 
-    confidence_interval: ConfidenceInterval
-    metric_name: str
-    estimator_name: str
     n_true: int = 0
     n_proxy: int = 0
     effective_sample_size: int = 0


### PR DESCRIPTION
### Description

- Removes redundant field declarations (`confidence_interval`, `metric_name`, `estimator_name`) from `ClassicalMeanInferenceResult` and `PredictionPoweredMeanInferenceResult`, which were already defined in the base class `MeanInferenceResult`. Also reorders the fields in `base.py` so that descriptive fields appear before `confidence_interval`.
- Handles this [ticket](https://github.com/orgs/EmertonData/projects/26/views/7?pane=issue&itemId=203357921) and Closes #313 

### Checklist

Quality gates that must be satisfied before requesting a review:

- [x] I have read `CONTRIBUTING.md`
- [x] `make lint` passes
- [x] `make type-check` passes
- [x] `make tests` passes
- [x] `make coverage` reports 100% coverage
- [x] `make test-notebooks` passes
- [ ] New public API has numpy-style docstrings
- [ ] New public API is inserted in the API reference section of the documentation
- [x] Docs build without warnings (`make doc`)
- [ ] `CHANGELOG.md` updated if the change is user-facing

### LLM usage

Disclose if an LLM was used in writing this PR:
- [ ] No LLM used
- [x] I used an LLM and I went through and validated all the code myself