### PR TITLE
Extract labeled/unlabeled NaN split into method-agnostic core.py

### DIFF
--- a/glide/estimators/clustered_core.py
+++ b/glide/estimators/clustered_core.py
@@ -10,6 +10,7 @@ from glide.core.validation import (
     _validate_unique_clusters,
     _validate_y_true,
 )
+from glide.estimators.core import _split_labeled_unlabeled
 
 
 def _preprocess(
@@ -22,7 +23,7 @@ def _preprocess(
     _validate_has_no_nan(y_proxy, "y_proxy")
     _validate_has_no_nan(clusters, "clusters")
 
-    labeled_mask = ~np.isnan(y_true)
+    y_true_labeled, y_proxy_labeled, y_proxy_unlabeled, labeled_mask = _split_labeled_unlabeled(y_true, y_proxy)
     labeled_clusters = clusters[labeled_mask]
     unlabeled_clusters = clusters[~labeled_mask]
 
@@ -47,9 +48,9 @@ def _preprocess(
         error_message=f"Need at least 2 fully unlabeled clusters; got {n_unlabeled_clusters}.",
     )
 
-    labeled_true_sums = np.bincount(labeled_cluster_indices, weights=y_true[labeled_mask])
-    labeled_proxy_sums = np.bincount(labeled_cluster_indices, weights=y_proxy[labeled_mask])
-    unlabeled_proxy_sums = np.bincount(unlabeled_cluster_indices, weights=y_proxy[~labeled_mask])
+    labeled_true_sums = np.bincount(labeled_cluster_indices, weights=y_true_labeled)
+    labeled_proxy_sums = np.bincount(labeled_cluster_indices, weights=y_proxy_labeled)
+    unlabeled_proxy_sums = np.bincount(unlabeled_cluster_indices, weights=y_proxy_unlabeled)
     labeled_sizes = np.bincount(labeled_cluster_indices)
     unlabeled_sizes = np.bincount(unlabeled_cluster_indices)
 

--- a/glide/estimators/core.py
+++ b/glide/estimators/core.py
@@ -1,0 +1,12 @@
+from typing import Tuple
+
+import numpy as np
+from numpy.typing import NDArray
+
+
+def _split_labeled_unlabeled(y_true: NDArray, y_proxy: NDArray) -> Tuple[NDArray, NDArray, NDArray, NDArray]:
+    labeled_mask = ~np.isnan(y_true)
+    y_true_labeled = y_true[labeled_mask]
+    y_proxy_labeled = y_proxy[labeled_mask]
+    y_proxy_unlabeled = y_proxy[~labeled_mask]
+    return y_true_labeled, y_proxy_labeled, y_proxy_unlabeled, labeled_mask

--- a/glide/estimators/multi_ppi.py
+++ b/glide/estimators/multi_ppi.py
@@ -1,7 +1,6 @@
 from math import floor
 from typing import Tuple
 
-import numpy as np
 from numpy.typing import NDArray
 
 from glide.confidence_intervals import CLTConfidenceInterval
@@ -12,6 +11,7 @@ from glide.core.validation import (
     _validate_y_true,
 )
 from glide.estimators.classical import ClassicalMeanEstimator
+from glide.estimators.core import _split_labeled_unlabeled
 from glide.estimators.multi_ppi_core import (
     _compute_mean_estimate,
     _compute_std_estimate,
@@ -64,11 +64,10 @@ class MultiPPIMeanEstimator:
         _validate_equal_lengths(y_true_all, y_proxies_all, names=["y_true", "y_proxies"])
         _validate_y_proxies(y_proxies_all)
         _validate_y_true(y_true_all)
-        labeled_mask = ~np.isnan(y_true_all)
+        y_true, y_proxies_labeled, y_proxies_unlabeled, labeled_mask = _split_labeled_unlabeled(
+            y_true_all, y_proxies_all
+        )
         _validate_sample_sizes(labeled_mask)
-        y_true = y_true_all[labeled_mask]
-        y_proxies_labeled = y_proxies_all[labeled_mask]
-        y_proxies_unlabeled = y_proxies_all[~labeled_mask]
         return y_true, y_proxies_labeled, y_proxies_unlabeled
 
     def estimate(

--- a/glide/estimators/ppi.py
+++ b/glide/estimators/ppi.py
@@ -1,7 +1,6 @@
 from math import floor
 from typing import Tuple
 
-import numpy as np
 from numpy.typing import NDArray
 
 from glide.confidence_intervals import CLTConfidenceInterval
@@ -12,6 +11,7 @@ from glide.core.validation import (
     _validate_y_true,
 )
 from glide.estimators.classical import ClassicalMeanEstimator
+from glide.estimators.core import _split_labeled_unlabeled
 from glide.estimators.ppi_core import (
     _compute_mean_estimate,
     _compute_std_estimate,
@@ -59,11 +59,8 @@ class PPIMeanEstimator:
         _validate_equal_lengths(y_true_all, y_proxy_all, names=["y_true", "y_proxy"])
         _validate_y_proxy(y_proxy_all)
         _validate_y_true(y_true_all)
-        labeled_mask = ~np.isnan(y_true_all)
+        y_true, y_proxy_labeled, y_proxy_unlabeled, labeled_mask = _split_labeled_unlabeled(y_true_all, y_proxy_all)
         _validate_sample_sizes(labeled_mask)
-        y_true = y_true_all[labeled_mask]
-        y_proxy_labeled = y_proxy_all[labeled_mask]
-        y_proxy_unlabeled = y_proxy_all[~labeled_mask]
         return y_true, y_proxy_labeled, y_proxy_unlabeled
 
     def estimate(

--- a/glide/estimators/ptd.py
+++ b/glide/estimators/ptd.py
@@ -12,6 +12,7 @@ from glide.core.validation import (
     _validate_y_true,
 )
 from glide.estimators.classical import ClassicalMeanEstimator
+from glide.estimators.core import _split_labeled_unlabeled
 from glide.estimators.ptd_core import (
     _compute_bootstrap_labeled_means,
     _compute_bootstrap_mean_estimates,
@@ -63,11 +64,8 @@ class PTDMeanEstimator:
         _validate_equal_lengths(y_true_all, y_proxy_all, names=["y_true", "y_proxy"])
         _validate_y_proxy(y_proxy_all)
         _validate_y_true(y_true_all)
-        labeled_mask = ~np.isnan(y_true_all)
+        y_true, y_proxy_labeled, y_proxy_unlabeled, labeled_mask = _split_labeled_unlabeled(y_true_all, y_proxy_all)
         _validate_sample_sizes(labeled_mask)
-        y_true = y_true_all[labeled_mask]
-        y_proxy_labeled = y_proxy_all[labeled_mask]
-        y_proxy_unlabeled = y_proxy_all[~labeled_mask]
         return y_true, y_proxy_labeled, y_proxy_unlabeled
 
     def estimate(

--- a/glide/estimators/stratified_core.py
+++ b/glide/estimators/stratified_core.py
@@ -28,10 +28,10 @@ def _preprocess(
         stratum_mask = groups == stratum_id
         stratum_y_true = y_true[stratum_mask]
         stratum_y_proxy = y_proxy[stratum_mask]
+        _validate_y_proxy(stratum_y_proxy, stratum_id)
         y_true_filtered, y_proxy_labeled, y_proxy_unlabeled, labeled_mask = _split_labeled_unlabeled(
             stratum_y_true, stratum_y_proxy
         )
-        _validate_y_proxy(stratum_y_proxy, stratum_id)
         _validate_sample_sizes(labeled_mask, stratum_id)
         strata.append((y_true_filtered, y_proxy_labeled, y_proxy_unlabeled))
 

--- a/glide/estimators/stratified_core.py
+++ b/glide/estimators/stratified_core.py
@@ -10,6 +10,7 @@ from glide.core.validation import (
     _validate_y_proxy,
     _validate_y_true,
 )
+from glide.estimators.core import _split_labeled_unlabeled
 
 
 def _preprocess(
@@ -27,12 +28,11 @@ def _preprocess(
         stratum_mask = groups == stratum_id
         stratum_y_true = y_true[stratum_mask]
         stratum_y_proxy = y_proxy[stratum_mask]
-        labeled_mask = ~np.isnan(stratum_y_true)
+        y_true_filtered, y_proxy_labeled, y_proxy_unlabeled, labeled_mask = _split_labeled_unlabeled(
+            stratum_y_true, stratum_y_proxy
+        )
         _validate_y_proxy(stratum_y_proxy, stratum_id)
         _validate_sample_sizes(labeled_mask, stratum_id)
-        y_true_filtered = stratum_y_true[labeled_mask]
-        y_proxy_labeled = stratum_y_proxy[labeled_mask]
-        y_proxy_unlabeled = stratum_y_proxy[~labeled_mask]
         strata.append((y_true_filtered, y_proxy_labeled, y_proxy_unlabeled))
 
     return strata

--- a/tests/unit/estimators/test_clustered_core.py
+++ b/tests/unit/estimators/test_clustered_core.py
@@ -27,13 +27,21 @@ def clusters() -> NDArray:
 
 
 def test_preprocess_delegates_to_validation(y_true, y_proxy, clusters):
+    labeled_mask = np.array([True, False, True, False])
     with (
         patch.object(clustered_core_module, "_validate_equal_lengths") as mock_validate_equal_lengths,
         patch.object(clustered_core_module, "_validate_y_true") as mock_validate_y_true,
         patch.object(clustered_core_module, "_validate_has_no_nan") as mock_validate_has_no_nan,
+        patch.object(clustered_core_module, "_split_labeled_unlabeled") as mock_split_labeled_unlabeled,
         patch.object(clustered_core_module, "_validate_unique_clusters") as mock_validate_unique_clusters,
         patch.object(clustered_core_module, "_validate_bounds") as mock_validate_bounds,
     ):
+        mock_split_labeled_unlabeled.return_value = (
+            np.array([4.0, 6.0]),
+            np.array([2.0, 6.0]),
+            np.array([4.0, 6.0]),
+            labeled_mask,
+        )
         _preprocess(y_true, y_proxy, clusters)
 
         mock_validate_equal_lengths.assert_called_once()
@@ -50,6 +58,10 @@ def test_preprocess_delegates_to_validation(y_true, y_proxy, clusters):
         assert mock_validate_has_no_nan.call_args_list[0][0][1] == "y_proxy"
         np.testing.assert_array_equal(mock_validate_has_no_nan.call_args_list[1][0][0], clusters)
         assert mock_validate_has_no_nan.call_args_list[1][0][1] == "clusters"
+
+        mock_split_labeled_unlabeled.assert_called_once()
+        np.testing.assert_array_equal(mock_split_labeled_unlabeled.call_args[0][0], y_true)
+        np.testing.assert_array_equal(mock_split_labeled_unlabeled.call_args[0][1], y_proxy)
 
         mock_validate_unique_clusters.assert_called_once()
         np.testing.assert_array_equal(mock_validate_unique_clusters.call_args[0][0], np.array(["A", "C"]))

--- a/tests/unit/estimators/test_clustered_core.py
+++ b/tests/unit/estimators/test_clustered_core.py
@@ -26,7 +26,7 @@ def clusters() -> NDArray:
 # --- _preprocess ---
 
 
-def test_preprocess_delegates_to_validation(y_true, y_proxy, clusters):
+def test_preprocess_delegates(y_true, y_proxy, clusters):
     labeled_mask = np.array([True, False, True, False])
     with (
         patch.object(clustered_core_module, "_validate_equal_lengths") as mock_validate_equal_lengths,

--- a/tests/unit/estimators/test_core.py
+++ b/tests/unit/estimators/test_core.py
@@ -13,3 +13,15 @@ def test_split_labeled_unlabeled():
     np.testing.assert_array_equal(y_proxy_labeled, np.array([0.9, 2.1]))
     np.testing.assert_array_equal(y_proxy_unlabeled, np.array([1.1, 3.0]))
     np.testing.assert_array_equal(labeled_mask, np.array([True, False, True, False]))
+
+
+def test_split_labeled_unlabeled_2d_y_proxy():
+    y_true = np.array([1.0, np.nan, 2.0, np.nan])
+    y_proxy = np.array([[0.9, 0.8], [1.1, 1.2], [2.1, 2.2], [3.0, 3.1]])
+
+    y_true_labeled, y_proxy_labeled, y_proxy_unlabeled, labeled_mask = _split_labeled_unlabeled(y_true, y_proxy)
+
+    np.testing.assert_array_equal(y_true_labeled, np.array([1.0, 2.0]))
+    np.testing.assert_array_equal(y_proxy_labeled, np.array([[0.9, 0.8], [2.1, 2.2]]))
+    np.testing.assert_array_equal(y_proxy_unlabeled, np.array([[1.1, 1.2], [3.0, 3.1]]))
+    np.testing.assert_array_equal(labeled_mask, np.array([True, False, True, False]))

--- a/tests/unit/estimators/test_core.py
+++ b/tests/unit/estimators/test_core.py
@@ -1,0 +1,15 @@
+import numpy as np
+
+from glide.estimators.core import _split_labeled_unlabeled
+
+
+def test_split_labeled_unlabeled():
+    y_true = np.array([1.0, np.nan, 2.0, np.nan])
+    y_proxy = np.array([0.9, 1.1, 2.1, 3.0])
+
+    y_true_labeled, y_proxy_labeled, y_proxy_unlabeled, labeled_mask = _split_labeled_unlabeled(y_true, y_proxy)
+
+    np.testing.assert_array_equal(y_true_labeled, np.array([1.0, 2.0]))
+    np.testing.assert_array_equal(y_proxy_labeled, np.array([0.9, 2.1]))
+    np.testing.assert_array_equal(y_proxy_unlabeled, np.array([1.1, 3.0]))
+    np.testing.assert_array_equal(labeled_mask, np.array([True, False, True, False]))

--- a/tests/unit/estimators/test_multi_ppi.py
+++ b/tests/unit/estimators/test_multi_ppi.py
@@ -30,20 +30,30 @@ def estimator() -> MultiPPIMeanEstimator:
 
 def test_preprocess_delegates_to_validation(estimator, y_arrays):
     y_true, y_proxies = y_arrays
+    labeled_mask = np.array([True, True, False, False])
     with (
         patch.object(multi_ppi_module, "_validate_equal_lengths") as mock_validate_equal_lengths,
         patch.object(multi_ppi_module, "_validate_y_proxies") as mock_validate_y_proxies,
         patch.object(multi_ppi_module, "_validate_y_true") as mock_validate_y_true,
+        patch.object(multi_ppi_module, "_split_labeled_unlabeled") as mock_split_labeled_unlabeled,
         patch.object(multi_ppi_module, "_validate_sample_sizes") as mock_validate_sample_sizes,
     ):
+        mock_split_labeled_unlabeled.return_value = (
+            np.array([1.0, 2.0]),
+            np.array([[1.0, 0.0], [2.0, 2.0]]),
+            np.array([[3.0, 1.0], [4.0, 3.0]]),
+            labeled_mask,
+        )
         estimator._preprocess(y_true, y_proxies)
 
         mock_validate_equal_lengths.assert_called_once_with(y_true, y_proxies, names=["y_true", "y_proxies"])
         mock_validate_y_proxies.assert_called_once_with(y_proxies)
         mock_validate_y_true.assert_called_once_with(y_true)
+        mock_split_labeled_unlabeled.assert_called_once()
+        np.testing.assert_array_equal(mock_split_labeled_unlabeled.call_args[0][0], y_true)
+        np.testing.assert_array_equal(mock_split_labeled_unlabeled.call_args[0][1], y_proxies)
         mock_validate_sample_sizes.assert_called_once()
-        labeled_mask_arg = mock_validate_sample_sizes.call_args[0][0]
-        np.testing.assert_array_equal(labeled_mask_arg, np.array([True, True, False, False]))
+        np.testing.assert_array_equal(mock_validate_sample_sizes.call_args[0][0], labeled_mask)
 
 
 def test_preprocess_valid_output(estimator, y_arrays):

--- a/tests/unit/estimators/test_multi_ppi.py
+++ b/tests/unit/estimators/test_multi_ppi.py
@@ -28,7 +28,7 @@ def estimator() -> MultiPPIMeanEstimator:
 # --- _preprocess ---
 
 
-def test_preprocess_delegates_to_validation(estimator, y_arrays):
+def test_preprocess_delegates(estimator, y_arrays):
     y_true, y_proxies = y_arrays
     labeled_mask = np.array([True, True, False, False])
     with (

--- a/tests/unit/estimators/test_ppi.py
+++ b/tests/unit/estimators/test_ppi.py
@@ -28,7 +28,7 @@ def estimator() -> PPIMeanEstimator:
 # --- _preprocess ---
 
 
-def test_preprocess_delegates_to_validation(estimator, y_arrays):
+def test_preprocess_delegates(estimator, y_arrays):
     y_true, y_proxy = y_arrays
     labeled_mask = np.array([True, True, False, False])
     with (

--- a/tests/unit/estimators/test_ppi.py
+++ b/tests/unit/estimators/test_ppi.py
@@ -30,20 +30,30 @@ def estimator() -> PPIMeanEstimator:
 
 def test_preprocess_delegates_to_validation(estimator, y_arrays):
     y_true, y_proxy = y_arrays
+    labeled_mask = np.array([True, True, False, False])
     with (
         patch.object(ppi_module, "_validate_equal_lengths") as mock_validate_equal_lengths,
         patch.object(ppi_module, "_validate_y_proxy") as mock_validate_y_proxy,
         patch.object(ppi_module, "_validate_y_true") as mock_validate_y_true,
+        patch.object(ppi_module, "_split_labeled_unlabeled") as mock_split_labeled_unlabeled,
         patch.object(ppi_module, "_validate_sample_sizes") as mock_validate_sample_sizes,
     ):
+        mock_split_labeled_unlabeled.return_value = (
+            np.array([1.0, 2.0]),
+            np.array([1.0, 2.0]),
+            np.array([3.0, 4.0]),
+            labeled_mask,
+        )
         estimator._preprocess(y_true, y_proxy)
 
         mock_validate_equal_lengths.assert_called_once_with(y_true, y_proxy, names=["y_true", "y_proxy"])
         mock_validate_y_proxy.assert_called_once_with(y_proxy)
         mock_validate_y_true.assert_called_once_with(y_true)
+        mock_split_labeled_unlabeled.assert_called_once()
+        np.testing.assert_array_equal(mock_split_labeled_unlabeled.call_args[0][0], y_true)
+        np.testing.assert_array_equal(mock_split_labeled_unlabeled.call_args[0][1], y_proxy)
         mock_validate_sample_sizes.assert_called_once()
-        labeled_mask_arg = mock_validate_sample_sizes.call_args[0][0]
-        np.testing.assert_array_equal(labeled_mask_arg, np.array([True, True, False, False]))
+        np.testing.assert_array_equal(mock_validate_sample_sizes.call_args[0][0], labeled_mask)
 
 
 def test_preprocess_valid_output(estimator, y_arrays):

--- a/tests/unit/estimators/test_ptd.py
+++ b/tests/unit/estimators/test_ptd.py
@@ -37,7 +37,7 @@ def test_preprocess_valid_output(estimator, y_arrays):
     assert not np.any(np.isnan(y_true))
 
 
-def test_preprocess_delegates_to_validation(estimator):
+def test_preprocess_delegates(estimator):
     y_true = np.array([1.0, 2.0, np.nan, np.nan])
     y_proxy = np.array([1.0, 2.0, 3.0, 4.0])
     labeled_mask = np.array([True, True, False, False])

--- a/tests/unit/estimators/test_ptd.py
+++ b/tests/unit/estimators/test_ptd.py
@@ -40,21 +40,31 @@ def test_preprocess_valid_output(estimator, y_arrays):
 def test_preprocess_delegates_to_validation(estimator):
     y_true = np.array([1.0, 2.0, np.nan, np.nan])
     y_proxy = np.array([1.0, 2.0, 3.0, 4.0])
+    labeled_mask = np.array([True, True, False, False])
 
     with (
         patch.object(ptd_module, "_validate_equal_lengths") as mock_validate_equal_lengths,
         patch.object(ptd_module, "_validate_y_proxy") as mock_validate_y_proxy,
         patch.object(ptd_module, "_validate_y_true") as mock_validate_y_true,
+        patch.object(ptd_module, "_split_labeled_unlabeled") as mock_split_labeled_unlabeled,
         patch.object(ptd_module, "_validate_sample_sizes") as mock_validate_sample_sizes,
     ):
+        mock_split_labeled_unlabeled.return_value = (
+            np.array([1.0, 2.0]),
+            np.array([1.0, 2.0]),
+            np.array([3.0, 4.0]),
+            labeled_mask,
+        )
         estimator._preprocess(y_true, y_proxy)
 
         mock_validate_equal_lengths.assert_called_once_with(y_true, y_proxy, names=["y_true", "y_proxy"])
         mock_validate_y_proxy.assert_called_once_with(y_proxy)
         mock_validate_y_true.assert_called_once_with(y_true)
+        mock_split_labeled_unlabeled.assert_called_once()
+        np.testing.assert_array_equal(mock_split_labeled_unlabeled.call_args[0][0], y_true)
+        np.testing.assert_array_equal(mock_split_labeled_unlabeled.call_args[0][1], y_proxy)
         mock_validate_sample_sizes.assert_called_once()
-        labeled_mask_arg = mock_validate_sample_sizes.call_args[0][0]
-        np.testing.assert_array_equal(labeled_mask_arg, np.array([True, True, False, False]))
+        np.testing.assert_array_equal(mock_validate_sample_sizes.call_args[0][0], labeled_mask)
 
 
 # ── estimate ──────────────────────────────────────────────────────────────────

--- a/tests/unit/estimators/test_stratified_core.py
+++ b/tests/unit/estimators/test_stratified_core.py
@@ -23,7 +23,7 @@ def groups():
 
 
 # --- _preprocess ---
-def test_preprocess_delegates_to_validation(y_true, y_proxy, groups):
+def test_preprocess_delegates(y_true, y_proxy, groups):
     with (
         patch.object(stratified_core_module, "_validate_has_no_nan") as mock_validate_has_no_nan,
         patch.object(stratified_core_module, "_validate_equal_lengths") as mock_validate_equal_lengths,

--- a/tests/unit/estimators/test_stratified_core.py
+++ b/tests/unit/estimators/test_stratified_core.py
@@ -28,8 +28,15 @@ def test_preprocess_delegates_to_validation(y_true, y_proxy, groups):
         patch.object(stratified_core_module, "_validate_has_no_nan") as mock_validate_has_no_nan,
         patch.object(stratified_core_module, "_validate_equal_lengths") as mock_validate_equal_lengths,
         patch.object(stratified_core_module, "_validate_y_proxy") as mock_validate_y_proxy,
+        patch.object(stratified_core_module, "_split_labeled_unlabeled") as mock_split_labeled_unlabeled,
         patch.object(stratified_core_module, "_validate_sample_sizes") as mock_validate_sample_sizes,
     ):
+        mock_split_labeled_unlabeled.return_value = (
+            np.array([5.0, 6.0]),
+            np.array([4.9, 6.1]),
+            np.array([5.2, 6.1]),
+            np.array([True, True, False, False]),
+        )
         _preprocess(y_true, y_proxy, groups)
 
         mock_validate_has_no_nan.assert_called_once()
@@ -48,6 +55,12 @@ def test_preprocess_delegates_to_validation(y_true, y_proxy, groups):
         y_proxy_b = y_proxy[groups == "B"]
         np.testing.assert_array_equal(mock_validate_y_proxy.call_args_list[2][0][0], y_proxy_b)
         assert mock_validate_y_proxy.call_args_list[2][0][1] == "B"
+
+        assert mock_split_labeled_unlabeled.call_count == 2
+        np.testing.assert_array_equal(mock_split_labeled_unlabeled.call_args_list[0][0][0], y_true[groups == "A"])
+        np.testing.assert_array_equal(mock_split_labeled_unlabeled.call_args_list[0][0][1], y_proxy[groups == "A"])
+        np.testing.assert_array_equal(mock_split_labeled_unlabeled.call_args_list[1][0][0], y_true[groups == "B"])
+        np.testing.assert_array_equal(mock_split_labeled_unlabeled.call_args_list[1][0][1], y_proxy[groups == "B"])
 
         assert mock_validate_sample_sizes.call_count == 2
         labeled_mask_a = ~np.isnan(y_true[groups == "A"])

--- a/tests/unit/estimators/test_stratified_core.py
+++ b/tests/unit/estimators/test_stratified_core.py
@@ -43,9 +43,11 @@ def test_preprocess_delegates_to_validation(y_true, y_proxy, groups):
         np.testing.assert_array_equal(mock_validate_has_no_nan.call_args[0][0], groups)
         assert mock_validate_has_no_nan.call_args[0][1] == "groups"
 
-        mock_validate_equal_lengths.assert_called_once_with(
-            y_true, y_proxy, groups, names=["y_true", "y_proxy", "groups"]
-        )
+        mock_validate_equal_lengths.assert_called_once()
+        np.testing.assert_array_equal(mock_validate_equal_lengths.call_args[0][0], y_true)
+        np.testing.assert_array_equal(mock_validate_equal_lengths.call_args[0][1], y_proxy)
+        np.testing.assert_array_equal(mock_validate_equal_lengths.call_args[0][2], groups)
+        assert mock_validate_equal_lengths.call_args[1]["names"] == ["y_true", "y_proxy", "groups"]
 
         assert mock_validate_y_proxy.call_count == 3
         np.testing.assert_array_equal(mock_validate_y_proxy.call_args_list[0][0][0], y_proxy)


### PR DESCRIPTION
### Description

- Extracts the repeated NaN-based labeled/unlabeled split (`labeled_mask = ~np.isnan(y_true)`) from `PPIMeanEstimator._preprocess`, `PTDMeanEstimator._preprocess`, and `stratified_core._preprocess` into a single shared helper `_split_labeled_unlabeled` in a new `glide/estimators/core.py`. The helper was also propagated to `MultiPPIMeanEstimator` and `ClusteredPPIMeanEstimator` (via `clustered_core.py`), and delegation tests were added for all call sites.
- Closes #312

### Checklist

Quality gates that must be satisfied before requesting a review:

- [x] I have read `CONTRIBUTING.md`
- [x] `make lint` passes
- [x] `make type-check` passes
- [x] `make tests` passes
- [x] `make coverage` reports 100% coverage
- [x] `make test-notebooks` passes
- [ ] New public API has numpy-style docstrings
- [ ] New public API is inserted in the API reference section of the documentation
- [ ] Docs build without warnings (`make doc`)
- [ ] `CHANGELOG.md` updated if the change is user-facing

### LLM usage

Disclose if an LLM was used in writing this PR:
- [ ] No LLM used
- [x] I used an LLM and I went through and validated all the code myself