### PR TITLE
Add dependabot skill for automated PR triage

### DIFF
--- a/.claude/skills/dependabot/SKILL.md
+++ b/.claude/skills/dependabot/SKILL.md
@@ -1,16 +1,16 @@
 ---
 name: dependabot
-description: Handle open dependabot PRs automatically. Detects all open PRs from the Dependabot bot, classifies each updated dependency as direct (declared in pyproject.toml) or indirect (transitive or GitHub Actions), and takes the appropriate action: for indirect deps, enables auto-merge once CI passes; for direct deps, checks out the branch, bumps the version constraint in pyproject.toml via uv, commits, pushes, and enables auto-merge. Use this skill whenever the user says "handle dependabot PRs", "take care of dependabot", "merge dependabot PRs", "process dependabot updates", "triage dependabot", "deal with dependabot", or anything similar about pending dependabot pull requests. Always prefer this skill proactively when dependabot is mentioned in the context of open PRs.
+description: Handle open dependabot PRs automatically. Detects all open PRs from the Dependabot bot, classifies each updated dependency as direct (declared in pyproject.toml) or indirect (transitive or GitHub Actions), and takes the appropriate action: for indirect deps, reports them as ready for maintainer review; for direct deps, checks out the branch, bumps the version constraint in pyproject.toml via uv, regenerates uv.lock, and pushes — so the maintainer only needs to approve and click merge. Use this skill whenever the user says "handle dependabot PRs", "take care of dependabot", "process dependabot updates", "triage dependabot", "deal with dependabot", or anything similar about pending dependabot pull requests.
 ---
 
 ## Overview
 
-This skill automates the weekly dependabot PR triage workflow. Dependabot updates `uv.lock` (and GitHub Actions pins) to newer package versions. The critical distinction is:
+This skill automates the prep work for the weekly dependabot PR triage. The key distinction:
 
-- **Indirect dependency** (transitive or GitHub Actions): the lock file update alone is sufficient. Just ensure CI passes and merge.
-- **Direct dependency** (declared in `pyproject.toml`): the version constraint in `pyproject.toml` must also be bumped so new contributors installing from the manifest get the correct minimum version.
+- **Indirect dependency** (transitive or GitHub Actions): the lock file update is sufficient. Nothing to do — just flag it as ready for maintainer review.
+- **Direct dependency** (declared in `pyproject.toml`): the version constraint there must also be bumped so new contributors get the correct minimum version. The skill checks out the branch, updates `pyproject.toml`, regenerates `uv.lock`, and pushes.
 
-The skill handles both cases end-to-end and uses `--auto` merge so PRs close automatically once CI is green, requiring no further babysitting.
+Merging is left to the maintainer in both cases.
 
 ---
 
@@ -25,8 +25,6 @@ gh pr list --author app/dependabot --state open \
 
 If no PRs are returned, report "No open dependabot PRs found." and stop.
 
-Print a brief list of the discovered PRs before doing anything else.
-
 ### Step 2 — Classify each PR as direct or indirect
 
 Parse the PR title. Dependabot titles follow one of these formats:
@@ -36,55 +34,40 @@ Parse the PR title. Dependabot titles follow one of these formats:
 
 Extract the **package name** (the token immediately after "Bump", lowercased).
 
-Read `pyproject.toml` and search all dependency arrays (`[project].dependencies` and every key under `[dependency-groups]`) for a line containing that package name. The match is case-insensitive.
+Read `pyproject.toml` and search all dependency arrays (`[project].dependencies` and every key under `[dependency-groups]`) for a line containing that package name (case-insensitive).
 
-- **Found** → direct dependency. Note which group it belongs to (`project`, `dev`, `doc`, etc.) and its current version constraint (operator + version, e.g., `>=0.0.53`).
+- **Found** → direct dependency. Note which group (`project`, `dev`, `doc`, etc.) and its current version constraint (e.g., `>=0.0.53`).
 - **Not found** → indirect or GitHub Actions dependency.
 
-Print a classification table before taking any action, and confirm with the user that they want to proceed:
+Print a classification table and ask the user to confirm before proceeding:
 
 | PR | Title | Type | Group | Current constraint |
 |----|-------|------|-------|--------------------|
 | #N | Bump ruff ... | direct | dev | `>=0.15.19` |
 | #N | Bump actions/checkout ... | indirect | — | — |
 
-Ask: *"Ready to process these PRs? Any you'd like to skip?"*
-
-Wait for the user's confirmation before proceeding.
+Ask: *"Ready to process these? Any you'd like to skip?"* Wait for confirmation.
 
 ### Step 3 — Handle indirect / GitHub Actions PRs
 
-For each **indirect** PR (process these first since they require no branch checkout):
+Nothing to change on these branches. Report each one:
 
-1. Enable auto-merge:
-   ```bash
-   gh pr merge <number> --squash --auto
-   ```
-   If the repository does not have auto-merge enabled, wait for CI then merge immediately:
-   ```bash
-   gh pr checks <number> --watch && gh pr merge <number> --squash
-   ```
-
-2. Report: `PR #<number> (<package>): indirect — auto-merge enabled.`
+`PR #<number> (<package>): indirect — no changes needed, ready for maintainer review.`
 
 ### Step 4 — Handle direct dependency PRs
 
-Work through each **direct** PR one at a time. For each:
+Work through each **direct** PR one at a time.
 
 #### 4a. Determine the target version
 
-From the PR title `Bump <package> from <old> to <new>`, extract `<new>` as dependabot's suggested version.
-
-Then verify whether a newer release exists on PyPI:
+From the PR title, extract dependabot's suggested version. Then verify the actual latest on PyPI:
 
 ```bash
 curl -s "https://pypi.org/pypi/<package>/json" \
   | python3 -c "import sys, json; d = json.load(sys.stdin); print(d['info']['version'])"
 ```
 
-Compare the PyPI latest with dependabot's `<new>`. Use whichever is higher as the **target version**. If PyPI is ahead, note it and use the PyPI version — dependabot may be slightly behind.
-
-(Skip this check for GitHub Actions PRs; they are not PyPI packages.)
+Use whichever is higher as the **target version**. If PyPI is ahead of dependabot, note it.
 
 #### 4b. Check out the branch
 
@@ -93,41 +76,30 @@ git fetch origin <headRefName>
 git checkout <headRefName>
 ```
 
-#### 4c. Build the uv add command
+#### 4c. Update pyproject.toml
 
-Use the group you identified in Step 2 to pick the right flag:
+Use the group from Step 2:
 
-- `[project].dependencies` → no group flag: `uv add "<package>>=<new-version>"`
-- `[dependency-groups] dev` → `uv add --group dev "<package>>=<new-version>"`
-- `[dependency-groups] doc` → `uv add --group doc "<package>>=<new-version>"`
-- Any other group → `uv add --group <group> "<package>>=<new-version>"`
+- `[project].dependencies` → `uv add "<package>>=<target-version>"`
+- `[dependency-groups] dev` → `uv add --group dev "<package>>=<target-version>"`
+- `[dependency-groups] doc` → `uv add --group doc "<package>>=<target-version>"`
 
-Always use `>=` as the operator unless the existing constraint uses a different operator (`==`, `~=`, etc.), in which case preserve it. The goal is to update the lower bound to the new version while keeping the constraint style unchanged.
+Preserve the existing constraint operator. If the constraint was `>=old`, use `>=new`. If `==old`, use `==new`.
 
-#### 4d. Run the update
-
-```bash
-uv add [--group <group>] "<package>>=<new-version>"
-```
-
-This updates `pyproject.toml` in place and may touch `uv.lock`. Verify the change:
+Verify the change was applied:
 
 ```bash
 grep -n "<package>" pyproject.toml
 ```
 
-Confirm that the version number in `pyproject.toml` now reflects `<new-version>`.
-
-#### 4e. Regenerate the lock file and commit
-
-After updating `pyproject.toml`, delete the existing lock file and do a clean regeneration. This ensures the lock is produced by our own resolver rather than being a partial merge of dependabot's lock and our toolchain:
+#### 4d. Regenerate the lock file
 
 ```bash
 rm uv.lock
 uv sync --all-groups
 ```
 
-Then commit and push:
+#### 4e. Commit and push
 
 ```bash
 git add pyproject.toml uv.lock
@@ -135,42 +107,31 @@ git commit -m "chore: bump <package> to <target-version> in pyproject.toml"
 git push origin <headRefName>
 ```
 
-#### 4f. Enable auto-merge
-
-```bash
-gh pr merge <number> --squash --auto
-```
-
-If auto-merge is unavailable:
-```bash
-gh pr checks <number> --watch && gh pr merge <number> --squash
-```
-
-#### 4g. Return to main before handling the next PR
+#### 4f. Return to main
 
 ```bash
 git checkout main
 ```
 
-Report: `PR #<number> (<package>): direct — pyproject.toml updated to >=<new-version>, pushed, auto-merge enabled.`
+Report: `PR #<number> (<package>): direct — pyproject.toml bumped to >=<target-version>, pushed. Ready for maintainer review.`
 
 ### Step 5 — Final summary
 
-After all PRs are processed, print a clean summary:
-
 | PR | Package | Type | Action |
 |----|---------|------|--------|
-| #N | ruff | direct | pyproject.toml bumped to >=0.15.20, auto-merge enabled |
-| #N | actions/checkout | indirect | auto-merge enabled |
+| #N | ruff | direct | pyproject.toml bumped to >=0.15.20, pushed |
+| #N | actions/checkout | indirect | no changes needed |
 | … | … | … | … |
+
+Tell the user which PRs are ready for their review and approval.
 
 ---
 
 ## Important constraints
 
-- **Never merge without CI.** Always use `--auto` so the merge only happens once tests pass. Never use `gh pr merge` without `--auto` unless you explicitly waited via `gh pr checks --watch`.
-- **Never force-push.** Dependabot branches are shared; only regular pushes are allowed.
-- **One PR at a time for direct deps.** Check out, update, commit, push, and return to `main` before moving to the next direct-dep PR. Never interleave checkouts.
-- **Preserve the constraint operator.** If `pyproject.toml` has `>=old`, write `>=new`. If it has `==old`, write `==new`. Never silently change the operator style.
-- **Always return to `main` when done.** Run `git checkout main` after the last PR is processed.
-- **Ask before acting.** Show the classification table from Step 2 and wait for user confirmation before making any changes.
+- **Never merge.** Leave approvals and merging entirely to the maintainer.
+- **Never force-push.** Only regular pushes on dependabot branches.
+- **One PR at a time for direct deps.** Checkout, update, commit, push, return to `main` before the next one.
+- **Preserve the constraint operator.** Never silently change `>=` to `==` or vice versa.
+- **Always return to `main` when done.**
+- **Ask before acting.** Show the classification table and wait for user confirmation.

--- a/.claude/skills/dependabot/SKILL.md
+++ b/.claude/skills/dependabot/SKILL.md
@@ -50,9 +50,13 @@ Ask: *"Ready to process these? Any you'd like to skip?"* Wait for confirmation.
 
 ### Step 3 — Handle indirect / GitHub Actions PRs
 
-Nothing to change on these branches. Report each one:
+Nothing to change on these branches. Post a comment on each:
 
-`PR #<number> (<package>): indirect — no changes needed, ready for maintainer review.`
+```bash
+gh pr comment <number> --body "Processed by the dependabot skill. This is an indirect dependency — no changes to \`pyproject.toml\` were needed. Ready for maintainer review."
+```
+
+Report each one: `PR #<number> (<package>): indirect — commented, ready for maintainer review.`
 
 ### Step 4 — Handle direct dependency PRs
 
@@ -107,13 +111,26 @@ git commit -m "chore: bump <package> to <target-version> in pyproject.toml"
 git push origin <headRefName>
 ```
 
-#### 4f. Return to main
+#### 4f. Post a comment on the PR
+
+```bash
+gh pr comment <number> --body "Processed by the dependabot skill.
+
+- \`pyproject.toml\`: bumped \`<package>\` constraint from \`>=<old-version>\` to \`>=<target-version>\` (group: \`<group>\`)
+- \`uv.lock\`: deleted and regenerated via \`uv sync --all-groups\`
+
+Ready for maintainer review."
+```
+
+If PyPI had a newer version than dependabot's suggestion, mention it: add a line like `Note: PyPI latest was <pypi-version>, which is ahead of dependabot's <dependabot-version> — used <pypi-version>.`
+
+#### 4g. Return to main
 
 ```bash
 git checkout main
 ```
 
-Report: `PR #<number> (<package>): direct — pyproject.toml bumped to >=<target-version>, pushed. Ready for maintainer review.`
+Report: `PR #<number> (<package>): direct — pyproject.toml bumped to >=<target-version>, commented, ready for maintainer review.`
 
 ### Step 5 — Final summary
 

--- a/.claude/skills/dependabot/SKILL.md
+++ b/.claude/skills/dependabot/SKILL.md
@@ -1,16 +1,20 @@
 ---
 name: dependabot
-description: Handle open dependabot PRs automatically. Detects all open PRs from the Dependabot bot, classifies each updated dependency as direct (declared in pyproject.toml) or indirect (transitive or GitHub Actions), and takes the appropriate action: for indirect deps, reports them as ready for maintainer review; for direct deps, checks out the branch, bumps the version constraint in pyproject.toml via uv, regenerates uv.lock, and pushes — so the maintainer only needs to approve and click merge. Use this skill whenever the user says "handle dependabot PRs", "take care of dependabot", "process dependabot updates", "triage dependabot", "deal with dependabot", or anything similar about pending dependabot pull requests.
+description: Handle open dependabot PRs automatically. Detects all open PRs from the Dependabot bot, classifies each updated dependency as direct (declared in pyproject.toml), indirect-python (transitive), or GitHub Actions, then applies the full unified change set (Python dep bumps + GitHub Actions version bumps) to every PR branch so all branches reach the same final state and merge cleanly in any order. Posts a summary comment on each PR. Merging is left to the maintainer. Use this skill whenever the user says "handle dependabot PRs", "take care of dependabot", "process dependabot updates", "triage dependabot", "deal with dependabot", or anything similar about pending dependabot pull requests.
 ---
 
 ## Overview
 
-This skill automates the prep work for the weekly dependabot PR triage. The key distinction:
+Automates the prep work for the weekly dependabot PR triage. Collects all Python dep bumps and GitHub Actions version bumps into a single unified change set and applies it to every PR branch — so all branches reach the same final state and merge cleanly in any order.
 
-- **Indirect dependency** (transitive or GitHub Actions): the lock file update is sufficient. Nothing to do — just flag it as ready for maintainer review.
-- **Direct dependency** (declared in `pyproject.toml`): the version constraint there must also be bumped so new contributors get the correct minimum version. The skill checks out the branch, updates `pyproject.toml`, regenerates `uv.lock`, and pushes.
+**Dependency types:**
+- **Direct**: declared in `pyproject.toml` — contributes a Python entry to the change set.
+- **Indirect-python**: transitive dep, not in `pyproject.toml` — no own Python entry, but still processed.
+- **GitHub Actions**: contributes a GHA entry to the change set.
 
-Merging is left to the maintainer in both cases.
+Every branch (direct, indirect-python, and github-actions) receives the full unified change set: all Python dep bumps applied to `pyproject.toml` + `uv.lock` regenerated + all GHA version bumps applied to `.github/workflows/`.
+
+Merging is left to the maintainer.
 
 ---
 
@@ -19,136 +23,147 @@ Merging is left to the maintainer in both cases.
 ### Step 1 — Discover open dependabot PRs
 
 ```bash
-gh pr list --author app/dependabot --state open \
-  --json number,title,headRefName,url,statusCheckRollup
+gh pr list --author app/dependabot --state open --json number,title,headRefName,url
 ```
 
-If no PRs are returned, report "No open dependabot PRs found." and stop.
+Stop and report if no PRs are found.
 
-### Step 2 — Classify each PR as direct or indirect
+### Step 2 — Classify every PR and collect the unified change set
 
-Parse the PR title. Dependabot titles follow one of these formats:
+Extract the package name (token after "Bump", lowercased). Search `pyproject.toml` (`[project].dependencies` and all `[dependency-groups]` keys) for that name (case-insensitive):
 
-- `Bump <package> from <old-version> to <new-version>` (Python/uv packages)
-- `Bump <owner>/<action> from <old-version> to <new-version>` (GitHub Actions)
+- **direct**: found — note the group (`project`, `dev`, `doc`, etc.) and current constraint (e.g. `>=0.0.53`).
+- **indirect-python**: Python package, not found.
+- **github-actions**: owner/action pattern (e.g. `actions/checkout`).
 
-Extract the **package name** (the token immediately after "Bump", lowercased).
-
-Read `pyproject.toml` and search all dependency arrays (`[project].dependencies` and every key under `[dependency-groups]`) for a line containing that package name (case-insensitive).
-
-- **Found** → direct dependency. Note which group (`project`, `dev`, `doc`, etc.) and its current version constraint (e.g., `>=0.0.53`).
-- **Not found** → indirect or GitHub Actions dependency.
-
-Print a classification table and ask the user to confirm before proceeding:
-
-| PR | Title | Type | Group | Current constraint |
-|----|-------|------|-------|--------------------|
-| #N | Bump ruff ... | direct | dev | `>=0.15.19` |
-| #N | Bump actions/checkout ... | indirect | — | — |
-
-Ask: *"Ready to process these? Any you'd like to skip?"* Wait for confirmation.
-
-### Step 3 — Handle indirect / GitHub Actions PRs
-
-Nothing to change on these branches. Post a comment on each:
-
-```bash
-gh pr comment <number> --body "Processed by the dependabot skill. This is an indirect dependency — no changes to \`pyproject.toml\` were needed. Ready for maintainer review."
-```
-
-Report each one: `PR #<number> (<package>): indirect — commented, ready for maintainer review.`
-
-### Step 4 — Handle direct dependency PRs
-
-Work through each **direct** PR one at a time.
-
-#### 4a. Determine the target version
-
-From the PR title, extract dependabot's suggested version. Then verify the actual latest on PyPI:
+For each **direct** PR, verify the actual latest version on PyPI:
 
 ```bash
 curl -s "https://pypi.org/pypi/<package>/json" \
   | python3 -c "import sys, json; d = json.load(sys.stdin); print(d['info']['version'])"
 ```
 
-Use whichever is higher as the **target version**. If PyPI is ahead of dependabot, note it.
+Use whichever is higher (PyPI vs dependabot) as the **target version**. Note if PyPI was ahead.
 
-#### 4b. Check out the branch
+For each **github-actions** PR, confirm the version format as it appears in the workflow files:
+
+```bash
+grep -r "<action>" .github/workflows/
+```
+
+The YAML often uses a `v` prefix (e.g., `@v4`) even if the PR title says "from 3 to 4".
+
+Build the unified change set:
+
+**Python entries** (from direct PRs):
+
+| Package | Old constraint | Target version | Group | Source PR |
+|---------|---------------|----------------|-------|-----------|
+| `<pkg-a>` | `>=1.0.0` | `1.1.0` | dev | #N |
+| `<pkg-b>` | `>=0.0.53` | `0.0.55` | doc | #M |
+
+**GitHub Actions entries** (from github-actions PRs):
+
+| Action | Old version (as in YAML) | New version | Source PR |
+|--------|--------------------------|-------------|-----------|
+| `<owner>/<action-a>` | `v3` | `v4` | #N |
+| `<owner>/<action-b>` | `v1` | `v2` | #M |
+
+Print the full classification table and unified change set, then ask: *"Ready to process these? Any you'd like to skip?"* Wait for confirmation.
+
+### Step 3 — Process all PR branches
+
+Work through **every** PR (direct, indirect-python, and github-actions) one at a time using the same procedure.
+
+#### 3a. Check out the branch
 
 ```bash
 git fetch origin <headRefName>
 git checkout <headRefName>
 ```
 
-#### 4c. Update pyproject.toml
+#### 3b. Apply the Python change set
 
-Use the group from Step 2:
+If the Python change set is non-empty, run `uv add` for every Python entry (regardless of which PR owns it), then regenerate the lock file:
 
 - `[project].dependencies` → `uv add "<package>>=<target-version>"`
 - `[dependency-groups] dev` → `uv add --group dev "<package>>=<target-version>"`
 - `[dependency-groups] doc` → `uv add --group doc "<package>>=<target-version>"`
 
-Preserve the existing constraint operator. If the constraint was `>=old`, use `>=new`. If `==old`, use `==new`.
-
-Verify the change was applied:
-
-```bash
-grep -n "<package>" pyproject.toml
-```
-
-#### 4d. Regenerate the lock file
+Preserve the existing constraint operator. For indirect-python and github-actions branches there is no own entry — apply the other entries anyway.
 
 ```bash
 rm uv.lock
 uv sync --all-groups
 ```
 
-#### 4e. Commit and push
+Delete rather than relying on `uv add`'s incremental update — this produces one clean resolution after all changes are applied together. Skip this entire sub-step if the Python change set is empty.
+
+#### 3c. Apply the GitHub Actions change set
+
+If the GHA change set is non-empty, for each entry replace the old version with the new across all workflow files:
 
 ```bash
-git add pyproject.toml uv.lock
-git commit -m "chore: bump <package> to <target-version> in pyproject.toml"
+sed -i '' 's|<action>@<old-version>|<action>@<new-version>|g' .github/workflows/*.yml
+```
+
+Run for every entry. The branch's own action (if any) is already bumped by dependabot, so the sed is a no-op for it. Skip this entire sub-step if the GHA change set is empty.
+
+#### 3d. Commit and push
+
+```bash
+git add pyproject.toml uv.lock .github/workflows/
+git commit -m "chore: apply dependabot updates"
 git push origin <headRefName>
 ```
 
-#### 4f. Post a comment on the PR
+`git add` only stages files that actually changed, so unmodified files are silently ignored. If `git commit` says "nothing to commit" (edge case), note it in the summary and continue.
 
-```bash
-gh pr comment <number> --body "Processed by the dependabot skill.
+#### 3e. Post a comment
 
-- \`pyproject.toml\`: bumped \`<package>\` constraint from \`>=<old-version>\` to \`>=<target-version>\` (group: \`<group>\`)
-- \`uv.lock\`: deleted and regenerated via \`uv sync --all-groups\`
+Template:
 
-Ready for maintainer review."
+```
+Processed by the dependabot skill[, grouped with #N, #M, …].
+
+Changes applied to this branch:
+- `pyproject.toml`: bumped `<package>` from `<old-constraint>` to `>=<target>` (group: `<group>`) ← this PR
+- `pyproject.toml`: bumped `<package>` from `<old-constraint>` to `>=<target>` (group: `<group>`) ← from #N
+- `uv.lock`: deleted and regenerated via `uv sync --all-groups`
+- `.github/workflows/`: updated `<action>` from `<old-version>` to `<new-version>` ← from #N
+
+All open dependabot changes were applied together to prevent merge conflicts. Ready for maintainer review.
 ```
 
-If PyPI had a newer version than dependabot's suggestion, mention it: add a line like `Note: PyPI latest was <pypi-version>, which is ahead of dependabot's <dependabot-version> — used <pypi-version>.`
+Rules:
+- Omit "grouped with" if this is the only PR in the batch.
+- Mark this PR's own entry `← this PR`; others `← from #N`. For indirect-python, all Python entries are `← from #N`.
+- Omit sections that are empty (no Python entries, or no GHA entries).
+- Add a PyPI note if PyPI was ahead: `Note: PyPI latest was <v>, ahead of dependabot's <v> — used <v>.`
 
-#### 4g. Return to main
+```bash
+gh pr comment <number> --body "<comment body>"
+```
+
+#### 3f. Return to main
 
 ```bash
 git checkout main
 ```
 
-Report: `PR #<number> (<package>): direct — pyproject.toml bumped to >=<target-version>, commented, ready for maintainer review.`
+### Step 4 — Final summary
 
-### Step 5 — Final summary
-
-| PR | Package | Type | Action |
-|----|---------|------|--------|
-| #N | ruff | direct | pyproject.toml bumped to >=0.15.20, pushed |
-| #N | actions/checkout | indirect | no changes needed |
-| … | … | … | … |
-
-Tell the user which PRs are ready for their review and approval.
+Print a table listing each PR number, package/action name, type (direct / indirect-python / github-actions), and action taken (e.g. "full change set applied, pushed" or "nothing to commit").
 
 ---
 
 ## Important constraints
 
-- **Never merge.** Leave approvals and merging entirely to the maintainer.
-- **Never force-push.** Only regular pushes on dependabot branches.
-- **One PR at a time for direct deps.** Checkout, update, commit, push, return to `main` before the next one.
-- **Preserve the constraint operator.** Never silently change `>=` to `==` or vice versa.
-- **Always return to `main` when done.**
-- **Ask before acting.** Show the classification table and wait for user confirmation.
+- **Collect before touching.** Complete the unified change set in Step 2 before checking out any branch.
+- **Apply all to all.** Every branch receives the full Python change set and the full GHA change set, regardless of its own type or which entry is "its own".
+- **Always commit and push.** Never skip for any branch type.
+- **Never merge.** Leave approvals and merging to the maintainer.
+- **Never force-push.**
+- **One branch at a time.** Checkout → apply → commit → push → return to `main` before the next.
+- **Preserve constraint operators.** Never change `>=` to `==` or vice versa.
+- **Ask before acting.** Wait for user confirmation after Step 2.

--- a/.claude/skills/dependabot/SKILL.md
+++ b/.claude/skills/dependabot/SKILL.md
@@ -1,18 +1,16 @@
 ---
 name: dependabot
-description: Handle open dependabot PRs automatically. Detects all open PRs from the Dependabot bot, classifies each updated dependency as direct (declared in pyproject.toml), indirect-python (transitive), or GitHub Actions, then applies the full unified change set (Python dep bumps + GitHub Actions version bumps) to every PR branch so all branches reach the same final state and merge cleanly in any order. Posts a summary comment on each PR. Merging is left to the maintainer. Use this skill whenever the user says "handle dependabot PRs", "take care of dependabot", "process dependabot updates", "triage dependabot", "deal with dependabot", or anything similar about pending dependabot pull requests.
+description: Handle open dependabot PRs automatically. Finds the oldest open dependabot PR, classifies it, applies the version bump to the branch, merges main to eliminate conflicts, and posts a summary comment. Merging is left to the maintainer. Use this skill whenever the user says "handle dependabot PRs", "take care of dependabot", "process dependabot updates", "triage dependabot", "deal with dependabot", or anything similar about pending dependabot pull requests.
 ---
 
 ## Overview
 
-Automates the prep work for the weekly dependabot PR triage. Collects all Python dep bumps and GitHub Actions version bumps into a single unified change set and applies it to every PR branch — so all branches reach the same final state and merge cleanly in any order.
+Processes the oldest open dependabot PR and makes it ready for maintainer review. Applies the dependency bump to the branch first, then merges the latest main to ensure the branch is conflict-free.
 
 **Dependency types:**
-- **Direct**: declared in `pyproject.toml` — contributes a Python entry to the change set.
-- **Indirect-python**: transitive dep, not in `pyproject.toml` — no own Python entry, but still processed.
-- **GitHub Actions**: contributes a GHA entry to the change set.
-
-Every branch (direct, indirect-python, and github-actions) receives the full unified change set: all Python dep bumps applied to `pyproject.toml` + `uv.lock` regenerated + all GHA version bumps applied to `.github/workflows/`.
+- **Direct**: declared in `pyproject.toml` — bump the version constraint and regenerate the lock file.
+- **Indirect-python**: transitive dep, not in `pyproject.toml` — regenerate the lock file only.
+- **GitHub Actions**: bump the action version in workflow files.
 
 Merging is left to the maintainer.
 
@@ -23,20 +21,20 @@ Merging is left to the maintainer.
 ### Step 1 — Discover open dependabot PRs
 
 ```bash
-gh pr list --author app/dependabot --state open --json number,title,headRefName,url
+gh pr list --author app/dependabot --state open --json number,title,headRefName,url --jq 'sort_by(.number)'
 ```
 
-Stop and report if no PRs are found.
+Stop and report if no PRs are found. Select the one with the **lowest PR number** as the target.
 
-### Step 2 — Classify every PR and collect the unified change set
+### Step 2 — Classify the PR
 
 Extract the package name (token after "Bump", lowercased). Search `pyproject.toml` (`[project].dependencies` and all `[dependency-groups]` keys) for that name (case-insensitive):
 
 - **direct**: found — note the group (`project`, `dev`, `doc`, etc.) and current constraint (e.g. `>=0.0.53`).
-- **indirect-python**: Python package, not found.
+- **indirect-python**: Python package, not found in `pyproject.toml`.
 - **github-actions**: owner/action pattern (e.g. `actions/checkout`).
 
-For each **direct** PR, verify the actual latest version on PyPI. Normalize the package name first by lowercasing and replacing underscores with dashes (PyPI's canonical form):
+For a **direct** PR, verify the actual latest version on PyPI. Normalize the package name first by lowercasing and replacing underscores with dashes:
 
 ```bash
 curl -s "https://pypi.org/pypi/<normalized-package>/json" \
@@ -45,111 +43,136 @@ curl -s "https://pypi.org/pypi/<normalized-package>/json" \
 
 Use whichever is higher (PyPI vs dependabot) as the **target version**. Note if PyPI was ahead.
 
-For each **github-actions** PR, confirm the version format as it appears in the workflow files:
+For a **github-actions** PR, confirm the version format as it appears in the workflow files:
 
 ```bash
 grep -r "<action>" .github/workflows/
 ```
 
-The YAML often uses a `v` prefix (e.g., `@v4`) even if the PR title says "from 3 to 4".
+Print the classification and target version, then ask: *"Ready to process this PR?"* Wait for confirmation before touching any branch.
 
-Build the unified change set:
-
-**Python entries** (from direct PRs):
-
-| Package | Old constraint | Target version | Group | Source PR |
-|---------|---------------|----------------|-------|-----------|
-| `<pkg-a>` | `>=1.0.0` | `1.1.0` | dev | #N |
-| `<pkg-b>` | `>=0.0.53` | `0.0.55` | doc | #M |
-
-**GitHub Actions entries** (from github-actions PRs):
-
-| Action | Old version (as in YAML) | New version | Source PR |
-|--------|--------------------------|-------------|-----------|
-| `<owner>/<action-a>` | `v3` | `v4` | #N |
-| `<owner>/<action-b>` | `v1` | `v2` | #M |
-
-Print the full classification table and unified change set, then ask: *"Ready to process these?"* Wait for confirmation before touching any branch.
-
-### Step 3 — Process all PR branches
-
-Work through **every** PR (direct, indirect-python, and github-actions) one at a time, in ascending PR number order, using the same procedure.
+### Step 3 — Process the PR branch
 
 #### 3a. Check out the branch
 
 ```bash
-git fetch origin <headRefName>
+git fetch origin
 git checkout <headRefName>
 ```
 
-#### 3b. Apply the Python change set
+#### 3b. Apply the version bump
 
-If the Python change set is non-empty, run `uv add` for every Python entry (regardless of which PR owns it), then regenerate the lock file:
+**Direct PR:** run `uv add` for this entry, then regenerate the lock file:
 
 - `[project].dependencies` → `uv add "<package>>=<target-version>"`
 - `[dependency-groups] dev` → `uv add --group dev "<package>>=<target-version>"`
 - `[dependency-groups] doc` → `uv add --group doc "<package>>=<target-version>"`
 
-Preserve the existing constraint operator. For indirect-python and github-actions branches there is no own entry — apply the other entries anyway.
+Preserve the existing constraint operator.
 
 ```bash
 rm uv.lock
-uv sync --all-groups
+make venv
 ```
 
-Delete rather than relying on `uv add`'s incremental update — this produces one clean resolution after all changes are applied together. Skip this entire sub-step if the Python change set is empty.
+**Indirect-python PR:** no `pyproject.toml` change. Regenerate the lock file only:
 
-If `uv sync --all-groups` fails, check out `main`, record the failure in the running summary, notify the user inline, and continue with the next PR. Mark the branch as "failed" in the Step 4 summary table.
+```bash
+rm uv.lock
+make venv
+```
 
-#### 3c. Apply the GitHub Actions change set
-
-If the GHA change set is non-empty, for each entry replace the old version with the new across all workflow files:
+**GitHub Actions PR:** replace the old version with the new across all workflow files:
 
 ```bash
 perl -pi -e 's|<action>@<old-version>|<action>@<new-version>|g' .github/workflows/*.yml
 ```
 
-Run for every entry. The branch's own action (if any) is already bumped by dependabot, so the sed is a no-op for it. Skip this entire sub-step if the GHA change set is empty.
+If `make venv` fails, check out `main`, record the failure, notify the user, and stop.
 
-#### 3d. Commit and push
+#### 3c. Commit the version bump
 
 ```bash
 git add pyproject.toml uv.lock .github/workflows/
-git commit -m "chore: apply dependabot updates"
+git commit -m "chore: apply dependabot update"
+```
+
+If `git commit` says "nothing to commit", note it and continue to 3d.
+
+#### 3d. Merge main
+
+```bash
+git merge origin/main
+```
+
+If the merge is clean (no conflicts) or already up-to-date, skip to 3f.
+
+If there are conflicts, resolve each type as follows:
+
+**`pyproject.toml` conflicts:** for each conflict block, compare the version strings from both sides and keep the higher version. Remove all conflict markers.
+
+```bash
+git add pyproject.toml
+```
+
+**`uv.lock` conflicts:** always resolve by deleting and regenerating:
+
+```bash
+rm uv.lock
+make venv
+git add uv.lock
+```
+
+**`.github/workflows/` conflicts:** for each conflict block, keep the higher version string. Remove all conflict markers.
+
+```bash
+git add .github/workflows/
+```
+
+If `make venv` fails during conflict resolution, abort the merge (`git merge --abort`), check out `main`, record the failure, notify the user, and stop.
+
+#### 3e. Commit the merge resolution
+
+Only needed when conflicts were present:
+
+```bash
+git commit --no-edit
+```
+
+#### 3f. Push
+
+```bash
 git push origin <headRefName>
 ```
 
-`git add` only stages files that actually changed, so unmodified files are silently ignored. If `git commit` says "nothing to commit" (edge case), note it in the summary and continue.
+If push is rejected, check out `main`, record the failure, notify the user, and stop.
 
-If any command in this step fails (commit hook error, push rejected, etc.), check out `main`, record the failure in the running summary, notify the user inline, and continue with the next PR. Mark the branch as "failed" in the Step 4 summary table.
-
-#### 3e. Post a comment
+#### 3g. Post a comment
 
 Template:
 
 ```
-Processed by the dependabot skill[, grouped with #N, #M, …].
+Processed by the dependabot skill.
 
 Changes applied to this branch:
-- `pyproject.toml`: bumped `<package>` from `<old-constraint>` to `>=<target>` (group: `<group>`) ← this PR
-- `pyproject.toml`: bumped `<package>` from `<old-constraint>` to `>=<target>` (group: `<group>`) ← from #N
-- `uv.lock`: deleted and regenerated via `uv sync --all-groups`
-- `.github/workflows/`: updated `<action>` from `<old-version>` to `<new-version>` ← from #N
+- `pyproject.toml`: bumped `<package>` from `<old-constraint>` to `>=<target>` (group: `<group>`)
+- `uv.lock`: deleted and regenerated via `make venv`
+- `.github/workflows/`: updated `<action>` from `<old-version>` to `<new-version>`
 
-All open dependabot changes were applied together to prevent merge conflicts. Ready for maintainer review.
+Merged latest main. Ready for maintainer review.
 ```
 
 Rules:
-- Omit "grouped with" if this is the only PR in the batch.
-- Mark this PR's own entry `← this PR`; others `← from #N`. For indirect-python, all Python entries are `← from #N`.
-- Omit sections that are empty (no Python entries, or no GHA entries).
+- Omit sections that are empty (no Python entry, no GHA entry).
 - Add a PyPI note if PyPI was ahead: `Note: PyPI latest was <v>, ahead of dependabot's <v> — used <v>.`
+- If the merge resolved conflicts, add: `Note: conflicts in <files> were resolved automatically.`
+- If the branch was already up-to-date with main, omit the "Merged latest main" line.
 
 ```bash
 gh pr comment <number> --body "<comment body>"
 ```
 
-#### 3f. Return to main
+#### 3h. Return to main
 
 ```bash
 git checkout main
@@ -157,17 +180,15 @@ git checkout main
 
 ### Step 4 — Final summary
 
-Print a table listing each PR number, package/action name, type (direct / indirect-python / github-actions), and action taken (e.g. "full change set applied, pushed" or "nothing to commit").
+Print the PR number, package/action name, type (direct / indirect-python / github-actions), and outcome (e.g. "processed and pushed" or "failed: <reason>").
 
 ---
 
 ## Important constraints
 
-- **Collect before touching.** Complete the unified change set in Step 2 before checking out any branch.
-- **Apply all to all.** Every branch receives the full Python change set and the full GHA change set, regardless of its own type or which entry is "its own".
-- **Always commit and push.** Never skip for any branch type.
+- **Confirm before acting.** Wait for user confirmation after Step 2.
+- **Process first, merge second.** Apply the version bump and commit before merging main.
 - **Never merge.** Leave approvals and merging to the maintainer.
 - **Never force-push.**
-- **One branch at a time.** Checkout → apply → commit → push → return to `main` before the next.
 - **Preserve constraint operators.** Never change `>=` to `==` or vice versa.
-- **Ask before acting.** Wait for user confirmation after Step 2.
+- **Oldest PR first.** Always select the PR with the lowest number.

--- a/.claude/skills/dependabot/SKILL.md
+++ b/.claude/skills/dependabot/SKILL.md
@@ -1,0 +1,176 @@
+---
+name: dependabot
+description: Handle open dependabot PRs automatically. Detects all open PRs from the Dependabot bot, classifies each updated dependency as direct (declared in pyproject.toml) or indirect (transitive or GitHub Actions), and takes the appropriate action: for indirect deps, enables auto-merge once CI passes; for direct deps, checks out the branch, bumps the version constraint in pyproject.toml via uv, commits, pushes, and enables auto-merge. Use this skill whenever the user says "handle dependabot PRs", "take care of dependabot", "merge dependabot PRs", "process dependabot updates", "triage dependabot", "deal with dependabot", or anything similar about pending dependabot pull requests. Always prefer this skill proactively when dependabot is mentioned in the context of open PRs.
+---
+
+## Overview
+
+This skill automates the weekly dependabot PR triage workflow. Dependabot updates `uv.lock` (and GitHub Actions pins) to newer package versions. The critical distinction is:
+
+- **Indirect dependency** (transitive or GitHub Actions): the lock file update alone is sufficient. Just ensure CI passes and merge.
+- **Direct dependency** (declared in `pyproject.toml`): the version constraint in `pyproject.toml` must also be bumped so new contributors installing from the manifest get the correct minimum version.
+
+The skill handles both cases end-to-end and uses `--auto` merge so PRs close automatically once CI is green, requiring no further babysitting.
+
+---
+
+## Workflow
+
+### Step 1 — Discover open dependabot PRs
+
+```bash
+gh pr list --author app/dependabot --state open \
+  --json number,title,headRefName,url,statusCheckRollup
+```
+
+If no PRs are returned, report "No open dependabot PRs found." and stop.
+
+Print a brief list of the discovered PRs before doing anything else.
+
+### Step 2 — Classify each PR as direct or indirect
+
+Parse the PR title. Dependabot titles follow one of these formats:
+
+- `Bump <package> from <old-version> to <new-version>` (Python/uv packages)
+- `Bump <owner>/<action> from <old-version> to <new-version>` (GitHub Actions)
+
+Extract the **package name** (the token immediately after "Bump", lowercased).
+
+Read `pyproject.toml` and search all dependency arrays (`[project].dependencies` and every key under `[dependency-groups]`) for a line containing that package name. The match is case-insensitive.
+
+- **Found** → direct dependency. Note which group it belongs to (`project`, `dev`, `doc`, etc.) and its current version constraint (operator + version, e.g., `>=0.0.53`).
+- **Not found** → indirect or GitHub Actions dependency.
+
+Print a classification table before taking any action, and confirm with the user that they want to proceed:
+
+| PR | Title | Type | Group | Current constraint |
+|----|-------|------|-------|--------------------|
+| #N | Bump ruff ... | direct | dev | `>=0.15.19` |
+| #N | Bump actions/checkout ... | indirect | — | — |
+
+Ask: *"Ready to process these PRs? Any you'd like to skip?"*
+
+Wait for the user's confirmation before proceeding.
+
+### Step 3 — Handle indirect / GitHub Actions PRs
+
+For each **indirect** PR (process these first since they require no branch checkout):
+
+1. Enable auto-merge:
+   ```bash
+   gh pr merge <number> --squash --auto
+   ```
+   If the repository does not have auto-merge enabled, wait for CI then merge immediately:
+   ```bash
+   gh pr checks <number> --watch && gh pr merge <number> --squash
+   ```
+
+2. Report: `PR #<number> (<package>): indirect — auto-merge enabled.`
+
+### Step 4 — Handle direct dependency PRs
+
+Work through each **direct** PR one at a time. For each:
+
+#### 4a. Determine the target version
+
+From the PR title `Bump <package> from <old> to <new>`, extract `<new>` as dependabot's suggested version.
+
+Then verify whether a newer release exists on PyPI:
+
+```bash
+curl -s "https://pypi.org/pypi/<package>/json" \
+  | python3 -c "import sys, json; d = json.load(sys.stdin); print(d['info']['version'])"
+```
+
+Compare the PyPI latest with dependabot's `<new>`. Use whichever is higher as the **target version**. If PyPI is ahead, note it and use the PyPI version — dependabot may be slightly behind.
+
+(Skip this check for GitHub Actions PRs; they are not PyPI packages.)
+
+#### 4b. Check out the branch
+
+```bash
+git fetch origin <headRefName>
+git checkout <headRefName>
+```
+
+#### 4c. Build the uv add command
+
+Use the group you identified in Step 2 to pick the right flag:
+
+- `[project].dependencies` → no group flag: `uv add "<package>>=<new-version>"`
+- `[dependency-groups] dev` → `uv add --group dev "<package>>=<new-version>"`
+- `[dependency-groups] doc` → `uv add --group doc "<package>>=<new-version>"`
+- Any other group → `uv add --group <group> "<package>>=<new-version>"`
+
+Always use `>=` as the operator unless the existing constraint uses a different operator (`==`, `~=`, etc.), in which case preserve it. The goal is to update the lower bound to the new version while keeping the constraint style unchanged.
+
+#### 4d. Run the update
+
+```bash
+uv add [--group <group>] "<package>>=<new-version>"
+```
+
+This updates `pyproject.toml` in place and may touch `uv.lock`. Verify the change:
+
+```bash
+grep -n "<package>" pyproject.toml
+```
+
+Confirm that the version number in `pyproject.toml` now reflects `<new-version>`.
+
+#### 4e. Regenerate the lock file and commit
+
+After updating `pyproject.toml`, delete the existing lock file and do a clean regeneration. This ensures the lock is produced by our own resolver rather than being a partial merge of dependabot's lock and our toolchain:
+
+```bash
+rm uv.lock
+uv sync --all-groups
+```
+
+Then commit and push:
+
+```bash
+git add pyproject.toml uv.lock
+git commit -m "chore: bump <package> to <target-version> in pyproject.toml"
+git push origin <headRefName>
+```
+
+#### 4f. Enable auto-merge
+
+```bash
+gh pr merge <number> --squash --auto
+```
+
+If auto-merge is unavailable:
+```bash
+gh pr checks <number> --watch && gh pr merge <number> --squash
+```
+
+#### 4g. Return to main before handling the next PR
+
+```bash
+git checkout main
+```
+
+Report: `PR #<number> (<package>): direct — pyproject.toml updated to >=<new-version>, pushed, auto-merge enabled.`
+
+### Step 5 — Final summary
+
+After all PRs are processed, print a clean summary:
+
+| PR | Package | Type | Action |
+|----|---------|------|--------|
+| #N | ruff | direct | pyproject.toml bumped to >=0.15.20, auto-merge enabled |
+| #N | actions/checkout | indirect | auto-merge enabled |
+| … | … | … | … |
+
+---
+
+## Important constraints
+
+- **Never merge without CI.** Always use `--auto` so the merge only happens once tests pass. Never use `gh pr merge` without `--auto` unless you explicitly waited via `gh pr checks --watch`.
+- **Never force-push.** Dependabot branches are shared; only regular pushes are allowed.
+- **One PR at a time for direct deps.** Check out, update, commit, push, and return to `main` before moving to the next direct-dep PR. Never interleave checkouts.
+- **Preserve the constraint operator.** If `pyproject.toml` has `>=old`, write `>=new`. If it has `==old`, write `==new`. Never silently change the operator style.
+- **Always return to `main` when done.** Run `git checkout main` after the last PR is processed.
+- **Ask before acting.** Show the classification table from Step 2 and wait for user confirmation before making any changes.

--- a/.claude/skills/dependabot/SKILL.md
+++ b/.claude/skills/dependabot/SKILL.md
@@ -34,12 +34,6 @@ Extract the package name (token after "Bump", lowercased). Search `pyproject.tom
 - **indirect-python**: Python package, not found in `pyproject.toml`.
 - **github-actions**: owner/action pattern (e.g. `actions/checkout`).
 
-For a **github-actions** PR, confirm the version format as it appears in the workflow files:
-
-```bash
-grep -r "<action>" .github/workflows/
-```
-
 Print the classification and target version, then ask: *"Ready to process this PR?"* Wait for confirmation before touching any branch.
 
 ### Step 3 — Process the PR branch

--- a/.claude/skills/dependabot/SKILL.md
+++ b/.claude/skills/dependabot/SKILL.md
@@ -34,15 +34,6 @@ Extract the package name (token after "Bump", lowercased). Search `pyproject.tom
 - **indirect-python**: Python package, not found in `pyproject.toml`.
 - **github-actions**: owner/action pattern (e.g. `actions/checkout`).
 
-For a **direct** PR, verify the actual latest version on PyPI. Normalize the package name first by lowercasing and replacing underscores with dashes:
-
-```bash
-curl -s "https://pypi.org/pypi/<normalized-package>/json" \
-  | python3 -c "import sys, json; d = json.load(sys.stdin); print(d['info']['version'])"
-```
-
-Use whichever is higher (PyPI vs dependabot) as the **target version**. Note if PyPI was ahead.
-
 For a **github-actions** PR, confirm the version format as it appears in the workflow files:
 
 ```bash
@@ -71,14 +62,12 @@ git checkout <headRefName>
 Preserve the existing constraint operator.
 
 ```bash
-rm uv.lock
 make venv
 ```
 
 **Indirect-python PR:** no `pyproject.toml` change. Regenerate the lock file only:
 
 ```bash
-rm uv.lock
 make venv
 ```
 
@@ -115,10 +104,9 @@ If there are conflicts, resolve each type as follows:
 git add pyproject.toml
 ```
 
-**`uv.lock` conflicts:** always resolve by deleting and regenerating:
+**`uv.lock` conflicts:** always resolve by regenerating:
 
 ```bash
-rm uv.lock
 make venv
 git add uv.lock
 ```
@@ -164,7 +152,6 @@ Merged latest main. Ready for maintainer review.
 
 Rules:
 - Omit sections that are empty (no Python entry, no GHA entry).
-- Add a PyPI note if PyPI was ahead: `Note: PyPI latest was <v>, ahead of dependabot's <v> — used <v>.`
 - If the merge resolved conflicts, add: `Note: conflicts in <files> were resolved automatically.`
 - If the branch was already up-to-date with main, omit the "Merged latest main" line.
 

--- a/.claude/skills/dependabot/SKILL.md
+++ b/.claude/skills/dependabot/SKILL.md
@@ -36,10 +36,10 @@ Extract the package name (token after "Bump", lowercased). Search `pyproject.tom
 - **indirect-python**: Python package, not found.
 - **github-actions**: owner/action pattern (e.g. `actions/checkout`).
 
-For each **direct** PR, verify the actual latest version on PyPI:
+For each **direct** PR, verify the actual latest version on PyPI. Normalize the package name first by lowercasing and replacing underscores with dashes (PyPI's canonical form):
 
 ```bash
-curl -s "https://pypi.org/pypi/<package>/json" \
+curl -s "https://pypi.org/pypi/<normalized-package>/json" \
   | python3 -c "import sys, json; d = json.load(sys.stdin); print(d['info']['version'])"
 ```
 
@@ -69,11 +69,11 @@ Build the unified change set:
 | `<owner>/<action-a>` | `v3` | `v4` | #N |
 | `<owner>/<action-b>` | `v1` | `v2` | #M |
 
-Print the full classification table and unified change set, then ask: *"Ready to process these? Any you'd like to skip?"* Wait for confirmation.
+Print the full classification table and unified change set, then ask: *"Ready to process these?"* Wait for confirmation before touching any branch.
 
 ### Step 3 — Process all PR branches
 
-Work through **every** PR (direct, indirect-python, and github-actions) one at a time using the same procedure.
+Work through **every** PR (direct, indirect-python, and github-actions) one at a time, in ascending PR number order, using the same procedure.
 
 #### 3a. Check out the branch
 
@@ -99,12 +99,14 @@ uv sync --all-groups
 
 Delete rather than relying on `uv add`'s incremental update — this produces one clean resolution after all changes are applied together. Skip this entire sub-step if the Python change set is empty.
 
+If `uv sync --all-groups` fails, check out `main`, record the failure in the running summary, notify the user inline, and continue with the next PR. Mark the branch as "failed" in the Step 4 summary table.
+
 #### 3c. Apply the GitHub Actions change set
 
 If the GHA change set is non-empty, for each entry replace the old version with the new across all workflow files:
 
 ```bash
-sed -i '' 's|<action>@<old-version>|<action>@<new-version>|g' .github/workflows/*.yml
+perl -pi -e 's|<action>@<old-version>|<action>@<new-version>|g' .github/workflows/*.yml
 ```
 
 Run for every entry. The branch's own action (if any) is already bumped by dependabot, so the sed is a no-op for it. Skip this entire sub-step if the GHA change set is empty.
@@ -118,6 +120,8 @@ git push origin <headRefName>
 ```
 
 `git add` only stages files that actually changed, so unmodified files are silently ignored. If `git commit` says "nothing to commit" (edge case), note it in the summary and continue.
+
+If any command in this step fails (commit hook error, push rejected, etc.), check out `main`, record the failure in the running summary, notify the user inline, and continue with the next PR. Mark the branch as "failed" in the Step 4 summary table.
 
 #### 3e. Post a comment
 


### PR DESCRIPTION
### Description

- Adds a new Claude Code skill (`/dependabot`) that automates the weekly dependabot PR triage: classifies each open dependabot PR as direct or indirect, bumps the version constraint in `pyproject.toml` and regenerates `uv.lock` for direct deps, and posts a status comment on each PR so the maintainer only needs to approve and merge.
- Handles this [ticket](https://github.com/orgs/EmertonData/projects/26/views/2?pane=issue&itemId=207305276)

### Noteworthy decisions

- The ticket initially mentioned automated merging. However, the agent will simply prepare the dependabot branches for merging but stops short of doing so. This task is left to maintainers but with minimal action
- A first version of the skill processed multiple dependabot PRs separately. However, upon testing, updating different packages in different branches and merging them sequentially led to conflicts. The skill has been rewritten to process only one dependabot PR at a time, the oldest one. Instructions were added to automatically resolve conflicts green-lighting the PR for approval and merging by a maintainer

### Checklist

Quality gates that must be satisfied before requesting a review:

- [x] I have read `CONTRIBUTING.md`
- [ ] `make lint` passes
- [ ] `make type-check` passes
- [ ] `make tests` passes
- [ ] `make coverage` reports 100% coverage
- [ ] `make test-notebooks` passes
- [ ] New public API has numpy-style docstrings
- [ ] New public API is inserted in the API reference section of the documentation
- [ ] Docs build without warnings (`make doc`)
- [ ] `CHANGELOG.md` updated if the change is user-facing

### LLM usage

Disclose if an LLM was used in writing this PR:
- [ ] No LLM used
- [x] I used an LLM and I went through and validated all the code myself