### PR TITLE
Add mean monitoring result dataclasses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### ✨ Added
 - `glide.confidence_sequences` module with the `ConfidenceSequence` protocol and `EmpiricalBernsteinConfidenceSequence`: an anytime-valid empirical-Bernstein confidence sequence.
+- `glide.mean_monitoring_results` module with `MeanMonitoringResult`, `ClassicalMeanMonitoringResult` and `PredictionPoweredMeanMonitoringResult`: result objects for drift-monitoring procedures over batched datasets.
 - GitHub Pages landing page at [emertondata.github.io/glide](https://emertondata.github.io/glide).
 
 ### 🔄 Changed

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -72,8 +72,8 @@
 
 | Class | Description |
 |-------|-------------|
-| [`ClassicalMeanMonitoringResult`](mean_monitoring_results.md#glide.mean_monitoring_results.classical.ClassicalMeanMonitoringResult) | Result object from the classical monitor |
-| [`PredictionPoweredMeanMonitoringResult`](mean_monitoring_results.md#glide.mean_monitoring_results.prediction_powered.PredictionPoweredMeanMonitoringResult) | Result object from the prediction-powered monitor |
+| [`ClassicalMeanMonitoringResult`](mean_monitoring_results.md#glide.mean_monitoring_results.classical.ClassicalMeanMonitoringResult) | Result object from classical monitors |
+| [`PredictionPoweredMeanMonitoringResult`](mean_monitoring_results.md#glide.mean_monitoring_results.prediction_powered.PredictionPoweredMeanMonitoringResult) | Result object from prediction-powered monitors |
 
 ## Scientific Validation
 

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -68,6 +68,13 @@
 | [`ClassicalMeanInferenceResult`](mean_inference_results.md#glide.mean_inference_results.classical.ClassicalMeanInferenceResult) | Result object from classical estimators |
 | [`PredictionPoweredMeanInferenceResult`](mean_inference_results.md#glide.mean_inference_results.prediction_powered.PredictionPoweredMeanInferenceResult) | Result object from prediction-powered estimators |
 
+## Monitoring Results
+
+| Class | Description |
+|-------|-------------|
+| [`ClassicalMeanMonitoringResult`](mean_monitoring_results.md#glide.mean_monitoring_results.classical.ClassicalMeanMonitoringResult) | Result object from the classical monitor |
+| [`PredictionPoweredMeanMonitoringResult`](mean_monitoring_results.md#glide.mean_monitoring_results.prediction_powered.PredictionPoweredMeanMonitoringResult) | Result object from the prediction-powered monitor |
+
 ## Scientific Validation
 
 | Function | Description |

--- a/docs/api/mean_monitoring_results.md
+++ b/docs/api/mean_monitoring_results.md
@@ -1,0 +1,11 @@
+# Monitoring Results
+
+::: glide.mean_monitoring_results.base
+
+---
+
+::: glide.mean_monitoring_results.classical
+
+---
+
+::: glide.mean_monitoring_results.prediction_powered

--- a/glide/mean_monitoring_results/__init__.py
+++ b/glide/mean_monitoring_results/__init__.py
@@ -1,0 +1,9 @@
+from glide.mean_monitoring_results.base import MeanMonitoringResult
+from glide.mean_monitoring_results.classical import ClassicalMeanMonitoringResult
+from glide.mean_monitoring_results.prediction_powered import PredictionPoweredMeanMonitoringResult
+
+__all__ = [
+    "MeanMonitoringResult",
+    "ClassicalMeanMonitoringResult",
+    "PredictionPoweredMeanMonitoringResult",
+]

--- a/glide/mean_monitoring_results/base.py
+++ b/glide/mean_monitoring_results/base.py
@@ -73,8 +73,8 @@ class MeanMonitoringResult:
         result = int(self.alarms.argmax())
         return result
 
-    def __str__(self) -> str:
-        lines: List[str] = [
+    def _common_lines(self) -> List[str]:
+        lines = [
             f"Metric: {self.metric_name}",
             f"Monitor: {self.monitor_name}",
             f"Number of Batches: {self.n_batches}",
@@ -85,7 +85,10 @@ class MeanMonitoringResult:
             f"Confidence Bound: {self.confidence_bounds[-1]:.3f}",
             f"Confidence Level: {self.confidence_level:.2f}",
         ]
-        return "\n".join(lines)
+        return lines
+
+    def __str__(self) -> str:
+        return "\n".join(self._common_lines())
 
     def summary(self) -> str:
         """Return a formatted summary of the monitoring result."""

--- a/glide/mean_monitoring_results/base.py
+++ b/glide/mean_monitoring_results/base.py
@@ -4,6 +4,7 @@ from typing import List, Optional
 from numpy.typing import NDArray
 
 from glide.confidence_sequences import ConfidenceSequence
+from glide.core.validation import _validate_equal_lengths, _validate_non_empty
 
 
 @dataclass(repr=False)
@@ -36,9 +37,17 @@ class MeanMonitoringResult:
     higher_is_better: bool
     alarm_threshold: float
     confidence_level: float
-    batch_identifiers: NDArray
     batch_mean_estimates: NDArray
     confidence_sequence: ConfidenceSequence
+
+    def __post_init__(self) -> None:
+        _validate_non_empty(self.batch_mean_estimates, "batch_mean_estimates")
+        _validate_equal_lengths(
+            self.batch_mean_estimates,
+            self.confidence_sequence.running_mean_estimates,
+            self.confidence_sequence.confidence_bounds,
+            names=["batch_mean_estimates", "running_mean_estimates", "confidence_bounds"],
+        )
 
     @property
     def running_means(self) -> NDArray:

--- a/glide/mean_monitoring_results/base.py
+++ b/glide/mean_monitoring_results/base.py
@@ -1,0 +1,95 @@
+from dataclasses import dataclass
+from typing import List, Optional
+
+from numpy.typing import NDArray
+
+from glide.confidence_sequences import ConfidenceSequence
+
+
+@dataclass(repr=False)
+class MeanMonitoringResult:
+    """Result of a drift-monitoring procedure over a batched dataset.
+
+    Holds the embedded ``confidence_sequence`` and exposes its per-look arrays as
+    properties. Every array is indexed by batch in chronological order and is
+    expressed in the original metric units. For batch ``t``:
+
+    - ``running_means[t]`` is the mean of the per-batch estimates up to ``t``;
+    - ``confidence_bounds[t]`` is the anytime-valid bound on that running mean,
+      on the side where drift is harmful (a lower bound when the metric is a
+      risk, an upper bound when it is a performance);
+    - ``alarms[t]`` is ``True`` once ``confidence_bounds[t]`` has crossed
+      ``alarm_threshold``, signalling a drift.
+
+    ``alarm_threshold`` is the user-supplied business threshold the confidence
+    bound is tested against: the worst metric value the user is willing to
+    tolerate, in metric units.
+
+    Because the threshold is a known constant, the only false-alarm budget is
+    the embedded sequence's, reported as ``confidence_level``: under no drift,
+    the probability of ever raising a false alarm is at most
+    ``1 - confidence_level``.
+    """
+
+    metric_name: str
+    monitor_name: str
+    higher_is_better: bool
+    alarm_threshold: float
+    confidence_level: float
+    batch_identifiers: NDArray
+    batch_mean_estimates: NDArray
+    confidence_sequence: ConfidenceSequence
+
+    @property
+    def running_means(self) -> NDArray:
+        result = self.confidence_sequence.running_mean_estimates
+        return result
+
+    @property
+    def confidence_bounds(self) -> NDArray:
+        result = self.confidence_sequence.confidence_bounds
+        return result
+
+    @property
+    def alarms(self) -> NDArray:
+        alternative = "smaller" if self.higher_is_better else "larger"
+        result = self.confidence_sequence.test_null_hypothesis(self.alarm_threshold, alternative)
+        return result
+
+    @property
+    def n_batches(self) -> int:
+        result = len(self.batch_mean_estimates)
+        return result
+
+    @property
+    def drift_detected(self) -> bool:
+        result = bool(self.alarms.any())
+        return result
+
+    @property
+    def first_alarm_index(self) -> Optional[int]:
+        if not self.drift_detected:
+            return None
+        result = int(self.alarms.argmax())
+        return result
+
+    def __str__(self) -> str:
+        lines: List[str] = [
+            f"Metric: {self.metric_name}",
+            f"Monitor: {self.monitor_name}",
+            f"Number of Batches: {self.n_batches}",
+            f"Drift Detected: {self.drift_detected}",
+            f"First Alarm Index: {self.first_alarm_index}",
+            f"Alarm Threshold: {self.alarm_threshold:.3f}",
+            f"Running Mean: {self.running_means[-1]:.3f}",
+            f"Confidence Bound: {self.confidence_bounds[-1]:.3f}",
+            f"Confidence Level: {self.confidence_level:.2f}",
+        ]
+        return "\n".join(lines)
+
+    def summary(self) -> str:
+        """Return a formatted summary of the monitoring result."""
+        return self.__str__()
+
+    def __repr__(self) -> str:
+        return self.__str__()

--- a/glide/mean_monitoring_results/classical.py
+++ b/glide/mean_monitoring_results/classical.py
@@ -1,0 +1,17 @@
+from dataclasses import dataclass
+
+from numpy.typing import NDArray
+
+from glide.mean_monitoring_results.base import MeanMonitoringResult
+
+
+@dataclass(repr=False)
+class ClassicalMeanMonitoringResult(MeanMonitoringResult):
+    """Monitoring result for the classical (proxy-free) monitor.
+
+    Adds the per-batch labeled sample count to the shared base. ``batch_n[t]``
+    is the number of labeled samples in batch ``t`` and has the same length as
+    ``batch_mean_estimates``.
+    """
+
+    batch_n: NDArray

--- a/glide/mean_monitoring_results/classical.py
+++ b/glide/mean_monitoring_results/classical.py
@@ -23,6 +23,6 @@ class ClassicalMeanMonitoringResult(MeanMonitoringResult):
 
     def __str__(self) -> str:
         lines = self._common_lines() + [
-            f"batch_n: {self.batch_n[-1]}",
+            f"batch_n: {self.batch_n.tolist()}",
         ]
         return "\n".join(lines)

--- a/glide/mean_monitoring_results/classical.py
+++ b/glide/mean_monitoring_results/classical.py
@@ -15,3 +15,9 @@ class ClassicalMeanMonitoringResult(MeanMonitoringResult):
     """
 
     batch_n: NDArray
+
+    def __str__(self) -> str:
+        lines = self._common_lines() + [
+            f"batch_n: {self.batch_n[-1]}",
+        ]
+        return "\n".join(lines)

--- a/glide/mean_monitoring_results/classical.py
+++ b/glide/mean_monitoring_results/classical.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass
 
 from numpy.typing import NDArray
 
+from glide.core.validation import _validate_equal_lengths
 from glide.mean_monitoring_results.base import MeanMonitoringResult
 
 
@@ -15,6 +16,10 @@ class ClassicalMeanMonitoringResult(MeanMonitoringResult):
     """
 
     batch_n: NDArray
+
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        _validate_equal_lengths(self.batch_mean_estimates, self.batch_n, names=["batch_mean_estimates", "batch_n"])
 
     def __str__(self) -> str:
         lines = self._common_lines() + [

--- a/glide/mean_monitoring_results/prediction_powered.py
+++ b/glide/mean_monitoring_results/prediction_powered.py
@@ -17,3 +17,10 @@ class PredictionPoweredMeanMonitoringResult(MeanMonitoringResult):
 
     batch_n_true: NDArray
     batch_n_proxy: NDArray
+
+    def __str__(self) -> str:
+        lines = self._common_lines() + [
+            f"batch_n_true: {self.batch_n_true[-1]}",
+            f"batch_n_proxy: {self.batch_n_proxy[-1]}",
+        ]
+        return "\n".join(lines)

--- a/glide/mean_monitoring_results/prediction_powered.py
+++ b/glide/mean_monitoring_results/prediction_powered.py
@@ -30,7 +30,7 @@ class PredictionPoweredMeanMonitoringResult(MeanMonitoringResult):
 
     def __str__(self) -> str:
         lines = self._common_lines() + [
-            f"batch_n_true: {self.batch_n_true[-1]}",
-            f"batch_n_proxy: {self.batch_n_proxy[-1]}",
+            f"batch_n_true: {self.batch_n_true.tolist()}",
+            f"batch_n_proxy: {self.batch_n_proxy.tolist()}",
         ]
         return "\n".join(lines)

--- a/glide/mean_monitoring_results/prediction_powered.py
+++ b/glide/mean_monitoring_results/prediction_powered.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass
 
 from numpy.typing import NDArray
 
+from glide.core.validation import _validate_equal_lengths
 from glide.mean_monitoring_results.base import MeanMonitoringResult
 
 
@@ -17,6 +18,15 @@ class PredictionPoweredMeanMonitoringResult(MeanMonitoringResult):
 
     batch_n_true: NDArray
     batch_n_proxy: NDArray
+
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        _validate_equal_lengths(
+            self.batch_mean_estimates,
+            self.batch_n_true,
+            self.batch_n_proxy,
+            names=["batch_mean_estimates", "batch_n_true", "batch_n_proxy"],
+        )
 
     def __str__(self) -> str:
         lines = self._common_lines() + [

--- a/glide/mean_monitoring_results/prediction_powered.py
+++ b/glide/mean_monitoring_results/prediction_powered.py
@@ -1,0 +1,19 @@
+from dataclasses import dataclass
+
+from numpy.typing import NDArray
+
+from glide.mean_monitoring_results.base import MeanMonitoringResult
+
+
+@dataclass(repr=False)
+class PredictionPoweredMeanMonitoringResult(MeanMonitoringResult):
+    """Monitoring result for the prediction-powered monitor.
+
+    Adds the per-batch labeled and total sample counts to the shared base.
+    ``batch_n_true[t]`` is the number of labeled samples in batch ``t`` and
+    ``batch_n_proxy[t]`` the total number of samples (labeled plus unlabeled);
+    both have the same length as ``batch_mean_estimates``.
+    """
+
+    batch_n_true: NDArray
+    batch_n_proxy: NDArray

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -114,6 +114,7 @@ nav:
     - Confidence Intervals: api/confidence_intervals.md
     - Confidence Sequences: api/confidence_sequences.md
     - Inference Results: api/mean_inference_results.md
+    - Monitoring Results: api/mean_monitoring_results.md
     - Scientific Validation: api/scientific_validation.md
     - I/O: api/io.md
 

--- a/tests/unit/mean_monitoring_results/test_base.py
+++ b/tests/unit/mean_monitoring_results/test_base.py
@@ -1,0 +1,104 @@
+import numpy as np
+
+from glide.confidence_sequences import EmpiricalBernsteinConfidenceSequence
+from glide.mean_monitoring_results import MeanMonitoringResult
+
+# --- MeanMonitoringResult (common attributes and properties) ---
+
+_SEQUENCE = EmpiricalBernsteinConfidenceSequence(
+    running_mean_estimates=np.array([0.4, 0.6]),
+    confidence_bounds=np.array([0.1, 0.55]),
+)
+_RESULT_HIGHER_IS_BETTER = MeanMonitoringResult(
+    metric_name="accuracy",
+    monitor_name="Test",
+    higher_is_better=True,
+    alarm_threshold=0.5,
+    confidence_level=0.95,
+    batch_identifiers=np.array([0, 1]),
+    batch_mean_estimates=np.array([0.4, 0.8]),
+    confidence_sequence=_SEQUENCE,
+)
+_RESULT_LOWER_IS_BETTER = MeanMonitoringResult(
+    metric_name="loss",
+    monitor_name="Test",
+    higher_is_better=False,
+    alarm_threshold=0.5,
+    confidence_level=0.95,
+    batch_identifiers=np.array([0, 1]),
+    batch_mean_estimates=np.array([0.4, 0.8]),
+    confidence_sequence=_SEQUENCE,
+)
+_RESULT_NO_ALARM = MeanMonitoringResult(
+    metric_name="accuracy",
+    monitor_name="Test",
+    higher_is_better=True,
+    alarm_threshold=-1.0,
+    confidence_level=0.95,
+    batch_identifiers=np.array([0, 1]),
+    batch_mean_estimates=np.array([0.4, 0.8]),
+    confidence_sequence=_SEQUENCE,
+)
+
+
+def test_base_running_means():
+    np.testing.assert_array_equal(_RESULT_HIGHER_IS_BETTER.running_means, np.array([0.4, 0.6]))
+
+
+def test_base_confidence_bounds():
+    np.testing.assert_array_equal(_RESULT_HIGHER_IS_BETTER.confidence_bounds, np.array([0.1, 0.55]))
+
+
+def test_base_alarms_higher_is_better():
+    np.testing.assert_array_equal(_RESULT_HIGHER_IS_BETTER.alarms, np.array([True, False]))
+
+
+def test_base_alarms_lower_is_better():
+    np.testing.assert_array_equal(_RESULT_LOWER_IS_BETTER.alarms, np.array([False, True]))
+
+
+def test_base_n_batches():
+    assert _RESULT_HIGHER_IS_BETTER.n_batches == 2
+
+
+def test_base_drift_detected_true():
+    assert _RESULT_HIGHER_IS_BETTER.drift_detected is True
+
+
+def test_base_drift_detected_false():
+    assert _RESULT_NO_ALARM.drift_detected is False
+
+
+def test_base_first_alarm_index_at_zero():
+    assert _RESULT_HIGHER_IS_BETTER.first_alarm_index == 0
+
+
+def test_base_first_alarm_index_not_at_zero():
+    assert _RESULT_LOWER_IS_BETTER.first_alarm_index == 1
+
+
+def test_base_first_alarm_index_none():
+    assert _RESULT_NO_ALARM.first_alarm_index is None
+
+
+def test_base_repr_equals_str_equals_summary():
+    assert repr(_RESULT_HIGHER_IS_BETTER) == str(_RESULT_HIGHER_IS_BETTER)
+    assert str(_RESULT_HIGHER_IS_BETTER) == _RESULT_HIGHER_IS_BETTER.summary()
+
+
+# --- MeanMonitoringResult.__str__ ---
+
+
+def test_base_str():
+    expected = (
+        "Metric: accuracy\n"
+        "Monitor: Test\n"
+        "Number of Batches: 2\n"
+        "Drift Detected: True\n"
+        "First Alarm Index: 0\n"
+        "Alarm Threshold: 0.500\n"
+        "Running Mean: 0.600\n"
+        "Confidence Bound: 0.550\n"
+        "Confidence Level: 0.95"
+    )
+    assert str(_RESULT_HIGHER_IS_BETTER) == expected

--- a/tests/unit/mean_monitoring_results/test_base.py
+++ b/tests/unit/mean_monitoring_results/test_base.py
@@ -44,7 +44,7 @@ def result_without_alarm(sequence):
     )
 
 
-def test_base_properties(result_with_alarm, result_without_alarm):
+def test_base_properties_with_alarm(result_with_alarm):
     np.testing.assert_array_equal(result_with_alarm.running_means, np.array([0.4, 0.6]))
     np.testing.assert_array_equal(result_with_alarm.confidence_bounds, np.array([0.1, 0.55]))
     assert result_with_alarm.n_batches == 2
@@ -52,6 +52,8 @@ def test_base_properties(result_with_alarm, result_without_alarm):
     assert result_with_alarm.drift_detected is True
     assert result_with_alarm.first_alarm_index == 0
 
+
+def test_base_properties_without_alarm(result_without_alarm):
     np.testing.assert_array_equal(result_without_alarm.alarms, np.array([False, False]))
     assert result_without_alarm.drift_detected is False
     assert result_without_alarm.first_alarm_index is None

--- a/tests/unit/mean_monitoring_results/test_base.py
+++ b/tests/unit/mean_monitoring_results/test_base.py
@@ -1,6 +1,9 @@
+from unittest.mock import patch
+
 import numpy as np
 import pytest
 
+import glide.mean_monitoring_results.base as base_module
 from glide.confidence_sequences import EmpiricalBernsteinConfidenceSequence
 from glide.mean_monitoring_results import MeanMonitoringResult
 
@@ -23,7 +26,6 @@ def result_with_alarm(sequence):
         higher_is_better=True,
         alarm_threshold=0.5,
         confidence_level=0.95,
-        batch_identifiers=np.array([0, 1]),
         batch_mean_estimates=np.array([0.4, 0.8]),
         confidence_sequence=sequence,
     )
@@ -37,7 +39,6 @@ def result_without_alarm(sequence):
         higher_is_better=False,
         alarm_threshold=2.0,
         confidence_level=0.95,
-        batch_identifiers=np.array([0, 1]),
         batch_mean_estimates=np.array([0.4, 0.8]),
         confidence_sequence=sequence,
     )
@@ -59,6 +60,36 @@ def test_base_properties(result_with_alarm, result_without_alarm):
 def test_base_repr_equals_str_equals_summary(result_with_alarm):
     assert repr(result_with_alarm) == str(result_with_alarm)
     assert str(result_with_alarm) == result_with_alarm.summary()
+
+
+# --- MeanMonitoringResult.__post_init__ ---
+
+
+def test_base_post_init_delegates_to_validation(sequence):
+    batch_mean_estimates = np.array([0.4, 0.8])
+    with (
+        patch.object(base_module, "_validate_non_empty") as mock_validate_non_empty,
+        patch.object(base_module, "_validate_equal_lengths") as mock_validate_equal_lengths,
+    ):
+        MeanMonitoringResult(
+            metric_name="accuracy",
+            monitor_name="Test",
+            higher_is_better=True,
+            alarm_threshold=0.5,
+            confidence_level=0.95,
+            batch_mean_estimates=batch_mean_estimates,
+            confidence_sequence=sequence,
+        )
+        mock_validate_non_empty.assert_called_once()
+        np.testing.assert_array_equal(mock_validate_non_empty.call_args[0][0], batch_mean_estimates)
+        assert mock_validate_non_empty.call_args[0][1] == "batch_mean_estimates"
+        mock_validate_equal_lengths.assert_called_once()
+        np.testing.assert_array_equal(mock_validate_equal_lengths.call_args[0][0], batch_mean_estimates)
+        np.testing.assert_array_equal(mock_validate_equal_lengths.call_args[0][1], sequence.running_mean_estimates)
+        np.testing.assert_array_equal(mock_validate_equal_lengths.call_args[0][2], sequence.confidence_bounds)
+        assert mock_validate_equal_lengths.call_args[1] == {
+            "names": ["batch_mean_estimates", "running_mean_estimates", "confidence_bounds"]
+        }
 
 
 # --- MeanMonitoringResult.__str__ ---

--- a/tests/unit/mean_monitoring_results/test_base.py
+++ b/tests/unit/mean_monitoring_results/test_base.py
@@ -1,95 +1,111 @@
 import numpy as np
+import pytest
 
 from glide.confidence_sequences import EmpiricalBernsteinConfidenceSequence
 from glide.mean_monitoring_results import MeanMonitoringResult
 
 # --- MeanMonitoringResult (common attributes and properties) ---
 
-_SEQUENCE = EmpiricalBernsteinConfidenceSequence(
-    running_mean_estimates=np.array([0.4, 0.6]),
-    confidence_bounds=np.array([0.1, 0.55]),
-)
-_RESULT_HIGHER_IS_BETTER = MeanMonitoringResult(
-    metric_name="accuracy",
-    monitor_name="Test",
-    higher_is_better=True,
-    alarm_threshold=0.5,
-    confidence_level=0.95,
-    batch_identifiers=np.array([0, 1]),
-    batch_mean_estimates=np.array([0.4, 0.8]),
-    confidence_sequence=_SEQUENCE,
-)
-_RESULT_LOWER_IS_BETTER = MeanMonitoringResult(
-    metric_name="loss",
-    monitor_name="Test",
-    higher_is_better=False,
-    alarm_threshold=0.5,
-    confidence_level=0.95,
-    batch_identifiers=np.array([0, 1]),
-    batch_mean_estimates=np.array([0.4, 0.8]),
-    confidence_sequence=_SEQUENCE,
-)
-_RESULT_NO_ALARM = MeanMonitoringResult(
-    metric_name="accuracy",
-    monitor_name="Test",
-    higher_is_better=True,
-    alarm_threshold=-1.0,
-    confidence_level=0.95,
-    batch_identifiers=np.array([0, 1]),
-    batch_mean_estimates=np.array([0.4, 0.8]),
-    confidence_sequence=_SEQUENCE,
-)
+
+@pytest.fixture
+def sequence():
+    return EmpiricalBernsteinConfidenceSequence(
+        running_mean_estimates=np.array([0.4, 0.6]),
+        confidence_bounds=np.array([0.1, 0.55]),
+    )
 
 
-def test_base_running_means():
-    np.testing.assert_array_equal(_RESULT_HIGHER_IS_BETTER.running_means, np.array([0.4, 0.6]))
+@pytest.fixture
+def result_higher_is_better(sequence):
+    return MeanMonitoringResult(
+        metric_name="accuracy",
+        monitor_name="Test",
+        higher_is_better=True,
+        alarm_threshold=0.5,
+        confidence_level=0.95,
+        batch_identifiers=np.array([0, 1]),
+        batch_mean_estimates=np.array([0.4, 0.8]),
+        confidence_sequence=sequence,
+    )
 
 
-def test_base_confidence_bounds():
-    np.testing.assert_array_equal(_RESULT_HIGHER_IS_BETTER.confidence_bounds, np.array([0.1, 0.55]))
+@pytest.fixture
+def result_lower_is_better(sequence):
+    return MeanMonitoringResult(
+        metric_name="loss",
+        monitor_name="Test",
+        higher_is_better=False,
+        alarm_threshold=0.5,
+        confidence_level=0.95,
+        batch_identifiers=np.array([0, 1]),
+        batch_mean_estimates=np.array([0.4, 0.8]),
+        confidence_sequence=sequence,
+    )
 
 
-def test_base_alarms_higher_is_better():
-    np.testing.assert_array_equal(_RESULT_HIGHER_IS_BETTER.alarms, np.array([True, False]))
+@pytest.fixture
+def result_no_alarm(sequence):
+    return MeanMonitoringResult(
+        metric_name="accuracy",
+        monitor_name="Test",
+        higher_is_better=True,
+        alarm_threshold=-1.0,
+        confidence_level=0.95,
+        batch_identifiers=np.array([0, 1]),
+        batch_mean_estimates=np.array([0.4, 0.8]),
+        confidence_sequence=sequence,
+    )
 
 
-def test_base_alarms_lower_is_better():
-    np.testing.assert_array_equal(_RESULT_LOWER_IS_BETTER.alarms, np.array([False, True]))
+def test_base_running_means(result_higher_is_better):
+    np.testing.assert_array_equal(result_higher_is_better.running_means, np.array([0.4, 0.6]))
 
 
-def test_base_n_batches():
-    assert _RESULT_HIGHER_IS_BETTER.n_batches == 2
+def test_base_confidence_bounds(result_higher_is_better):
+    np.testing.assert_array_equal(result_higher_is_better.confidence_bounds, np.array([0.1, 0.55]))
 
 
-def test_base_drift_detected_true():
-    assert _RESULT_HIGHER_IS_BETTER.drift_detected is True
+def test_base_alarms_higher_is_better(result_higher_is_better):
+    np.testing.assert_array_equal(result_higher_is_better.alarms, np.array([True, False]))
 
 
-def test_base_drift_detected_false():
-    assert _RESULT_NO_ALARM.drift_detected is False
+def test_base_alarms_lower_is_better(result_lower_is_better):
+    np.testing.assert_array_equal(result_lower_is_better.alarms, np.array([False, True]))
 
 
-def test_base_first_alarm_index_at_zero():
-    assert _RESULT_HIGHER_IS_BETTER.first_alarm_index == 0
+def test_base_n_batches(result_higher_is_better):
+    assert result_higher_is_better.n_batches == 2
 
 
-def test_base_first_alarm_index_not_at_zero():
-    assert _RESULT_LOWER_IS_BETTER.first_alarm_index == 1
+def test_base_drift_detected_true(result_higher_is_better):
+    assert result_higher_is_better.drift_detected is True
 
 
-def test_base_first_alarm_index_none():
-    assert _RESULT_NO_ALARM.first_alarm_index is None
+def test_base_drift_detected_false(result_no_alarm):
+    assert result_no_alarm.drift_detected is False
 
 
-def test_base_repr_equals_str_equals_summary():
-    assert repr(_RESULT_HIGHER_IS_BETTER) == str(_RESULT_HIGHER_IS_BETTER)
-    assert str(_RESULT_HIGHER_IS_BETTER) == _RESULT_HIGHER_IS_BETTER.summary()
+def test_base_first_alarm_index_at_zero(result_higher_is_better):
+    assert result_higher_is_better.first_alarm_index == 0
+
+
+def test_base_first_alarm_index_not_at_zero(result_lower_is_better):
+    assert result_lower_is_better.first_alarm_index == 1
+
+
+def test_base_first_alarm_index_none(result_no_alarm):
+    assert result_no_alarm.first_alarm_index is None
+
+
+def test_base_repr_equals_str_equals_summary(result_higher_is_better):
+    assert repr(result_higher_is_better) == str(result_higher_is_better)
+    assert str(result_higher_is_better) == result_higher_is_better.summary()
 
 
 # --- MeanMonitoringResult.__str__ ---
 
 
-def test_base_str():
+def test_base_str(result_higher_is_better):
     expected = (
         "Metric: accuracy\n"
         "Monitor: Test\n"
@@ -101,4 +117,4 @@ def test_base_str():
         "Confidence Bound: 0.550\n"
         "Confidence Level: 0.95"
     )
-    assert str(_RESULT_HIGHER_IS_BETTER) == expected
+    assert str(result_higher_is_better) == expected

--- a/tests/unit/mean_monitoring_results/test_base.py
+++ b/tests/unit/mean_monitoring_results/test_base.py
@@ -16,7 +16,7 @@ def sequence():
 
 
 @pytest.fixture
-def result_higher_is_better(sequence):
+def result_with_alarm(sequence):
     return MeanMonitoringResult(
         metric_name="accuracy",
         monitor_name="Test",
@@ -30,21 +30,7 @@ def result_higher_is_better(sequence):
 
 
 @pytest.fixture
-def result_lower_is_better(sequence):
-    return MeanMonitoringResult(
-        metric_name="loss",
-        monitor_name="Test",
-        higher_is_better=False,
-        alarm_threshold=0.5,
-        confidence_level=0.95,
-        batch_identifiers=np.array([0, 1]),
-        batch_mean_estimates=np.array([0.4, 0.8]),
-        confidence_sequence=sequence,
-    )
-
-
-@pytest.fixture
-def result_no_alarm(sequence):
+def result_without_alarm(sequence):
     return MeanMonitoringResult(
         metric_name="accuracy",
         monitor_name="Test",
@@ -57,55 +43,28 @@ def result_no_alarm(sequence):
     )
 
 
-def test_base_running_means(result_higher_is_better):
-    np.testing.assert_array_equal(result_higher_is_better.running_means, np.array([0.4, 0.6]))
+def test_base_properties(result_with_alarm, result_without_alarm):
+    np.testing.assert_array_equal(result_with_alarm.running_means, np.array([0.4, 0.6]))
+    np.testing.assert_array_equal(result_with_alarm.confidence_bounds, np.array([0.1, 0.55]))
+    assert result_with_alarm.n_batches == 2
+    np.testing.assert_array_equal(result_with_alarm.alarms, np.array([True, False]))
+    assert result_with_alarm.drift_detected is True
+    assert result_with_alarm.first_alarm_index == 0
+
+    np.testing.assert_array_equal(result_without_alarm.alarms, np.array([False, False]))
+    assert result_without_alarm.drift_detected is False
+    assert result_without_alarm.first_alarm_index is None
 
 
-def test_base_confidence_bounds(result_higher_is_better):
-    np.testing.assert_array_equal(result_higher_is_better.confidence_bounds, np.array([0.1, 0.55]))
-
-
-def test_base_alarms_higher_is_better(result_higher_is_better):
-    np.testing.assert_array_equal(result_higher_is_better.alarms, np.array([True, False]))
-
-
-def test_base_alarms_lower_is_better(result_lower_is_better):
-    np.testing.assert_array_equal(result_lower_is_better.alarms, np.array([False, True]))
-
-
-def test_base_n_batches(result_higher_is_better):
-    assert result_higher_is_better.n_batches == 2
-
-
-def test_base_drift_detected_true(result_higher_is_better):
-    assert result_higher_is_better.drift_detected is True
-
-
-def test_base_drift_detected_false(result_no_alarm):
-    assert result_no_alarm.drift_detected is False
-
-
-def test_base_first_alarm_index_at_zero(result_higher_is_better):
-    assert result_higher_is_better.first_alarm_index == 0
-
-
-def test_base_first_alarm_index_not_at_zero(result_lower_is_better):
-    assert result_lower_is_better.first_alarm_index == 1
-
-
-def test_base_first_alarm_index_none(result_no_alarm):
-    assert result_no_alarm.first_alarm_index is None
-
-
-def test_base_repr_equals_str_equals_summary(result_higher_is_better):
-    assert repr(result_higher_is_better) == str(result_higher_is_better)
-    assert str(result_higher_is_better) == result_higher_is_better.summary()
+def test_base_repr_equals_str_equals_summary(result_with_alarm):
+    assert repr(result_with_alarm) == str(result_with_alarm)
+    assert str(result_with_alarm) == result_with_alarm.summary()
 
 
 # --- MeanMonitoringResult.__str__ ---
 
 
-def test_base_str(result_higher_is_better):
+def test_base_str(result_with_alarm):
     expected = (
         "Metric: accuracy\n"
         "Monitor: Test\n"
@@ -117,4 +76,4 @@ def test_base_str(result_higher_is_better):
         "Confidence Bound: 0.550\n"
         "Confidence Level: 0.95"
     )
-    assert str(result_higher_is_better) == expected
+    assert str(result_with_alarm) == expected

--- a/tests/unit/mean_monitoring_results/test_base.py
+++ b/tests/unit/mean_monitoring_results/test_base.py
@@ -34,8 +34,8 @@ def result_without_alarm(sequence):
     return MeanMonitoringResult(
         metric_name="accuracy",
         monitor_name="Test",
-        higher_is_better=True,
-        alarm_threshold=-1.0,
+        higher_is_better=False,
+        alarm_threshold=2.0,
         confidence_level=0.95,
         batch_identifiers=np.array([0, 1]),
         batch_mean_estimates=np.array([0.4, 0.8]),

--- a/tests/unit/mean_monitoring_results/test_classical.py
+++ b/tests/unit/mean_monitoring_results/test_classical.py
@@ -1,26 +1,50 @@
 import numpy as np
+import pytest
 
 from glide.confidence_sequences import EmpiricalBernsteinConfidenceSequence
 from glide.mean_monitoring_results import ClassicalMeanMonitoringResult
 
 # --- ClassicalMeanMonitoringResult ---
 
-_SEQUENCE = EmpiricalBernsteinConfidenceSequence(
-    running_mean_estimates=np.array([0.4, 0.6]),
-    confidence_bounds=np.array([0.1, 0.55]),
-)
-_CLASSICAL = ClassicalMeanMonitoringResult(
-    metric_name="accuracy",
-    monitor_name="Classical",
-    higher_is_better=True,
-    alarm_threshold=0.5,
-    confidence_level=0.95,
-    batch_identifiers=np.array([0, 1]),
-    batch_mean_estimates=np.array([0.4, 0.8]),
-    confidence_sequence=_SEQUENCE,
-    batch_n=np.array([10, 12]),
-)
+
+@pytest.fixture
+def sequence():
+    return EmpiricalBernsteinConfidenceSequence(
+        running_mean_estimates=np.array([0.4, 0.6]),
+        confidence_bounds=np.array([0.1, 0.55]),
+    )
 
 
-def test_classical_batch_n():
-    np.testing.assert_array_equal(_CLASSICAL.batch_n, np.array([10, 12]))
+@pytest.fixture
+def classical_result(sequence):
+    return ClassicalMeanMonitoringResult(
+        metric_name="accuracy",
+        monitor_name="Classical",
+        higher_is_better=True,
+        alarm_threshold=0.5,
+        confidence_level=0.95,
+        batch_identifiers=np.array([0, 1]),
+        batch_mean_estimates=np.array([0.4, 0.8]),
+        confidence_sequence=sequence,
+        batch_n=np.array([10, 12]),
+    )
+
+
+def test_classical_batch_n(classical_result):
+    np.testing.assert_array_equal(classical_result.batch_n, np.array([10, 12]))
+
+
+def test_classical_str(classical_result):
+    expected = (
+        "Metric: accuracy\n"
+        "Monitor: Classical\n"
+        "Number of Batches: 2\n"
+        "Drift Detected: True\n"
+        "First Alarm Index: 0\n"
+        "Alarm Threshold: 0.500\n"
+        "Running Mean: 0.600\n"
+        "Confidence Bound: 0.550\n"
+        "Confidence Level: 0.95\n"
+        "batch_n: 12"
+    )
+    assert str(classical_result) == expected

--- a/tests/unit/mean_monitoring_results/test_classical.py
+++ b/tests/unit/mean_monitoring_results/test_classical.py
@@ -67,6 +67,6 @@ def test_classical_str(classical_result):
         "Running Mean: 0.600\n"
         "Confidence Bound: 0.550\n"
         "Confidence Level: 0.95\n"
-        "batch_n: 12"
+        "batch_n: [10, 12]"
     )
     assert str(classical_result) == expected

--- a/tests/unit/mean_monitoring_results/test_classical.py
+++ b/tests/unit/mean_monitoring_results/test_classical.py
@@ -1,0 +1,26 @@
+import numpy as np
+
+from glide.confidence_sequences import EmpiricalBernsteinConfidenceSequence
+from glide.mean_monitoring_results import ClassicalMeanMonitoringResult
+
+# --- ClassicalMeanMonitoringResult ---
+
+_SEQUENCE = EmpiricalBernsteinConfidenceSequence(
+    running_mean_estimates=np.array([0.4, 0.6]),
+    confidence_bounds=np.array([0.1, 0.55]),
+)
+_CLASSICAL = ClassicalMeanMonitoringResult(
+    metric_name="accuracy",
+    monitor_name="Classical",
+    higher_is_better=True,
+    alarm_threshold=0.5,
+    confidence_level=0.95,
+    batch_identifiers=np.array([0, 1]),
+    batch_mean_estimates=np.array([0.4, 0.8]),
+    confidence_sequence=_SEQUENCE,
+    batch_n=np.array([10, 12]),
+)
+
+
+def test_classical_batch_n():
+    np.testing.assert_array_equal(_CLASSICAL.batch_n, np.array([10, 12]))

--- a/tests/unit/mean_monitoring_results/test_classical.py
+++ b/tests/unit/mean_monitoring_results/test_classical.py
@@ -1,6 +1,9 @@
+from unittest.mock import patch
+
 import numpy as np
 import pytest
 
+import glide.mean_monitoring_results.classical as classical_module
 from glide.confidence_sequences import EmpiricalBernsteinConfidenceSequence
 from glide.mean_monitoring_results import ClassicalMeanMonitoringResult
 
@@ -23,7 +26,6 @@ def classical_result(sequence):
         higher_is_better=True,
         alarm_threshold=0.5,
         confidence_level=0.95,
-        batch_identifiers=np.array([0, 1]),
         batch_mean_estimates=np.array([0.4, 0.8]),
         confidence_sequence=sequence,
         batch_n=np.array([10, 12]),
@@ -32,6 +34,26 @@ def classical_result(sequence):
 
 def test_classical_batch_n(classical_result):
     np.testing.assert_array_equal(classical_result.batch_n, np.array([10, 12]))
+
+
+def test_classical_post_init_delegates_to_validation(sequence):
+    batch_mean_estimates = np.array([0.4, 0.8])
+    batch_n = np.array([10, 12])
+    with patch.object(classical_module, "_validate_equal_lengths") as mock_validate_equal_lengths:
+        ClassicalMeanMonitoringResult(
+            metric_name="accuracy",
+            monitor_name="Classical",
+            higher_is_better=True,
+            alarm_threshold=0.5,
+            confidence_level=0.95,
+            batch_mean_estimates=batch_mean_estimates,
+            confidence_sequence=sequence,
+            batch_n=batch_n,
+        )
+        mock_validate_equal_lengths.assert_called_once()
+        np.testing.assert_array_equal(mock_validate_equal_lengths.call_args[0][0], batch_mean_estimates)
+        np.testing.assert_array_equal(mock_validate_equal_lengths.call_args[0][1], batch_n)
+        assert mock_validate_equal_lengths.call_args[1] == {"names": ["batch_mean_estimates", "batch_n"]}
 
 
 def test_classical_str(classical_result):

--- a/tests/unit/mean_monitoring_results/test_prediction_powered.py
+++ b/tests/unit/mean_monitoring_results/test_prediction_powered.py
@@ -31,11 +31,8 @@ def prediction_powered_result(sequence):
     )
 
 
-def test_prediction_powered_batch_n_true(prediction_powered_result):
+def test_prediction_powered_batch_n_properties(prediction_powered_result):
     np.testing.assert_array_equal(prediction_powered_result.batch_n_true, np.array([10, 12]))
-
-
-def test_prediction_powered_batch_n_proxy(prediction_powered_result):
     np.testing.assert_array_equal(prediction_powered_result.batch_n_proxy, np.array([100, 120]))
 
 

--- a/tests/unit/mean_monitoring_results/test_prediction_powered.py
+++ b/tests/unit/mean_monitoring_results/test_prediction_powered.py
@@ -1,0 +1,31 @@
+import numpy as np
+
+from glide.confidence_sequences import EmpiricalBernsteinConfidenceSequence
+from glide.mean_monitoring_results import PredictionPoweredMeanMonitoringResult
+
+# --- PredictionPoweredMeanMonitoringResult ---
+
+_SEQUENCE = EmpiricalBernsteinConfidenceSequence(
+    running_mean_estimates=np.array([0.4, 0.6]),
+    confidence_bounds=np.array([0.1, 0.55]),
+)
+_PREDICTION_POWERED = PredictionPoweredMeanMonitoringResult(
+    metric_name="accuracy",
+    monitor_name="PPI",
+    higher_is_better=True,
+    alarm_threshold=0.5,
+    confidence_level=0.95,
+    batch_identifiers=np.array([0, 1]),
+    batch_mean_estimates=np.array([0.4, 0.8]),
+    confidence_sequence=_SEQUENCE,
+    batch_n_true=np.array([10, 12]),
+    batch_n_proxy=np.array([100, 120]),
+)
+
+
+def test_prediction_powered_batch_n_true():
+    np.testing.assert_array_equal(_PREDICTION_POWERED.batch_n_true, np.array([10, 12]))
+
+
+def test_prediction_powered_batch_n_proxy():
+    np.testing.assert_array_equal(_PREDICTION_POWERED.batch_n_proxy, np.array([100, 120]))

--- a/tests/unit/mean_monitoring_results/test_prediction_powered.py
+++ b/tests/unit/mean_monitoring_results/test_prediction_powered.py
@@ -74,7 +74,7 @@ def test_prediction_powered_str(prediction_powered_result):
         "Running Mean: 0.600\n"
         "Confidence Bound: 0.550\n"
         "Confidence Level: 0.95\n"
-        "batch_n_true: 12\n"
-        "batch_n_proxy: 120"
+        "batch_n_true: [10, 12]\n"
+        "batch_n_proxy: [100, 120]"
     )
     assert str(prediction_powered_result) == expected

--- a/tests/unit/mean_monitoring_results/test_prediction_powered.py
+++ b/tests/unit/mean_monitoring_results/test_prediction_powered.py
@@ -1,31 +1,56 @@
 import numpy as np
+import pytest
 
 from glide.confidence_sequences import EmpiricalBernsteinConfidenceSequence
 from glide.mean_monitoring_results import PredictionPoweredMeanMonitoringResult
 
 # --- PredictionPoweredMeanMonitoringResult ---
 
-_SEQUENCE = EmpiricalBernsteinConfidenceSequence(
-    running_mean_estimates=np.array([0.4, 0.6]),
-    confidence_bounds=np.array([0.1, 0.55]),
-)
-_PREDICTION_POWERED = PredictionPoweredMeanMonitoringResult(
-    metric_name="accuracy",
-    monitor_name="PPI",
-    higher_is_better=True,
-    alarm_threshold=0.5,
-    confidence_level=0.95,
-    batch_identifiers=np.array([0, 1]),
-    batch_mean_estimates=np.array([0.4, 0.8]),
-    confidence_sequence=_SEQUENCE,
-    batch_n_true=np.array([10, 12]),
-    batch_n_proxy=np.array([100, 120]),
-)
+
+@pytest.fixture
+def sequence():
+    return EmpiricalBernsteinConfidenceSequence(
+        running_mean_estimates=np.array([0.4, 0.6]),
+        confidence_bounds=np.array([0.1, 0.55]),
+    )
 
 
-def test_prediction_powered_batch_n_true():
-    np.testing.assert_array_equal(_PREDICTION_POWERED.batch_n_true, np.array([10, 12]))
+@pytest.fixture
+def prediction_powered_result(sequence):
+    return PredictionPoweredMeanMonitoringResult(
+        metric_name="accuracy",
+        monitor_name="PPI",
+        higher_is_better=True,
+        alarm_threshold=0.5,
+        confidence_level=0.95,
+        batch_identifiers=np.array([0, 1]),
+        batch_mean_estimates=np.array([0.4, 0.8]),
+        confidence_sequence=sequence,
+        batch_n_true=np.array([10, 12]),
+        batch_n_proxy=np.array([100, 120]),
+    )
 
 
-def test_prediction_powered_batch_n_proxy():
-    np.testing.assert_array_equal(_PREDICTION_POWERED.batch_n_proxy, np.array([100, 120]))
+def test_prediction_powered_batch_n_true(prediction_powered_result):
+    np.testing.assert_array_equal(prediction_powered_result.batch_n_true, np.array([10, 12]))
+
+
+def test_prediction_powered_batch_n_proxy(prediction_powered_result):
+    np.testing.assert_array_equal(prediction_powered_result.batch_n_proxy, np.array([100, 120]))
+
+
+def test_prediction_powered_str(prediction_powered_result):
+    expected = (
+        "Metric: accuracy\n"
+        "Monitor: PPI\n"
+        "Number of Batches: 2\n"
+        "Drift Detected: True\n"
+        "First Alarm Index: 0\n"
+        "Alarm Threshold: 0.500\n"
+        "Running Mean: 0.600\n"
+        "Confidence Bound: 0.550\n"
+        "Confidence Level: 0.95\n"
+        "batch_n_true: 12\n"
+        "batch_n_proxy: 120"
+    )
+    assert str(prediction_powered_result) == expected

--- a/tests/unit/mean_monitoring_results/test_prediction_powered.py
+++ b/tests/unit/mean_monitoring_results/test_prediction_powered.py
@@ -1,6 +1,9 @@
+from unittest.mock import patch
+
 import numpy as np
 import pytest
 
+import glide.mean_monitoring_results.prediction_powered as prediction_powered_module
 from glide.confidence_sequences import EmpiricalBernsteinConfidenceSequence
 from glide.mean_monitoring_results import PredictionPoweredMeanMonitoringResult
 
@@ -23,7 +26,6 @@ def prediction_powered_result(sequence):
         higher_is_better=True,
         alarm_threshold=0.5,
         confidence_level=0.95,
-        batch_identifiers=np.array([0, 1]),
         batch_mean_estimates=np.array([0.4, 0.8]),
         confidence_sequence=sequence,
         batch_n_true=np.array([10, 12]),
@@ -34,6 +36,31 @@ def prediction_powered_result(sequence):
 def test_prediction_powered_batch_n_properties(prediction_powered_result):
     np.testing.assert_array_equal(prediction_powered_result.batch_n_true, np.array([10, 12]))
     np.testing.assert_array_equal(prediction_powered_result.batch_n_proxy, np.array([100, 120]))
+
+
+def test_prediction_powered_post_init_delegates_to_validation(sequence):
+    batch_mean_estimates = np.array([0.4, 0.8])
+    batch_n_true = np.array([10, 12])
+    batch_n_proxy = np.array([100, 120])
+    with patch.object(prediction_powered_module, "_validate_equal_lengths") as mock_validate_equal_lengths:
+        PredictionPoweredMeanMonitoringResult(
+            metric_name="accuracy",
+            monitor_name="PPI",
+            higher_is_better=True,
+            alarm_threshold=0.5,
+            confidence_level=0.95,
+            batch_mean_estimates=batch_mean_estimates,
+            confidence_sequence=sequence,
+            batch_n_true=batch_n_true,
+            batch_n_proxy=batch_n_proxy,
+        )
+        mock_validate_equal_lengths.assert_called_once()
+        np.testing.assert_array_equal(mock_validate_equal_lengths.call_args[0][0], batch_mean_estimates)
+        np.testing.assert_array_equal(mock_validate_equal_lengths.call_args[0][1], batch_n_true)
+        np.testing.assert_array_equal(mock_validate_equal_lengths.call_args[0][2], batch_n_proxy)
+        assert mock_validate_equal_lengths.call_args[1] == {
+            "names": ["batch_mean_estimates", "batch_n_true", "batch_n_proxy"]
+        }
 
 
 def test_prediction_powered_str(prediction_powered_result):


### PR DESCRIPTION

### Description

- Adds `glide.mean_monitoring_results` module with `MeanMonitoringResult` (base), `ClassicalMeanMonitoringResult` and `PredictionPoweredMeanMonitoringResult`: result objects returned by anytime-valid drift-monitoring procedures over batched data, exposing running means, confidence bounds and alarm state derived from an embedded `ConfidenceSequence`.
- Closes #315
- Noteworthy: `running_means` was renamed to `running_mean_estimates` on the `ConfidenceSequence` object. `confidence_level` is now supplied as a field at construction on `MeanMonitoringResult`, since it was removed from `ConfidenceSequence`.

### Checklist

Quality gates that must be satisfied before requesting a review:

- [x] I have read `CONTRIBUTING.md`
- [x] `make lint` passes
- [x] `make type-check` passes
- [x] `make tests` passes
- [x] `make coverage` reports 100% coverage
- [x] `make test-notebooks` passes
- [x] New public API has numpy-style docstrings
- [x] New public API is inserted in the API reference section of the documentation
- [x] Docs build without warnings (`make doc`)
- [x] `CHANGELOG.md` updated if the change is user-facing

### LLM usage

Disclose if an LLM was used in writing this PR:
- [ ] No LLM used
- [x] I used an LLM and I went through and validated all the code myself