### PR TITLE
Add empirical-Bernstein confidence sequence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ## [Next release]
 
 ### ✨ Added
-- `glide.confidence_sequences` package with the `ConfidenceSequence` protocol and `EmpiricalBernsteinConfidenceSequence`: an anytime-valid empirical-Bernstein confidence sequence.
+- `glide.confidence_sequences` module with the `ConfidenceSequence` protocol and `EmpiricalBernsteinConfidenceSequence`: an anytime-valid empirical-Bernstein confidence sequence.
 - GitHub Pages landing page at [emertondata.github.io/glide](https://emertondata.github.io/glide).
 
 ### 🔄 Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ## [Next release]
 
 ### ✨ Added
+- `glide.confidence_sequences` package with the `ConfidenceSequence` protocol and `EmpiricalBernsteinConfidenceSequence`: an anytime-valid empirical-Bernstein confidence sequence.
 - GitHub Pages landing page at [emertondata.github.io/glide](https://emertondata.github.io/glide).
 
 ### 🔄 Changed

--- a/docs/api/confidence_sequences.md
+++ b/docs/api/confidence_sequences.md
@@ -1,0 +1,4 @@
+# Confidence Sequences
+
+::: glide.confidence_sequences.empirical_bernstein.EmpiricalBernsteinConfidenceSequence
+

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -55,6 +55,12 @@
 | [`CLTConfidenceInterval`](confidence_intervals.md#glide.confidence_intervals.clt.CLTConfidenceInterval) | CLT-based normal approximation confidence intervals |
 | [`BootstrapConfidenceInterval`](confidence_intervals.md#glide.confidence_intervals.bootstrap.BootstrapConfidenceInterval) | Quantile-based bootstrap confidence intervals |
 
+## Confidence Sequences
+
+| Class | Description |
+|-------|-------------|
+| [`EmpiricalBernsteinConfidenceSequence`](confidence_sequences.md#glide.confidence_sequences.empirical_bernstein.EmpiricalBernsteinConfidenceSequence) | Anytime-valid empirical-Bernstein confidence sequence |
+
 ## Inference Results
 
 | Class | Description |

--- a/glide/confidence_sequences/__init__.py
+++ b/glide/confidence_sequences/__init__.py
@@ -1,0 +1,7 @@
+from glide.confidence_sequences.base import ConfidenceSequence
+from glide.confidence_sequences.empirical_bernstein import EmpiricalBernsteinConfidenceSequence
+
+__all__ = [
+    "ConfidenceSequence",
+    "EmpiricalBernsteinConfidenceSequence",
+]

--- a/glide/confidence_sequences/base.py
+++ b/glide/confidence_sequences/base.py
@@ -1,0 +1,28 @@
+from typing import Literal, Protocol
+
+from numpy.typing import NDArray
+
+
+class ConfidenceSequence(Protocol):
+    """Structural protocol for anytime-valid confidence sequences.
+
+    The time-uniform analogue of :class:`ConfidenceInterval`: instead of a single
+    bound it carries a bound per look (one per batch), valid simultaneously at all
+    looks. Any class implementing this protocol can be used as a
+    ``confidence_sequence`` in result objects like ``MeanMonitoringResult``.
+    """
+
+    running_mean_estimates: NDArray
+    confidence_bounds: NDArray
+
+    def test_null_hypothesis(
+        self,
+        h0_value: float,
+        alternative: Literal["larger", "smaller"] = "larger",
+    ) -> NDArray:
+        """Test the running mean against a value at every look.
+
+        Returns the boolean per-look alarm vector, with time-uniform family-wise
+        error control over all looks.
+        """
+        ...

--- a/glide/confidence_sequences/empirical_bernstein.py
+++ b/glide/confidence_sequences/empirical_bernstein.py
@@ -1,0 +1,133 @@
+from dataclasses import dataclass
+from typing import Literal, Tuple
+
+import numpy as np
+from numpy.typing import NDArray
+from scipy.integrate import quad
+from scipy.optimize import brentq
+
+from glide.core.validation import _validate_literal
+
+
+def _compute_mixture_wealth(deviation: float, variance_process: float) -> float:
+    # ψ_E(β) = −log(1−β) − β is the cumulant of the exponential-family mixture.
+    def integrand(betting_parameter: float) -> float:
+        psi_exponential = -np.log1p(-betting_parameter) - betting_parameter
+        value = np.exp(betting_parameter * deviation - psi_exponential * variance_process)
+        return value
+
+    integral, _ = quad(integrand, 0.0, 1.0)
+    return integral
+
+
+def _compute_mixture_boundary(variance_process: float, miscoverage: float) -> float:
+    wealth_target = 1.0 / miscoverage
+
+    def excess_wealth(deviation: float) -> float:
+        value = _compute_mixture_wealth(deviation, variance_process) - wealth_target
+        return value
+
+    # No fixed upper bracket works because the root grows with variance_process and
+    # 1/miscoverage; double until excess_wealth turns non-negative.
+    upper_bracket = 1.0
+    while excess_wealth(upper_bracket) < 0.0:
+        upper_bracket *= 2.0
+    boundary = brentq(excess_wealth, 0.0, upper_bracket)
+    return boundary
+
+
+def _compute_empirical_bernstein_bounds(
+    batch_estimates: NDArray,
+    seed_center: float,
+    miscoverage: float,
+) -> Tuple[NDArray, NDArray]:
+    n_batches = len(batch_estimates)
+    batch_counts = np.arange(1, n_batches + 1)
+    running_mean_estimates = np.cumsum(batch_estimates) / batch_counts
+    # Centers must be predictable (known before each batch arrives): use the previous
+    # running mean, seeded with seed_center before the first batch.
+    predictable_centers = np.hstack([np.array([seed_center]), running_mean_estimates[:-1]])
+    variance_process = np.cumsum((batch_estimates - predictable_centers) ** 2)
+    boundaries = np.array([_compute_mixture_boundary(value, miscoverage) for value in variance_process])
+    lower_bounds = running_mean_estimates - boundaries / batch_counts
+    return running_mean_estimates, lower_bounds
+
+
+@dataclass
+class EmpiricalBernsteinConfidenceSequence:
+    """Anytime-valid empirical-Bernstein confidence sequence on a running mean.
+
+    Holds the per-look running means and the one-sided anytime-valid bound on the
+    side where drift is harmful (a lower bound for a risk, an upper bound for a
+    performance, after the monitor has mapped the sequence back to the original
+    metric orientation). The bounds hold simultaneously at all looks, so testing
+    after every batch does not inflate the false-alarm probability.
+
+    Parameters
+    ----------
+    running_mean_estimates : NDArray
+        Per-look running mean of the per-batch estimates, in original metric units.
+    confidence_bounds : NDArray
+        Per-look harmful-side anytime-valid bound, in original metric units.
+
+    References
+    ----------
+    Waudby-Smith, Ian, and Aaditya Ramdas. "Estimating means of bounded random
+    variables by betting." Journal of the Royal Statistical Society Series B:
+    Statistical Methodology 86, no. 1 (2024): 1-27.
+
+    Howard, Steven R., Aaditya Ramdas, Jon McAuliffe, and Jasjeet Sekhon. "Time-uniform,
+    nonparametric, nonasymptotic confidence sequences." The Annals of Statistics 49,
+    no. 2 (2021): 1055-1080.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from glide.confidence_sequences import EmpiricalBernsteinConfidenceSequence
+    >>> sequence = EmpiricalBernsteinConfidenceSequence(
+    ...     running_mean_estimates=np.array([0.4, 0.6]),
+    ...     confidence_bounds=np.array([0.1, 0.55]),
+    ... )
+    >>> sequence.test_null_hypothesis(0.5, alternative="larger")
+    array([False,  True])
+    """
+
+    running_mean_estimates: NDArray
+    confidence_bounds: NDArray
+
+    def test_null_hypothesis(
+        self,
+        h0_value: float,
+        alternative: Literal["larger", "smaller"] = "larger",
+    ) -> NDArray:
+        """Test the running mean against ``h0_value`` at every look.
+
+        Parameters
+        ----------
+        h0_value : float
+            The threshold the harmful-side bound is tested against (for a monitor,
+            the user-supplied business threshold).
+        alternative : str, optional
+            ``'larger'`` (default) when the metric is a risk: alarm where the lower
+            bound exceeds ``h0_value``. ``'smaller'`` when it is a performance: alarm
+            where the upper bound falls below ``h0_value``. A confidence sequence is
+            one-sided, so ``'two-sided'`` is not accepted.
+
+        Returns
+        -------
+        NDArray
+            Boolean per-look alarm vector, ``True`` once the bound has crossed
+            ``h0_value``. Time-uniform family-wise error is controlled over all looks.
+
+        Raises
+        ------
+        ValueError
+            If ``alternative`` is not ``'larger'`` or ``'smaller'``.
+        """
+        alternatives = ["larger", "smaller"]
+        _validate_literal(alternative, "alternative", alternatives)
+        if alternative == alternatives[0]:
+            alarms = self.confidence_bounds > h0_value
+        else:
+            alarms = self.confidence_bounds < h0_value
+        return alarms

--- a/glide/confidence_sequences/empirical_bernstein.py
+++ b/glide/confidence_sequences/empirical_bernstein.py
@@ -10,7 +10,6 @@ from glide.core.validation import _validate_bounds, _validate_literal
 
 
 def _compute_mixture_wealth(deviation: float, variance_process_value: float) -> float:
-    # ψ_E(β) = −log(1−β) − β is the cumulant of the exponential-family mixture.
     def integrand(betting_parameter: float) -> float:
         psi_exponential = -np.log(1 - betting_parameter) - betting_parameter
         value = np.exp(betting_parameter * deviation - psi_exponential * variance_process_value)
@@ -27,8 +26,6 @@ def _compute_mixture_boundary(variance_process_value: float, miscoverage: float)
         value = _compute_mixture_wealth(deviation, variance_process_value) - wealth_target
         return value
 
-    # No fixed upper bracket works because the root grows with variance_process_value and
-    # 1/miscoverage; double until excess_wealth turns non-negative.
     upper_bracket = 1.0
     while excess_wealth(upper_bracket) < 0.0:
         upper_bracket *= 2.0
@@ -45,8 +42,6 @@ def _compute_empirical_bernstein_bounds(
     n_batches = len(batch_estimates)
     batch_counts = np.arange(1, n_batches + 1)
     running_mean_estimates = np.cumsum(batch_estimates) / batch_counts
-    # Centers must be predictable (known before each batch arrives): use the previous
-    # running mean, seeded with seed_center before the first batch.
     predictable_centers = np.hstack([np.array([seed_center]), running_mean_estimates[:-1]])
     variance_process = np.cumsum((batch_estimates - predictable_centers) ** 2)
     boundaries = np.array([_compute_mixture_boundary(value, miscoverage) for value in variance_process])

--- a/glide/confidence_sequences/empirical_bernstein.py
+++ b/glide/confidence_sequences/empirical_bernstein.py
@@ -6,7 +6,7 @@ from numpy.typing import NDArray
 from scipy.integrate import quad
 from scipy.optimize import brentq
 
-from glide.core.validation import _validate_literal
+from glide.core.validation import _validate_bounds, _validate_literal
 
 
 def _compute_mixture_wealth(deviation: float, variance_process_value: float) -> float:
@@ -41,6 +41,7 @@ def _compute_empirical_bernstein_bounds(
     seed_center: float,
     miscoverage: float,
 ) -> Tuple[NDArray, NDArray]:
+    _validate_bounds(miscoverage, "miscoverage", lower=0.0, upper=1.0, left_inclusive=False, right_inclusive=False)
     n_batches = len(batch_estimates)
     batch_counts = np.arange(1, n_batches + 1)
     running_mean_estimates = np.cumsum(batch_estimates) / batch_counts

--- a/glide/confidence_sequences/empirical_bernstein.py
+++ b/glide/confidence_sequences/empirical_bernstein.py
@@ -9,25 +9,25 @@ from scipy.optimize import brentq
 from glide.core.validation import _validate_literal
 
 
-def _compute_mixture_wealth(deviation: float, variance_process: float) -> float:
+def _compute_mixture_wealth(deviation: float, variance_process_value: float) -> float:
     # ψ_E(β) = −log(1−β) − β is the cumulant of the exponential-family mixture.
     def integrand(betting_parameter: float) -> float:
-        psi_exponential = -np.log1p(-betting_parameter) - betting_parameter
-        value = np.exp(betting_parameter * deviation - psi_exponential * variance_process)
+        psi_exponential = -np.log(1 - betting_parameter) - betting_parameter
+        value = np.exp(betting_parameter * deviation - psi_exponential * variance_process_value)
         return value
 
     integral, _ = quad(integrand, 0.0, 1.0)
     return integral
 
 
-def _compute_mixture_boundary(variance_process: float, miscoverage: float) -> float:
+def _compute_mixture_boundary(variance_process_value: float, miscoverage: float) -> float:
     wealth_target = 1.0 / miscoverage
 
     def excess_wealth(deviation: float) -> float:
-        value = _compute_mixture_wealth(deviation, variance_process) - wealth_target
+        value = _compute_mixture_wealth(deviation, variance_process_value) - wealth_target
         return value
 
-    # No fixed upper bracket works because the root grows with variance_process and
+    # No fixed upper bracket works because the root grows with variance_process_value and
     # 1/miscoverage; double until excess_wealth turns non-negative.
     upper_bracket = 1.0
     while excess_wealth(upper_bracket) < 0.0:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -112,6 +112,7 @@ nav:
     - Samplers: api/samplers.md
     - Estimators: api/estimators.md
     - Confidence Intervals: api/confidence_intervals.md
+    - Confidence Sequences: api/confidence_sequences.md
     - Inference Results: api/mean_inference_results.md
     - Scientific Validation: api/scientific_validation.md
     - I/O: api/io.md

--- a/tests/unit/confidence_intervals/test_bootstrap.py
+++ b/tests/unit/confidence_intervals/test_bootstrap.py
@@ -1,6 +1,9 @@
+from unittest.mock import patch
+
 import numpy as np
 import pytest
 
+import glide.confidence_intervals.bootstrap as bootstrap_module
 from glide.confidence_intervals import BootstrapConfidenceInterval
 
 
@@ -68,6 +71,14 @@ def test_bounds_change_with_confidence_level(estimates):
 # --- test_null_hypothesis ---
 
 
+def test_null_hypothesis_delegates_to_validation(estimates):
+    ci = BootstrapConfidenceInterval(bootstrap_estimates=estimates)
+    with patch.object(bootstrap_module, "_validate_literal") as mock_validate_literal:
+        ci.test_null_hypothesis(h0_value=0.0, alternative="larger")
+
+        mock_validate_literal.assert_called_once_with("larger", "alternative", ["two-sided", "larger", "smaller"])
+
+
 def test_null_hypothesis_null_is_true(estimates):
     ci = BootstrapConfidenceInterval(bootstrap_estimates=estimates)
     _, p_value, df = ci.test_null_hypothesis(h0_value=2.25)
@@ -97,9 +108,3 @@ def test_null_hypothesis_smaller(estimates):
     expected_p = 0.4
     assert p_value == pytest.approx(expected_p, abs=0.001)
     assert df == float("inf")
-
-
-def test_null_hypothesis_invalid_alternative(estimates):
-    ci = BootstrapConfidenceInterval(bootstrap_estimates=estimates)
-    with pytest.raises(ValueError, match="'alternative' must be 'two-sided', 'larger', or 'smaller'"):
-        ci.test_null_hypothesis(h0_value=0.0, alternative="invalid")  # ty: ignore

--- a/tests/unit/confidence_intervals/test_clt.py
+++ b/tests/unit/confidence_intervals/test_clt.py
@@ -1,5 +1,8 @@
+from unittest.mock import patch
+
 import pytest
 
+import glide.confidence_intervals.clt as clt_module
 from glide.confidence_intervals import CLTConfidenceInterval
 
 
@@ -52,6 +55,14 @@ def test_bounds_change_with_confidence_level():
 # --- test_null_hypothesis ---
 
 
+def test_null_hypothesis_delegates_to_validation():
+    ci = CLTConfidenceInterval(mean=0.0, std=1.0)
+    with patch.object(clt_module, "_validate_literal") as mock_validate_literal:
+        ci.test_null_hypothesis(h0_value=0.0, alternative="larger")
+
+        mock_validate_literal.assert_called_once_with("larger", "alternative", ["two-sided", "larger", "smaller"])
+
+
 def test_null_hypothesis_null_is_true():
     ci = CLTConfidenceInterval(mean=0.0, std=1.0)
     z_stat, p_value, df = ci.test_null_hypothesis(h0_value=0.0)
@@ -94,9 +105,3 @@ def test_null_hypothesis_smaller_positive_z():
     ci = CLTConfidenceInterval(mean=1.96, std=1.0)
     _, p_value, _ = ci.test_null_hypothesis(h0_value=0.0, alternative="smaller")
     assert p_value == pytest.approx(0.975, abs=0.001)
-
-
-def test_null_hypothesis_invalid_alternative():
-    ci = CLTConfidenceInterval(mean=0.0, std=1.0)
-    with pytest.raises(ValueError, match="'alternative' must be 'two-sided', 'larger', or 'smaller'"):
-        ci.test_null_hypothesis(h0_value=0.0, alternative="invalid")  # ty: ignore

--- a/tests/unit/confidence_sequences/test_empirical_bernstein.py
+++ b/tests/unit/confidence_sequences/test_empirical_bernstein.py
@@ -48,6 +48,16 @@ def test_compute_mixture_boundary_increases_with_confidence():
 # --- _compute_empirical_bernstein_bounds ---
 
 
+def test_compute_empirical_bernstein_bounds_delegates_to_validation():
+    batch_estimates = np.array([0.4, 0.6, 0.5])
+    with patch.object(empirical_bernstein_module, "_validate_bounds") as mock_validate_bounds:
+        _compute_empirical_bernstein_bounds(batch_estimates, seed_center=0.5, miscoverage=0.2)
+
+        mock_validate_bounds.assert_called_once_with(
+            0.2, "miscoverage", lower=0.0, upper=1.0, left_inclusive=False, right_inclusive=False
+        )
+
+
 def test_compute_empirical_bernstein_bounds():
     batch_estimates = np.array([0.4, 0.6, 0.5])
     running_mean_estimates, lower_bounds = _compute_empirical_bernstein_bounds(

--- a/tests/unit/confidence_sequences/test_empirical_bernstein.py
+++ b/tests/unit/confidence_sequences/test_empirical_bernstein.py
@@ -1,0 +1,95 @@
+import numpy as np
+import pytest
+
+from glide.confidence_sequences import EmpiricalBernsteinConfidenceSequence
+from glide.confidence_sequences.empirical_bernstein import (
+    _compute_empirical_bernstein_bounds,
+    _compute_mixture_boundary,
+    _compute_mixture_wealth,
+)
+
+EXPECTED_LOWER_BOUNDS = np.array([-2.27458313, -0.86521862, -0.41014575])
+
+
+# --- _compute_mixture_wealth ---
+
+
+def test_compute_mixture_wealth_positive():
+    wealth = _compute_mixture_wealth(0.5, 0.1)
+    assert wealth > 0
+
+
+# --- _compute_mixture_boundary ---
+
+
+@pytest.mark.parametrize("miscoverage", [0.1, 0.2, 0.5])
+def test_compute_mixture_boundary_zero_variance(miscoverage):
+    boundary = _compute_mixture_boundary(0.0, miscoverage)
+    assert (np.exp(boundary) - 1) / boundary == pytest.approx(1 / miscoverage, abs=1e-6)
+
+
+def test_compute_mixture_boundary_increases_with_variance():
+    small = _compute_mixture_boundary(0.5, 0.1)
+    large = _compute_mixture_boundary(2.0, 0.1)
+    assert small < large
+
+
+def test_compute_mixture_boundary_increases_with_confidence():
+    loose = _compute_mixture_boundary(0.5, 0.2)
+    tight = _compute_mixture_boundary(0.5, 0.05)
+    assert loose < tight
+
+
+# --- _compute_empirical_bernstein_bounds ---
+
+
+def test_compute_empirical_bernstein_bounds():
+    batch_estimates = np.array([0.4, 0.6, 0.5])
+    running_mean_estimates, lower_bounds = _compute_empirical_bernstein_bounds(
+        batch_estimates, seed_center=0.5, miscoverage=0.2
+    )
+    np.testing.assert_allclose(running_mean_estimates, np.array([0.4, 0.5, 0.5]))
+    np.testing.assert_allclose(lower_bounds, EXPECTED_LOWER_BOUNDS, atol=1e-6)
+
+
+def test_compute_empirical_bernstein_bounds_single_batch():
+    batch_estimates = np.array([0.7])
+    running_mean_estimates, lower_bounds = _compute_empirical_bernstein_bounds(
+        batch_estimates, seed_center=0.5, miscoverage=0.1
+    )
+    np.testing.assert_array_equal(running_mean_estimates, np.array([0.7]))
+    assert len(lower_bounds) == 1
+
+
+# --- EmpiricalBernsteinConfidenceSequence ---
+
+
+@pytest.fixture
+def sequence():
+    return EmpiricalBernsteinConfidenceSequence(
+        running_mean_estimates=np.array([0.4, 0.6]),
+        confidence_bounds=np.array([0.1, 0.55]),
+    )
+
+
+def test_running_mean_estimates_stored(sequence):
+    np.testing.assert_array_equal(sequence.running_mean_estimates, np.array([0.4, 0.6]))
+
+
+def test_confidence_bounds_stored(sequence):
+    np.testing.assert_array_equal(sequence.confidence_bounds, np.array([0.1, 0.55]))
+
+
+def test_null_hypothesis_larger(sequence):
+    alarms = sequence.test_null_hypothesis(0.5, alternative="larger")
+    np.testing.assert_array_equal(alarms, np.array([False, True]))
+
+
+def test_null_hypothesis_smaller(sequence):
+    alarms = sequence.test_null_hypothesis(0.3, alternative="smaller")
+    np.testing.assert_array_equal(alarms, np.array([True, False]))
+
+
+def test_null_hypothesis_invalid_alternative(sequence):
+    with pytest.raises(ValueError, match="'alternative' must be"):
+        sequence.test_null_hypothesis(0.5, alternative="two-sided")

--- a/tests/unit/confidence_sequences/test_empirical_bernstein.py
+++ b/tests/unit/confidence_sequences/test_empirical_bernstein.py
@@ -1,6 +1,9 @@
+from unittest.mock import patch
+
 import numpy as np
 import pytest
 
+import glide.confidence_sequences.empirical_bernstein as empirical_bernstein_module
 from glide.confidence_sequences import EmpiricalBernsteinConfidenceSequence
 from glide.confidence_sequences.empirical_bernstein import (
     _compute_empirical_bernstein_bounds,
@@ -14,9 +17,9 @@ EXPECTED_LOWER_BOUNDS = np.array([-2.27458313, -0.86521862, -0.41014575])
 # --- _compute_mixture_wealth ---
 
 
-def test_compute_mixture_wealth_positive():
+def test_compute_mixture_wealth_known_value():
     wealth = _compute_mixture_wealth(0.5, 0.1)
-    assert wealth > 0
+    assert wealth == pytest.approx(1.227, abs=1e-3)
 
 
 # --- _compute_mixture_boundary ---
@@ -31,13 +34,15 @@ def test_compute_mixture_boundary_zero_variance(miscoverage):
 def test_compute_mixture_boundary_increases_with_variance():
     small = _compute_mixture_boundary(0.5, 0.1)
     large = _compute_mixture_boundary(2.0, 0.1)
-    assert small < large
+    assert small == pytest.approx(4.298, abs=1e-3)
+    assert large == pytest.approx(5.780, abs=1e-3)
 
 
 def test_compute_mixture_boundary_increases_with_confidence():
     loose = _compute_mixture_boundary(0.5, 0.2)
     tight = _compute_mixture_boundary(0.5, 0.05)
-    assert loose < tight
+    assert loose == pytest.approx(3.283, abs=1e-3)
+    assert tight == pytest.approx(5.249, abs=1e-3)
 
 
 # --- _compute_empirical_bernstein_bounds ---
@@ -52,15 +57,6 @@ def test_compute_empirical_bernstein_bounds():
     np.testing.assert_allclose(lower_bounds, EXPECTED_LOWER_BOUNDS, atol=1e-6)
 
 
-def test_compute_empirical_bernstein_bounds_single_batch():
-    batch_estimates = np.array([0.7])
-    running_mean_estimates, lower_bounds = _compute_empirical_bernstein_bounds(
-        batch_estimates, seed_center=0.5, miscoverage=0.1
-    )
-    np.testing.assert_array_equal(running_mean_estimates, np.array([0.7]))
-    assert len(lower_bounds) == 1
-
-
 # --- EmpiricalBernsteinConfidenceSequence ---
 
 
@@ -72,12 +68,16 @@ def sequence():
     )
 
 
-def test_running_mean_estimates_stored(sequence):
+def test_sequence_attributes(sequence):
     np.testing.assert_array_equal(sequence.running_mean_estimates, np.array([0.4, 0.6]))
-
-
-def test_confidence_bounds_stored(sequence):
     np.testing.assert_array_equal(sequence.confidence_bounds, np.array([0.1, 0.55]))
+
+
+def test_null_hypothesis_delegates_to_validation(sequence):
+    with patch.object(empirical_bernstein_module, "_validate_literal") as mock_validate_literal:
+        sequence.test_null_hypothesis(0.5, alternative="larger")
+
+        mock_validate_literal.assert_called_once_with("larger", "alternative", ["larger", "smaller"])
 
 
 def test_null_hypothesis_larger(sequence):
@@ -88,8 +88,3 @@ def test_null_hypothesis_larger(sequence):
 def test_null_hypothesis_smaller(sequence):
     alarms = sequence.test_null_hypothesis(0.3, alternative="smaller")
     np.testing.assert_array_equal(alarms, np.array([True, False]))
-
-
-def test_null_hypothesis_invalid_alternative(sequence):
-    with pytest.raises(ValueError, match="'alternative' must be"):
-        sequence.test_null_hypothesis(0.5, alternative="two-sided")

--- a/tests/unit/confidence_sequences/test_empirical_bernstein.py
+++ b/tests/unit/confidence_sequences/test_empirical_bernstein.py
@@ -11,9 +11,6 @@ from glide.confidence_sequences.empirical_bernstein import (
     _compute_mixture_wealth,
 )
 
-EXPECTED_LOWER_BOUNDS = np.array([-2.27458313, -0.86521862, -0.41014575])
-
-
 # --- _compute_mixture_wealth ---
 
 
@@ -28,7 +25,9 @@ def test_compute_mixture_wealth_known_value():
 @pytest.mark.parametrize("miscoverage", [0.1, 0.2, 0.5])
 def test_compute_mixture_boundary_zero_variance(miscoverage):
     boundary = _compute_mixture_boundary(0.0, miscoverage)
-    assert (np.exp(boundary) - 1) / boundary == pytest.approx(1 / miscoverage, abs=1e-6)
+    closed_form_integral = (np.exp(boundary) - 1) / boundary
+    wealth = 1 / miscoverage
+    assert closed_form_integral == pytest.approx(wealth, abs=1e-6)
 
 
 def test_compute_mixture_boundary_increases_with_variance():
@@ -66,8 +65,9 @@ def test_compute_empirical_bernstein_bounds(batch_estimates):
     running_mean_estimates, lower_bounds = _compute_empirical_bernstein_bounds(
         batch_estimates, seed_center=0.5, miscoverage=0.2
     )
+    expected_lower_bound = np.array([-2.27458313, -0.86521862, -0.41014575])
     np.testing.assert_allclose(running_mean_estimates, np.array([0.4, 0.5, 0.5]))
-    np.testing.assert_allclose(lower_bounds, EXPECTED_LOWER_BOUNDS, atol=1e-6)
+    np.testing.assert_allclose(lower_bounds, expected_lower_bound, atol=1e-6)
 
 
 # --- EmpiricalBernsteinConfidenceSequence ---

--- a/tests/unit/confidence_sequences/test_empirical_bernstein.py
+++ b/tests/unit/confidence_sequences/test_empirical_bernstein.py
@@ -48,8 +48,12 @@ def test_compute_mixture_boundary_increases_with_confidence():
 # --- _compute_empirical_bernstein_bounds ---
 
 
-def test_compute_empirical_bernstein_bounds_delegates_to_validation():
-    batch_estimates = np.array([0.4, 0.6, 0.5])
+@pytest.fixture
+def batch_estimates():
+    return np.array([0.4, 0.6, 0.5])
+
+
+def test_compute_empirical_bernstein_bounds_delegates_to_validation(batch_estimates):
     with patch.object(empirical_bernstein_module, "_validate_bounds") as mock_validate_bounds:
         _compute_empirical_bernstein_bounds(batch_estimates, seed_center=0.5, miscoverage=0.2)
 
@@ -58,8 +62,7 @@ def test_compute_empirical_bernstein_bounds_delegates_to_validation():
         )
 
 
-def test_compute_empirical_bernstein_bounds():
-    batch_estimates = np.array([0.4, 0.6, 0.5])
+def test_compute_empirical_bernstein_bounds(batch_estimates):
     running_mean_estimates, lower_bounds = _compute_empirical_bernstein_bounds(
         batch_estimates, seed_center=0.5, miscoverage=0.2
     )


### PR DESCRIPTION
### Description

- Adds the `glide/confidence_sequences/` package with a `ConfidenceSequence` structural protocol and `EmpiricalBernsteinConfidenceSequence`: an anytime-valid one-sided bound on a running mean that holds simultaneously at all looks, with no false-alarm inflation from peeking. The package mirrors `glide/confidence_intervals/` in structure and serves as the foundational layer the drift monitors will depend on.
- Closes #314

### Checklist

- [x] I have read `CONTRIBUTING.md`
- [x] `make lint` passes
- [x] `make type-check` passes
- [x] `make tests` passes
- [x] `make coverage` reports 100% coverage
- [x] `make test-notebooks` passes
- [x] New public API has numpy-style docstrings
- [x] New public API is inserted in the API reference section of the documentation
- [x] Docs build without warnings (`make doc`)
- [x] `CHANGELOG.md` updated if the change is user-facing

### LLM usage

Disclose if an LLM was used in writing this PR:
- [ ] No LLM used
- [x] I used an LLM and I went through and validated all the code myself