### PR TITLE
Add PPIMeanMonitor for anytime-valid drift detection (PPRM)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ## [Next release]
 
 ### ✨ Added
+- `PPIMeanMonitor` in `glide.monitors`: anytime-valid drift detection over batched production data combining true and proxy labels.
 - `glide.monitors` module with `ClassicalMeanMonitor`: detects drift of a metric across batches of labeled data.
 - `glide.confidence_sequences` module with the `ConfidenceSequence` protocol and `EmpiricalBernsteinConfidenceSequence`: an anytime-valid empirical-Bernstein confidence sequence.
 - `glide.mean_monitoring_results` module with `MeanMonitoringResult`, `ClassicalMeanMonitoringResult` and `PredictionPoweredMeanMonitoringResult`: result objects for drift-monitoring procedures over batched datasets.

--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ If you use GLIDE in your work, please cite us using the "Cite this repository" b
 | Stratified Predict-Then-Debias | `estimators.StratifiedPTDMeanEstimator` | [[7]](#ref-7) | [Link](https://github.com/DanKluger/PTDBoot) |
 | Clustered Predict-Then-Debias | `estimators.ClusteredPTDMeanEstimator` | [[7]](#ref-7) | [Link](https://github.com/DanKluger/PTDBoot) |
 | IPW Predict-Then-Debias | `estimators.IPWPTDMeanEstimator` | [[7]](#ref-7) | [Link](https://github.com/DanKluger/PTDBoot) |
+| Prediction-Powered Risk Monitoring (PPRM) | `monitors.PPIMeanMonitor` | [[9]](#ref-9), [[10]](#ref-10) | — |
 
 ### 📖 References
 
@@ -106,6 +107,10 @@ If you use GLIDE in your work, please cite us using the "Cite this repository" b
 <a id="ref-7"></a>[7] <a href="https://arxiv.org/abs/2501.18577">Kluger, Dan M., Kerri Lu, Tijana Zrnic, Sherrie Wang, and Stephen Bates. "Prediction-powered inference with imputed covariates and nonuniform sampling." arXiv preprint arXiv:2501.18577 (2025).</a>
 
 <a id="ref-8"></a>[8] <a id="ref-8-link" href="https://arxiv.org/abs/2509.21707">Shan, Jiawei, Zhifeng Chen, Yiming Dong, Yazhen Wang, and Jiwei Zhao. "SADA: Safe and Adaptive Aggregation of Multiple Black-Box Predictions in Semi-Supervised Learning." arXiv preprint arXiv:2509.21707 (2025).</a>.
+
+<a id="ref-9"></a>[9] <a href="https://arxiv.org/abs/2602.02229">Zhang, Guangyi, Yunlong Cai, Guanding Yu, and Osvaldo Simeone. "Prediction-Powered Risk Monitoring of Deployed Models for Detecting Harmful Distribution Shifts." arXiv preprint arXiv:2602.02229 (2026).</a>
+
+<a id="ref-10"></a>[10] <a href="https://arxiv.org/abs/2110.06177">Podkopaev, Aleksandr, and Aaditya Ramdas. "Tracking the risk of a deployed model and detecting harmful distribution shifts." International Conference on Learning Representations (ICLR), 2022.</a>
 
 ## 📬 Stay Updated
 

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -50,9 +50,17 @@
 
 ## Monitors
 
+### Classical
+
 | Class | Description |
 |-------|-------------|
 | [`ClassicalMeanMonitor`](monitors.md#glide.monitors.classical.ClassicalMeanMonitor) | Anytime-valid drift monitor over batched labels, without proxy predictions |
+
+### Prediction-Powered
+
+| Class | Description |
+|-------|-------------|
+| [`PPIMeanMonitor`](monitors.md#glide.monitors.ppi.PPIMeanMonitor) | Anytime-valid drift monitor combining true and proxy labels |
 
 ## Confidence Intervals
 

--- a/docs/api/monitors.md
+++ b/docs/api/monitors.md
@@ -1,3 +1,7 @@
 # Monitors
 
 ::: glide.monitors.classical.ClassicalMeanMonitor
+
+---
+
+::: glide.monitors.ppi.PPIMeanMonitor

--- a/glide/monitors/__init__.py
+++ b/glide/monitors/__init__.py
@@ -1,5 +1,7 @@
 from glide.monitors.classical import ClassicalMeanMonitor
+from glide.monitors.ppi import PPIMeanMonitor
 
 __all__ = [
     "ClassicalMeanMonitor",
+    "PPIMeanMonitor",
 ]

--- a/glide/monitors/ppi.py
+++ b/glide/monitors/ppi.py
@@ -64,6 +64,8 @@ class PPIMeanMonitor:
     >>> result = monitor.detect(y_true, y_proxy, batches, higher_is_better=False, threshold=0.5)
     >>> result.drift_detected
     True
+    >>> result.first_alarm_index
+    23
     """
 
     def _preprocess(
@@ -243,10 +245,9 @@ class PPIMeanMonitor:
         confidence_level : float, optional
             How confident each alarm should be. At the default ``0.8`` the monitor
             raises "80% confident" alarms: under no drift it has at most a 20% chance
-            of *ever* raising a false alarm, no matter how often you look. Raising it
-            (say to ``0.95``) demands more evidence before alarming, so alarms become
-            more trustworthy but arrive later; lowering it detects sooner at the cost
-            of more false alarms.
+            of raising a false alarm. Raising this value demands more evidence before
+            alarming, so alarms become more trustworthy but arrive later; lowering it
+            detects sooner at the cost of more false alarms.
         power_tuning : bool, optional
             If ``True`` (default), compute the power-tuning parameter of each batch on
             all previous batches (the first batch, having no predecessor, uses 1). If
@@ -299,7 +300,7 @@ class PPIMeanMonitor:
 
         risk_batch_estimates = np.empty(n_batches)
         for position in range(n_batches):
-            if position == 0:
+            if position == 0 or (not power_tuning):
                 tuning_parameter = 1.0
             else:
                 earlier_mask = batch_codes < position

--- a/glide/monitors/ppi.py
+++ b/glide/monitors/ppi.py
@@ -1,0 +1,357 @@
+from typing import Tuple
+
+import numpy as np
+from numpy.typing import NDArray
+
+from glide.confidence_sequences import EmpiricalBernsteinConfidenceSequence
+from glide.confidence_sequences.empirical_bernstein import _compute_empirical_bernstein_bounds
+from glide.core.validation import (
+    _validate_bounds,
+    _validate_equal_lengths,
+    _validate_has_no_nan,
+    _validate_non_empty,
+    _validate_y_proxy,
+    _validate_y_true,
+)
+from glide.estimators.core import _split_labeled_unlabeled
+from glide.estimators.ppi_core import _compute_mean_estimate
+from glide.mean_monitoring_results import PredictionPoweredMeanMonitoringResult
+from glide.monitors.core import _scale_from_unit_risk, _scale_to_unit_risk, _unique_ordered_batches
+from glide.monitors.ppi_core import (
+    _compute_clipped_tuning_parameter,
+    _denormalize_from_unit_interval,
+    _normalize_to_unit_interval,
+)
+
+
+class PPIMeanMonitor:
+    """Anytime-valid drift monitor over a batched dataset of true and proxy labels.
+
+    It uses a per-batch Prediction-Powered Inference (PPI) estimate: a small set of
+    true labels and a large set of proxy labels, combined with a power-tuning
+    parameter fitted on the batches that strictly precede it (predictable, as
+    required for validity). To be used on accumulated non-overlapping production
+    batches by calling :meth:`detect` on the whole accumulated dataset at any time.
+    Data is passed oldest batch first, and every batch is monitored. The monitor
+    builds an anytime-valid confidence sequence on the running mean of the per-batch
+    PPI estimates, and raises a drift alarm when it crosses a user-supplied
+    ``threshold`` (the worst tolerable metric value). Because the bounds are valid at
+    all times simultaneously, :meth:`detect` may be called after every new batch
+    without inflating the false-alarm probability.
+
+    References
+    ----------
+    Zhang, Guangyi, Yunlong Cai, Guanding Yu, and Osvaldo Simeone. "Prediction-powered
+    risk monitoring of deployed models for detecting harmful distribution shifts."
+    arXiv preprint arXiv:2602.02229 (2026).
+
+    Howard, Steven R., Aaditya Ramdas, Jon McAuliffe, and Jasjeet Sekhon. "Time-uniform,
+    nonparametric, nonasymptotic confidence sequences." The Annals of Statistics 49,
+    no. 2 (2021): 1055-1080.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from glide.monitors import PPIMeanMonitor
+    >>> pre_drift_y_true = np.array([0.0, 0.2, np.nan, np.nan])
+    >>> pre_drift_y_proxy = np.array([0.0, 0.2, 0.0, 0.2])
+    >>> post_drift_y_true = np.array([0.8, 1.0, np.nan, np.nan])
+    >>> post_drift_y_proxy = np.array([0.8, 1.0, 0.8, 1.0])
+    >>> y_true = np.hstack([pre_drift_y_true, np.tile(post_drift_y_true, 50)])
+    >>> y_proxy = np.hstack([pre_drift_y_proxy, np.tile(post_drift_y_proxy, 50)])
+    >>> batches = np.repeat(np.arange(51), 4)
+    >>> monitor = PPIMeanMonitor()
+    >>> result = monitor.detect(y_true, y_proxy, batches, higher_is_better=False, threshold=0.5)
+    >>> result.drift_detected
+    True
+    """
+
+    def _preprocess(
+        self,
+        y_true: NDArray,
+        y_proxy: NDArray,
+        batches: NDArray,
+        higher_is_better: bool,
+        threshold: float,
+        confidence_level: float,
+        max_tuning_parameter: float,
+        metric_lower_bound: float,
+        metric_upper_bound: float,
+    ) -> Tuple[NDArray, NDArray, float, NDArray, NDArray, NDArray]:
+        _validate_non_empty(y_true, "y_true")
+        _validate_equal_lengths(y_true, y_proxy, batches, names=["y_true", "y_proxy", "batches"])
+        _validate_has_no_nan(batches, "batches")
+        _validate_bounds(
+            confidence_level, "confidence_level", lower=0, upper=1, left_inclusive=False, right_inclusive=False
+        )
+        _validate_bounds(max_tuning_parameter, "max_tuning_parameter", lower=0, left_inclusive=False)
+        _validate_bounds(
+            metric_lower_bound,
+            "metric_lower_bound",
+            upper=metric_upper_bound,
+            right_inclusive=False,
+            error_message=(
+                f"'metric_lower_bound' must be strictly smaller than 'metric_upper_bound'; "
+                f"got {metric_lower_bound!r} and {metric_upper_bound!r}."
+            ),
+        )
+        _validate_bounds(
+            threshold,
+            "threshold",
+            lower=metric_lower_bound,
+            upper=metric_upper_bound,
+            error_message=(
+                f"'threshold' must lie between 'metric_lower_bound'={metric_lower_bound!r} and "
+                f"'metric_upper_bound'={metric_upper_bound!r}."
+            ),
+        )
+        _validate_y_proxy(y_proxy)
+        _validate_y_true(y_true)
+        labeled_mask = ~np.isnan(y_true)
+        labeled_values = y_true[labeled_mask]
+        _validate_bounds(
+            labeled_values,
+            "y_true",
+            lower=metric_lower_bound,
+            upper=metric_upper_bound,
+            error_message=(
+                f"'y_true' values must lie between 'metric_lower_bound'={metric_lower_bound!r} and "
+                f"'metric_upper_bound'={metric_upper_bound!r}; got values in "
+                f"[{labeled_values.min()!r}, {labeled_values.max()!r}]."
+            ),
+        )
+        _validate_bounds(
+            y_proxy,
+            "y_proxy",
+            lower=metric_lower_bound,
+            upper=metric_upper_bound,
+            error_message=(
+                f"'y_proxy' values must lie between 'metric_lower_bound'={metric_lower_bound!r} and "
+                f"'metric_upper_bound'={metric_upper_bound!r}; got values in "
+                f"[{y_proxy.min()!r}, {y_proxy.max()!r}]."
+            ),
+        )
+        batch_identifiers, batch_codes = _unique_ordered_batches(batches)
+        n_batches = len(batch_identifiers)
+        batch_n_true = np.bincount(batch_codes[labeled_mask], minlength=n_batches)
+        batch_n_proxy = np.bincount(batch_codes, minlength=n_batches)
+        batch_n_unlabeled = batch_n_proxy - batch_n_true
+
+        worst_labeled_position = np.argmin(batch_n_true)
+        _validate_bounds(
+            batch_n_true[worst_labeled_position],
+            "y_true",
+            lower=2,
+            error_message=(
+                f"'y_true' must have at least 2 labeled values per batch; got "
+                f"{batch_n_true[worst_labeled_position]} in batch '{batch_identifiers[worst_labeled_position]}'."
+            ),
+        )
+        worst_unlabeled_position = np.argmin(batch_n_unlabeled)
+        _validate_bounds(
+            batch_n_unlabeled[worst_unlabeled_position],
+            "y_true",
+            lower=2,
+            error_message=(
+                f"'y_true' must have at least 2 unlabeled values per batch; got "
+                f"{batch_n_unlabeled[worst_unlabeled_position]} in batch "
+                f"'{batch_identifiers[worst_unlabeled_position]}'."
+            ),
+        )
+
+        risk_y_true = _scale_to_unit_risk(y_true, metric_lower_bound, metric_upper_bound, higher_is_better)
+        risk_y_proxy = _scale_to_unit_risk(y_proxy, metric_lower_bound, metric_upper_bound, higher_is_better)
+        risk_threshold = _scale_to_unit_risk(threshold, metric_lower_bound, metric_upper_bound, higher_is_better)
+        return risk_y_true, risk_y_proxy, risk_threshold, batch_codes, batch_n_true, batch_n_proxy
+
+    def _postprocess(
+        self,
+        risk_running_means: NDArray,
+        risk_confidence_bounds: NDArray,
+        risk_batch_mean_estimates: NDArray,
+        higher_is_better: bool,
+        metric_lower_bound: float,
+        metric_upper_bound: float,
+    ) -> Tuple[NDArray, NDArray, NDArray]:
+        running_means = _scale_from_unit_risk(
+            risk_running_means, metric_lower_bound, metric_upper_bound, higher_is_better
+        )
+        confidence_bounds = _scale_from_unit_risk(
+            risk_confidence_bounds, metric_lower_bound, metric_upper_bound, higher_is_better
+        )
+        batch_mean_estimates = _scale_from_unit_risk(
+            risk_batch_mean_estimates, metric_lower_bound, metric_upper_bound, higher_is_better
+        )
+        return running_means, confidence_bounds, batch_mean_estimates
+
+    def detect(
+        self,
+        y_true: NDArray,
+        y_proxy: NDArray,
+        batches: NDArray,
+        higher_is_better: bool,
+        threshold: float,
+        metric_name: str = "Metric",
+        confidence_level: float = 0.8,
+        power_tuning: bool = True,
+        metric_lower_bound: float = 0.0,
+        metric_upper_bound: float = 1.0,
+        max_tuning_parameter: float = 1.0,
+    ) -> PredictionPoweredMeanMonitoringResult:
+        """Detect a drift of the running mean across a batched dataset.
+
+        Splits the data by batch, computes a prediction-powered estimate per batch
+        with a power-tuning parameter fitted only on batches that strictly precede
+        it (the first batch, having no predecessor, uses the classic PPI weight of
+        1), and builds an anytime-valid empirical-Bernstein confidence sequence on
+        the running mean of those estimates. An alarm is raised at every batch where
+        the sequence crosses the user-supplied ``threshold``.
+
+        Rows must be ordered oldest batch first and grouped into contiguous blocks;
+        identifier values are not compared, so any label type works. Batches must be
+        non-overlapping (no shared samples), and successive calls must be made on
+        growing histories of the same data; passing the full accumulated dataset at
+        every call makes the anytime-valid guarantee hold jointly over all calls.
+        Alternatively the data may be restricted to the most recent batches, in which
+        case the guarantee holds within each restriction but not across the moving
+        history as a whole.
+
+        Parameters
+        ----------
+        y_true : NDArray
+            Array of labeled observations, shape ``(n_samples,)``.
+            Labeled entries are finite; unlabeled entries are ``np.nan``.
+        y_proxy : NDArray
+            Array of proxy predictions, shape ``(n_samples,)``.
+            Must be fully populated (no NaN).
+        batches : NDArray
+            Array of batch identifiers, shape ``(n_samples,)``. Rows must be ordered
+            oldest batch first and grouped into contiguous blocks. Identifier values
+            are not compared, so any hashable label type works (integers, dates,
+            free-form strings).
+        higher_is_better : bool
+            ``False`` when the metric is a risk (drift means the metric increased),
+            ``True`` when it is a performance (drift means the metric decreased).
+        threshold : float
+            The metric value the running mean is monitored against, in metric units:
+            the worst level the user is willing to tolerate. An alarm fires once the
+            anytime-valid bound proves the running metric has crossed it (the running
+            risk exceeds it for a risk, the running performance falls below it for a
+            performance). Must lie within ``[metric_lower_bound, metric_upper_bound]``.
+        metric_name : str, optional
+            Human-readable label for the metric. Defaults to ``"Metric"``.
+        confidence_level : float, optional
+            How confident each alarm should be. At the default ``0.8`` the monitor
+            raises "80% confident" alarms: under no drift it has at most a 20% chance
+            of *ever* raising a false alarm, no matter how often you look. Raising it
+            (say to ``0.95``) demands more evidence before alarming, so alarms become
+            more trustworthy but arrive later; lowering it detects sooner at the cost
+            of more false alarms.
+        power_tuning : bool, optional
+            If ``True`` (default), compute the power-tuning parameter of each batch on
+            all previous batches (the first batch, having no predecessor, uses 1). If
+            ``False``, use 1 everywhere (classic PPI).
+        metric_lower_bound : float, optional
+            Known lower bound of the metric. Defaults to ``0.0``.
+        metric_upper_bound : float, optional
+            Known upper bound of the metric. Defaults to ``1.0``.
+        max_tuning_parameter : float, optional
+            Upper clip for the power-tuning parameter. Larger values allow more
+            reliance on the proxy but widen the confidence sequence through the
+            affine normalization. Defaults to ``1.0``.
+
+        Returns
+        -------
+        PredictionPoweredMeanMonitoringResult
+            Per-batch estimates, running means, anytime-valid confidence bounds,
+            alarm flags, and the alarm threshold, all in the original metric
+            orientation.
+
+        Raises
+        ------
+        ValueError
+            - If ``y_true`` is empty.
+            - If ``y_true``, ``y_proxy`` and ``batches`` have different lengths.
+            - If ``batches`` contains NaN values (numeric dtype) or None values (non-numeric dtype).
+            - If ``confidence_level`` is not in (0, 1).
+            - If ``max_tuning_parameter`` is not strictly positive.
+            - If ``metric_lower_bound >= metric_upper_bound``.
+            - If ``threshold`` falls outside ``[metric_lower_bound, metric_upper_bound]``.
+            - If any proxy value is NaN or all proxy values are identical.
+            - If labeled ``y_true`` values are constant.
+            - If any value falls outside ``[metric_lower_bound, metric_upper_bound]``.
+            - If batches are interleaved rather than grouped into contiguous blocks.
+            - If any batch has fewer than 2 labeled or fewer than 2 unlabeled samples.
+            - If proxy values are constant across the prior batches (with ``power_tuning=True``).
+        """
+        risk_y_true, risk_y_proxy, risk_threshold, batch_codes, batch_n_true, batch_n_proxy = self._preprocess(
+            y_true,
+            y_proxy,
+            batches,
+            higher_is_better,
+            threshold,
+            confidence_level,
+            max_tuning_parameter,
+            metric_lower_bound,
+            metric_upper_bound,
+        )
+        n_batches = len(batch_n_true)
+
+        risk_batch_estimates = np.empty(n_batches)
+        for position in range(n_batches):
+            if position == 0:
+                tuning_parameter = 1.0
+            else:
+                earlier_mask = batch_codes < position
+                y_true_earlier, y_proxy_labeled_earlier, y_proxy_unlabeled_earlier, _ = _split_labeled_unlabeled(
+                    risk_y_true[earlier_mask], risk_y_proxy[earlier_mask]
+                )
+                tuning_parameter = _compute_clipped_tuning_parameter(
+                    y_true_earlier,
+                    y_proxy_labeled_earlier,
+                    y_proxy_unlabeled_earlier,
+                    power_tuning,
+                    max_tuning_parameter,
+                )
+            batch_mask = batch_codes == position
+            y_true_labeled, y_proxy_labeled, y_proxy_unlabeled, _ = _split_labeled_unlabeled(
+                risk_y_true[batch_mask], risk_y_proxy[batch_mask]
+            )
+            risk_batch_estimates[position] = _compute_mean_estimate(
+                y_true_labeled, y_proxy_labeled, y_proxy_unlabeled, tuning_parameter
+            )
+
+        normalized_estimates = _normalize_to_unit_interval(risk_batch_estimates, max_tuning_parameter)
+        normalized_threshold = _normalize_to_unit_interval(risk_threshold, max_tuning_parameter)
+
+        miscoverage = 1.0 - confidence_level
+        normalized_running_means, normalized_lower_bounds = _compute_empirical_bernstein_bounds(
+            normalized_estimates, normalized_threshold, miscoverage
+        )
+
+        risk_running_means = _denormalize_from_unit_interval(normalized_running_means, max_tuning_parameter)
+        risk_lower_bounds = _denormalize_from_unit_interval(normalized_lower_bounds, max_tuning_parameter)
+        running_means, confidence_bounds, batch_mean_estimates = self._postprocess(
+            risk_running_means,
+            risk_lower_bounds,
+            risk_batch_estimates,
+            higher_is_better,
+            metric_lower_bound,
+            metric_upper_bound,
+        )
+        confidence_sequence = EmpiricalBernsteinConfidenceSequence(
+            running_mean_estimates=running_means,
+            confidence_bounds=confidence_bounds,
+        )
+        result = PredictionPoweredMeanMonitoringResult(
+            metric_name=metric_name,
+            monitor_name=self.__class__.__name__,
+            higher_is_better=higher_is_better,
+            alarm_threshold=threshold,
+            confidence_level=confidence_level,
+            batch_mean_estimates=batch_mean_estimates,
+            confidence_sequence=confidence_sequence,
+            batch_n_true=batch_n_true,
+            batch_n_proxy=batch_n_proxy,
+        )
+        return result

--- a/glide/monitors/ppi.py
+++ b/glide/monitors/ppi.py
@@ -30,14 +30,12 @@ class PPIMeanMonitor:
     It uses a per-batch Prediction-Powered Inference (PPI) estimate: a small set of
     true labels and a large set of proxy labels, combined with a power-tuning
     parameter fitted on the batches that strictly precede it (predictable, as
-    required for validity). To be used on accumulated non-overlapping production
-    batches by calling :meth:`detect` on the whole accumulated dataset at any time.
-    Data is passed oldest batch first, and every batch is monitored. The monitor
-    builds an anytime-valid confidence sequence on the running mean of the per-batch
-    PPI estimates, and raises a drift alarm when it crosses a user-supplied
-    ``threshold`` (the worst tolerable metric value). Because the bounds are valid at
-    all times simultaneously, :meth:`detect` may be called after every new batch
-    without inflating the false-alarm probability.
+    required for validity). The monitor builds an anytime-valid confidence sequence
+    on the running mean of the per-batch PPI estimates, and raises a drift alarm
+    when it crosses a user-supplied ``threshold`` (the worst tolerable metric
+    value). Because the bounds are valid at all times simultaneously, :meth:`detect`
+    may be called after every new batch without inflating the false-alarm
+    probability.
 
     References
     ----------

--- a/glide/monitors/ppi.py
+++ b/glide/monitors/ppi.py
@@ -200,12 +200,10 @@ class PPIMeanMonitor:
     ) -> PredictionPoweredMeanMonitoringResult:
         """Detect a drift of the running mean across a batched dataset.
 
-        Splits the data by batch, computes a prediction-powered estimate per batch
-        with a power-tuning parameter fitted only on batches that strictly precede
-        it (the first batch, having no predecessor, uses the classic PPI weight of
-        1), and builds an anytime-valid empirical-Bernstein confidence sequence on
-        the running mean of those estimates. An alarm is raised at every batch where
-        the sequence crosses the user-supplied ``threshold``.
+        Splits the data by batch, computes a prediction-powered estimate per batch,
+        and builds an anytime-valid empirical-Bernstein confidence sequence on the
+        running mean of those estimates. An alarm is raised at every batch where the
+        sequence crosses the user-supplied ``threshold``.
 
         Rows must be ordered oldest batch first and grouped into contiguous blocks;
         identifier values are not compared, so any label type works. Batches must be

--- a/glide/monitors/ppi.py
+++ b/glide/monitors/ppi.py
@@ -104,7 +104,7 @@ class PPIMeanMonitor:
             upper=metric_upper_bound,
             error_message=(
                 f"'threshold' must lie between 'metric_lower_bound'={metric_lower_bound!r} and "
-                f"'metric_upper_bound'={metric_upper_bound!r}."
+                f"'metric_upper_bound'={metric_upper_bound!r}; got {threshold!r}."
             ),
         )
         _validate_y_proxy(y_proxy)
@@ -250,8 +250,11 @@ class PPIMeanMonitor:
             detects sooner at the cost of more false alarms.
         power_tuning : bool, optional
             If ``True`` (default), compute the power-tuning parameter of each batch on
-            all previous batches (the first batch, having no predecessor, uses 1). If
-            ``False``, use 1 everywhere (classic PPI).
+            all previous batches (the first batch, having no predecessor, uses
+            ``min(1.0, max_tuning_parameter)``). If ``False``, use
+            ``min(1.0, max_tuning_parameter)`` everywhere (classic PPI). A tuning
+            parameter computed from data is additionally clipped to be no lower than
+            zero if the computation would otherwise turn out negative.
         metric_lower_bound : float, optional
             Known lower bound of the metric. Defaults to ``0.0``.
         metric_upper_bound : float, optional
@@ -301,7 +304,7 @@ class PPIMeanMonitor:
         risk_batch_estimates = np.empty(n_batches)
         for position in range(n_batches):
             if position == 0 or (not power_tuning):
-                tuning_parameter = 1.0
+                tuning_parameter = min(1.0, max_tuning_parameter)
             else:
                 earlier_mask = batch_codes < position
                 y_true_earlier, y_proxy_labeled_earlier, y_proxy_unlabeled_earlier, _ = _split_labeled_unlabeled(

--- a/glide/monitors/ppi_core.py
+++ b/glide/monitors/ppi_core.py
@@ -3,6 +3,7 @@ from typing import Union, overload
 from numpy.typing import NDArray
 
 from glide.estimators.ppi_core import _compute_tuning_parameter
+from glide.monitors.core import _scale_from_unit_risk, _scale_to_unit_risk
 
 
 def _compute_clipped_tuning_parameter(
@@ -25,8 +26,7 @@ def _normalize_to_unit_interval(
     values: Union[float, NDArray],
     max_tuning_parameter: float,
 ) -> Union[float, NDArray]:
-    normalization = 1.0 + 2.0 * max_tuning_parameter
-    normalized = (values + max_tuning_parameter) / normalization
+    normalized = _scale_to_unit_risk(values, -max_tuning_parameter, 1.0 + max_tuning_parameter, higher_is_better=False)
     return normalized
 
 
@@ -38,6 +38,5 @@ def _denormalize_from_unit_interval(
     values: Union[float, NDArray],
     max_tuning_parameter: float,
 ) -> Union[float, NDArray]:
-    normalization = 1.0 + 2.0 * max_tuning_parameter
-    original = values * normalization - max_tuning_parameter
+    original = _scale_from_unit_risk(values, -max_tuning_parameter, 1.0 + max_tuning_parameter, higher_is_better=False)
     return original

--- a/glide/monitors/ppi_core.py
+++ b/glide/monitors/ppi_core.py
@@ -1,0 +1,43 @@
+from typing import Union, overload
+
+from numpy.typing import NDArray
+
+from glide.estimators.ppi_core import _compute_tuning_parameter
+
+
+def _compute_clipped_tuning_parameter(
+    y_true_labeled: NDArray,
+    y_proxy_labeled: NDArray,
+    y_proxy_unlabeled: NDArray,
+    power_tuning: bool,
+    max_tuning_parameter: float,
+) -> float:
+    tuning_parameter = _compute_tuning_parameter(y_true_labeled, y_proxy_labeled, y_proxy_unlabeled, power_tuning)
+    clipped_tuning_parameter = min(max(tuning_parameter, 0.0), max_tuning_parameter)
+    return clipped_tuning_parameter
+
+
+@overload
+def _normalize_to_unit_interval(values: float, max_tuning_parameter: float) -> float: ...
+@overload
+def _normalize_to_unit_interval(values: NDArray, max_tuning_parameter: float) -> NDArray: ...
+def _normalize_to_unit_interval(
+    values: Union[float, NDArray],
+    max_tuning_parameter: float,
+) -> Union[float, NDArray]:
+    normalization = 1.0 + 2.0 * max_tuning_parameter
+    normalized = (values + max_tuning_parameter) / normalization
+    return normalized
+
+
+@overload
+def _denormalize_from_unit_interval(values: float, max_tuning_parameter: float) -> float: ...
+@overload
+def _denormalize_from_unit_interval(values: NDArray, max_tuning_parameter: float) -> NDArray: ...
+def _denormalize_from_unit_interval(
+    values: Union[float, NDArray],
+    max_tuning_parameter: float,
+) -> Union[float, NDArray]:
+    normalization = 1.0 + 2.0 * max_tuning_parameter
+    original = values * normalization - max_tuning_parameter
+    return original

--- a/tests/functional/monitors/test_classical.py
+++ b/tests/functional/monitors/test_classical.py
@@ -42,13 +42,7 @@ def test_detect_batch_mean_estimates_match_classical_estimator(y, batches):
 
 
 def test_detect_prefix_consistency(y, batches):
-    """Detecting on a growing history is prefix-consistent with detecting on the full history.
-
-    Every batch is monitored (there is no reference batch to exclude), so restricting
-    the call to the first k batches must reproduce exactly the first k entries of the
-    arrays returned by the call on the full dataset. This is the property that makes
-    repeated calls on a growing history jointly valid.
-    """
+    """Detecting on a growing history is prefix-consistent with detecting on the full history."""
     monitor = ClassicalMeanMonitor()
     full = monitor.detect(y, batches, higher_is_better=False, threshold=0.5)
     prefix_mask = batches <= 2

--- a/tests/functional/monitors/test_ppi.py
+++ b/tests/functional/monitors/test_ppi.py
@@ -9,56 +9,47 @@ import pytest
 
 from glide.estimators import PPIMeanEstimator
 from glide.monitors import PPIMeanMonitor
-from glide.simulators import generate_gaussian_dataset, simulate_annotation
+from glide.simulators import generate_stratified_binary_dataset, simulate_annotation
 
 # ── fixtures ───────────────────────────────────────────────────────────────────
 
 
 @pytest.fixture
-def batches():
-    return np.repeat(np.arange(5), 8)
+def dataset():
+    n_batches = 5
+    batch_size = 20
+    n_labeled_per_batch = 8
 
-
-@pytest.fixture
-def y_true_oracle_and_proxy():
-    return generate_gaussian_dataset(
-        n_total=40, true_mean=0.5, true_std=1.0, proxy_mean=0.5, proxy_std=1.0, correlation=0.8, random_seed=0
+    y_true_oracle, y_proxy, batches = generate_stratified_binary_dataset(
+        n_total=[batch_size] * n_batches,
+        true_mean=[0.5] * n_batches,
+        proxy_mean=[0.6] * n_batches,
+        correlation=[0.8] * n_batches,
+        random_seed=0,
     )
-
-
-@pytest.fixture
-def y_true(y_true_oracle_and_proxy):
-    y_true_oracle, _ = y_true_oracle_and_proxy
-    xi = np.tile(np.array([1, 1, 0, 0, 0, 0, 0, 0]), 5)
-    return simulate_annotation(y_true_oracle, xi)
-
-
-@pytest.fixture
-def y_proxy(y_true_oracle_and_proxy):
-    _, y_proxy = y_true_oracle_and_proxy
-    return y_proxy
+    rng = np.random.default_rng(seed=1)
+    xis = []
+    for _ in range(n_batches):
+        xi_batch = np.zeros(batch_size)
+        xi_batch[rng.choice(batch_size, size=n_labeled_per_batch)] = 1
+        xis.append(xi_batch)
+    xi = np.concat(xis)
+    y_true = simulate_annotation(y_true_oracle, xi)
+    return y_true, y_proxy, batches
 
 
 # ── tests ──────────────────────────────────────────────────────────────────────
 
 
-def test_detect_batch_estimates_match_ppi_estimator(y_true, y_proxy, batches):
-    """Each batch estimate equals the PPI estimator computed on that batch alone.
-
-    Power tuning must be disabled on both sides: the monitor fits its tuning
-    parameter on the batches strictly preceding the current one, so with power
-    tuning enabled the two estimates would only agree by coincidence. Checking
-    every batch (not just the first) exercises the ``power_tuning=False`` code
-    path on batches that would otherwise be power-tuned.
-    """
-    result = PPIMeanMonitor().detect(
+def test_detect_batch_estimates_match_ppi_estimator(dataset):
+    """Each batch estimate equals the PPI estimator computed on that batch alone when power tuning is disabled."""
+    y_true, y_proxy, batches = dataset
+    monitor_result = PPIMeanMonitor().detect(
         y_true,
         y_proxy,
         batches,
         higher_is_better=False,
         threshold=0.5,
-        metric_lower_bound=-5.0,
-        metric_upper_bound=5.0,
         power_tuning=False,
     )
     n_batches = len(np.unique(batches))
@@ -68,17 +59,12 @@ def test_detect_batch_estimates_match_ppi_estimator(y_true, y_proxy, batches):
         estimator_result = PPIMeanEstimator().estimate(y_true[batch_mask], y_proxy[batch_mask], power_tuning=False)
         estimator_means[batch_id] = estimator_result.mean
 
-    np.testing.assert_allclose(result.batch_mean_estimates, estimator_means)
+    np.testing.assert_allclose(monitor_result.batch_mean_estimates, estimator_means)
 
 
-def test_detect_prefix_consistency(y_true, y_proxy, batches):
-    """Detecting on a growing history is prefix-consistent with detecting on the full history.
-
-    Every batch is monitored (there is no reference batch to exclude), so restricting
-    the call to the first k batches must reproduce exactly the first k entries of the
-    arrays returned by the call on the full dataset. This is the property that makes
-    repeated calls on a growing history jointly valid.
-    """
+def test_detect_prefix_consistency(dataset):
+    """Detecting on a growing history is prefix-consistent with detecting on the full history."""
+    y_true, y_proxy, batches = dataset
     monitor = PPIMeanMonitor()
     full = monitor.detect(
         y_true,
@@ -86,8 +72,6 @@ def test_detect_prefix_consistency(y_true, y_proxy, batches):
         batches,
         higher_is_better=False,
         threshold=0.5,
-        metric_lower_bound=-5.0,
-        metric_upper_bound=5.0,
     )
     prefix_mask = batches <= 2
     prefix = monitor.detect(
@@ -96,92 +80,29 @@ def test_detect_prefix_consistency(y_true, y_proxy, batches):
         batches[prefix_mask],
         higher_is_better=False,
         threshold=0.5,
-        metric_lower_bound=-5.0,
-        metric_upper_bound=5.0,
     )
 
     np.testing.assert_allclose(prefix.running_means, full.running_means[:3])
     np.testing.assert_allclose(prefix.confidence_bounds, full.confidence_bounds[:3])
 
 
-def test_detect_higher_is_better_symmetry(y_true, y_proxy, batches):
+def test_detect_higher_is_better_symmetry(dataset):
     """Monitoring a performance is the mirror image of monitoring its negation as a risk."""
+    y_true, y_proxy, batches = dataset
     risk = PPIMeanMonitor().detect(
         y_true,
         y_proxy,
         batches,
         higher_is_better=False,
         threshold=0.3,
-        metric_lower_bound=-5.0,
-        metric_upper_bound=5.0,
     )
     performance = PPIMeanMonitor().detect(
-        -y_true,
-        -y_proxy,
+        1 - y_true,
+        1 - y_proxy,
         batches,
         higher_is_better=True,
-        threshold=-0.3,
-        metric_lower_bound=-5.0,
-        metric_upper_bound=5.0,
+        threshold=0.7,
     )
 
     np.testing.assert_array_equal(performance.alarms, risk.alarms)
-    np.testing.assert_allclose(performance.confidence_bounds, -risk.confidence_bounds)
-
-
-def test_detect_no_alarm_on_stationary_stream_below_threshold():
-    """A stationary stream well below the threshold never triggers an alarm."""
-    n_batches = 15
-    y_true_oracle, y_proxy = generate_gaussian_dataset(
-        n_total=n_batches * 8,
-        true_mean=0.1,
-        true_std=0.02,
-        proxy_mean=0.1,
-        proxy_std=0.02,
-        correlation=0.8,
-        random_seed=1,
-    )
-    xi = np.tile(np.array([1, 1, 0, 0, 0, 0, 0, 0]), n_batches)
-    y_true = simulate_annotation(y_true_oracle, xi)
-    batches = np.repeat(np.arange(n_batches), 8)
-
-    result = PPIMeanMonitor().detect(
-        y_true,
-        y_proxy,
-        batches,
-        higher_is_better=False,
-        threshold=0.5,
-        metric_lower_bound=0.0,
-        metric_upper_bound=1.0,
-    )
-
-    assert not result.drift_detected
-
-
-def test_detect_alarm_on_stream_well_above_threshold():
-    """A stream well above the threshold eventually triggers an alarm."""
-    n_batches = 30
-    y_true_oracle, y_proxy = generate_gaussian_dataset(
-        n_total=n_batches * 8,
-        true_mean=0.9,
-        true_std=0.02,
-        proxy_mean=0.9,
-        proxy_std=0.02,
-        correlation=0.8,
-        random_seed=1,
-    )
-    xi = np.tile(np.array([1, 1, 0, 0, 0, 0, 0, 0]), n_batches)
-    y_true = simulate_annotation(y_true_oracle, xi)
-    batches = np.repeat(np.arange(n_batches), 8)
-
-    result = PPIMeanMonitor().detect(
-        y_true,
-        y_proxy,
-        batches,
-        higher_is_better=False,
-        threshold=0.5,
-        metric_lower_bound=0.0,
-        metric_upper_bound=1.0,
-    )
-
-    assert result.drift_detected
+    np.testing.assert_allclose(performance.confidence_bounds, 1 - risk.confidence_bounds)

--- a/tests/functional/monitors/test_ppi.py
+++ b/tests/functional/monitors/test_ppi.py
@@ -1,0 +1,187 @@
+"""Functional tests for PPIMeanMonitor.
+
+These tests verify end-to-end statistical properties rather than implementation
+details, and therefore require larger datasets to hold reliably.
+"""
+
+import numpy as np
+import pytest
+
+from glide.estimators import PPIMeanEstimator
+from glide.monitors import PPIMeanMonitor
+from glide.simulators import generate_gaussian_dataset, simulate_annotation
+
+# ── fixtures ───────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def batches():
+    return np.repeat(np.arange(5), 8)
+
+
+@pytest.fixture
+def y_true_oracle_and_proxy():
+    return generate_gaussian_dataset(
+        n_total=40, true_mean=0.5, true_std=1.0, proxy_mean=0.5, proxy_std=1.0, correlation=0.8, random_seed=0
+    )
+
+
+@pytest.fixture
+def y_true(y_true_oracle_and_proxy):
+    y_true_oracle, _ = y_true_oracle_and_proxy
+    xi = np.tile(np.array([1, 1, 0, 0, 0, 0, 0, 0]), 5)
+    return simulate_annotation(y_true_oracle, xi)
+
+
+@pytest.fixture
+def y_proxy(y_true_oracle_and_proxy):
+    _, y_proxy = y_true_oracle_and_proxy
+    return y_proxy
+
+
+# ── tests ──────────────────────────────────────────────────────────────────────
+
+
+def test_detect_batch_estimates_match_ppi_estimator(y_true, y_proxy, batches):
+    """Each batch estimate equals the PPI estimator computed on that batch alone.
+
+    Power tuning must be disabled on both sides: the monitor fits its tuning
+    parameter on the batches strictly preceding the current one, so with power
+    tuning enabled the two estimates would only agree by coincidence. Checking
+    every batch (not just the first) exercises the ``power_tuning=False`` code
+    path on batches that would otherwise be power-tuned.
+    """
+    result = PPIMeanMonitor().detect(
+        y_true,
+        y_proxy,
+        batches,
+        higher_is_better=False,
+        threshold=0.5,
+        metric_lower_bound=-5.0,
+        metric_upper_bound=5.0,
+        power_tuning=False,
+    )
+    n_batches = len(np.unique(batches))
+    estimator_means = np.zeros(n_batches)
+    for batch_id in range(n_batches):
+        batch_mask = batches == batch_id
+        estimator_result = PPIMeanEstimator().estimate(y_true[batch_mask], y_proxy[batch_mask], power_tuning=False)
+        estimator_means[batch_id] = estimator_result.mean
+
+    np.testing.assert_allclose(result.batch_mean_estimates, estimator_means)
+
+
+def test_detect_prefix_consistency(y_true, y_proxy, batches):
+    """Detecting on a growing history is prefix-consistent with detecting on the full history.
+
+    Every batch is monitored (there is no reference batch to exclude), so restricting
+    the call to the first k batches must reproduce exactly the first k entries of the
+    arrays returned by the call on the full dataset. This is the property that makes
+    repeated calls on a growing history jointly valid.
+    """
+    monitor = PPIMeanMonitor()
+    full = monitor.detect(
+        y_true,
+        y_proxy,
+        batches,
+        higher_is_better=False,
+        threshold=0.5,
+        metric_lower_bound=-5.0,
+        metric_upper_bound=5.0,
+    )
+    prefix_mask = batches <= 2
+    prefix = monitor.detect(
+        y_true[prefix_mask],
+        y_proxy[prefix_mask],
+        batches[prefix_mask],
+        higher_is_better=False,
+        threshold=0.5,
+        metric_lower_bound=-5.0,
+        metric_upper_bound=5.0,
+    )
+
+    np.testing.assert_allclose(prefix.running_means, full.running_means[:3])
+    np.testing.assert_allclose(prefix.confidence_bounds, full.confidence_bounds[:3])
+
+
+def test_detect_higher_is_better_symmetry(y_true, y_proxy, batches):
+    """Monitoring a performance is the mirror image of monitoring its negation as a risk."""
+    risk = PPIMeanMonitor().detect(
+        y_true,
+        y_proxy,
+        batches,
+        higher_is_better=False,
+        threshold=0.3,
+        metric_lower_bound=-5.0,
+        metric_upper_bound=5.0,
+    )
+    performance = PPIMeanMonitor().detect(
+        -y_true,
+        -y_proxy,
+        batches,
+        higher_is_better=True,
+        threshold=-0.3,
+        metric_lower_bound=-5.0,
+        metric_upper_bound=5.0,
+    )
+
+    np.testing.assert_array_equal(performance.alarms, risk.alarms)
+    np.testing.assert_allclose(performance.confidence_bounds, -risk.confidence_bounds)
+
+
+def test_detect_no_alarm_on_stationary_stream_below_threshold():
+    """A stationary stream well below the threshold never triggers an alarm."""
+    n_batches = 15
+    y_true_oracle, y_proxy = generate_gaussian_dataset(
+        n_total=n_batches * 8,
+        true_mean=0.1,
+        true_std=0.02,
+        proxy_mean=0.1,
+        proxy_std=0.02,
+        correlation=0.8,
+        random_seed=1,
+    )
+    xi = np.tile(np.array([1, 1, 0, 0, 0, 0, 0, 0]), n_batches)
+    y_true = simulate_annotation(y_true_oracle, xi)
+    batches = np.repeat(np.arange(n_batches), 8)
+
+    result = PPIMeanMonitor().detect(
+        y_true,
+        y_proxy,
+        batches,
+        higher_is_better=False,
+        threshold=0.5,
+        metric_lower_bound=0.0,
+        metric_upper_bound=1.0,
+    )
+
+    assert not result.drift_detected
+
+
+def test_detect_alarm_on_stream_well_above_threshold():
+    """A stream well above the threshold eventually triggers an alarm."""
+    n_batches = 30
+    y_true_oracle, y_proxy = generate_gaussian_dataset(
+        n_total=n_batches * 8,
+        true_mean=0.9,
+        true_std=0.02,
+        proxy_mean=0.9,
+        proxy_std=0.02,
+        correlation=0.8,
+        random_seed=1,
+    )
+    xi = np.tile(np.array([1, 1, 0, 0, 0, 0, 0, 0]), n_batches)
+    y_true = simulate_annotation(y_true_oracle, xi)
+    batches = np.repeat(np.arange(n_batches), 8)
+
+    result = PPIMeanMonitor().detect(
+        y_true,
+        y_proxy,
+        batches,
+        higher_is_better=False,
+        threshold=0.5,
+        metric_lower_bound=0.0,
+        metric_upper_bound=1.0,
+    )
+
+    assert result.drift_detected

--- a/tests/functional/monitors/test_ppi.py
+++ b/tests/functional/monitors/test_ppi.py
@@ -33,7 +33,7 @@ def dataset():
         xi_batch = np.zeros(batch_size)
         xi_batch[rng.choice(batch_size, size=n_labeled_per_batch)] = 1
         xis.append(xi_batch)
-    xi = np.concat(xis)
+    xi = np.hstack(xis)
     y_true = simulate_annotation(y_true_oracle, xi)
     return y_true, y_proxy, batches
 

--- a/tests/functional/monitors/test_ppi.py
+++ b/tests/functional/monitors/test_ppi.py
@@ -31,7 +31,8 @@ def dataset():
     xis = []
     for _ in range(n_batches):
         xi_batch = np.zeros(batch_size)
-        xi_batch[rng.choice(batch_size, size=n_labeled_per_batch)] = 1
+        labeled_indices = rng.choice(batch_size, size=n_labeled_per_batch)
+        xi_batch[labeled_indices] = 1
         xis.append(xi_batch)
     xi = np.hstack(xis)
     y_true = simulate_annotation(y_true_oracle, xi)

--- a/tests/unit/monitors/test_ppi.py
+++ b/tests/unit/monitors/test_ppi.py
@@ -1,0 +1,292 @@
+from unittest.mock import patch
+
+import numpy as np
+import pytest
+
+import glide.monitors.ppi as ppi_module
+from glide.confidence_sequences import EmpiricalBernsteinConfidenceSequence
+from glide.mean_monitoring_results import PredictionPoweredMeanMonitoringResult
+from glide.monitors import PPIMeanMonitor
+
+
+@pytest.fixture
+def y_true():
+    return np.array([0.1, 0.3, np.nan, np.nan, 0.2, 0.4, np.nan, np.nan])
+
+
+@pytest.fixture
+def y_proxy():
+    return np.array([0.1, 0.3, 0.15, 0.35, 0.2, 0.4, 0.25, 0.45])
+
+
+@pytest.fixture
+def batches():
+    return np.array([0, 0, 0, 0, 1, 1, 1, 1])
+
+
+@pytest.fixture
+def monitor():
+    return PPIMeanMonitor()
+
+
+# --- _preprocess ---
+
+
+def test_preprocess_delegates_to_validation(monitor, y_true, y_proxy, batches):
+    with (
+        patch.object(ppi_module, "_validate_non_empty") as mock_validate_non_empty,
+        patch.object(ppi_module, "_validate_equal_lengths") as mock_validate_equal_lengths,
+        patch.object(ppi_module, "_validate_has_no_nan") as mock_validate_has_no_nan,
+        patch.object(ppi_module, "_validate_bounds") as mock_validate_bounds,
+        patch.object(ppi_module, "_validate_y_proxy") as mock_validate_y_proxy,
+        patch.object(ppi_module, "_validate_y_true") as mock_validate_y_true,
+        patch.object(ppi_module, "_unique_ordered_batches") as mock_unique_ordered_batches,
+    ):
+        mock_unique_ordered_batches.return_value = (np.array([0, 1]), np.array([0, 0, 0, 0, 1, 1, 1, 1]))
+        monitor._preprocess(
+            y_true,
+            y_proxy,
+            batches,
+            higher_is_better=False,
+            threshold=0.5,
+            confidence_level=0.8,
+            max_tuning_parameter=1.0,
+            metric_lower_bound=0.0,
+            metric_upper_bound=1.0,
+        )
+
+        mock_validate_non_empty.assert_called_once()
+        np.testing.assert_array_equal(mock_validate_non_empty.call_args[0][0], y_true)
+        assert mock_validate_non_empty.call_args[0][1] == "y_true"
+
+        mock_validate_equal_lengths.assert_called_once()
+        np.testing.assert_array_equal(mock_validate_equal_lengths.call_args[0][0], y_true)
+        np.testing.assert_array_equal(mock_validate_equal_lengths.call_args[0][1], y_proxy)
+        np.testing.assert_array_equal(mock_validate_equal_lengths.call_args[0][2], batches)
+        assert mock_validate_equal_lengths.call_args[1] == {"names": ["y_true", "y_proxy", "batches"]}
+
+        mock_validate_has_no_nan.assert_called_once()
+        np.testing.assert_array_equal(mock_validate_has_no_nan.call_args[0][0], batches)
+        assert mock_validate_has_no_nan.call_args[0][1] == "batches"
+
+        mock_validate_y_proxy.assert_called_once()
+        np.testing.assert_array_equal(mock_validate_y_proxy.call_args[0][0], y_proxy)
+
+        mock_validate_y_true.assert_called_once()
+        np.testing.assert_array_equal(mock_validate_y_true.call_args[0][0], y_true)
+
+        mock_unique_ordered_batches.assert_called_once()
+        np.testing.assert_array_equal(mock_unique_ordered_batches.call_args[0][0], batches)
+
+        assert mock_validate_bounds.call_count == 8
+
+        assert mock_validate_bounds.call_args_list[0][0] == (0.8, "confidence_level")
+        assert mock_validate_bounds.call_args_list[0][1] == {
+            "lower": 0,
+            "upper": 1,
+            "left_inclusive": False,
+            "right_inclusive": False,
+        }
+
+        assert mock_validate_bounds.call_args_list[1][0] == (1.0, "max_tuning_parameter")
+        assert mock_validate_bounds.call_args_list[1][1] == {"lower": 0, "left_inclusive": False}
+
+        assert mock_validate_bounds.call_args_list[2][0] == (0.0, "metric_lower_bound")
+        assert mock_validate_bounds.call_args_list[2][1]["upper"] == 1.0
+        assert mock_validate_bounds.call_args_list[2][1]["right_inclusive"] is False
+        assert (
+            "'metric_lower_bound' must be strictly smaller than 'metric_upper_bound'"
+            in mock_validate_bounds.call_args_list[2][1]["error_message"]
+        )
+
+        assert mock_validate_bounds.call_args_list[3][0] == (0.5, "threshold")
+        assert mock_validate_bounds.call_args_list[3][1]["lower"] == 0.0
+        assert mock_validate_bounds.call_args_list[3][1]["upper"] == 1.0
+        assert "'threshold' must lie between" in mock_validate_bounds.call_args_list[3][1]["error_message"]
+
+        np.testing.assert_array_equal(mock_validate_bounds.call_args_list[4][0][0], np.array([0.1, 0.3, 0.2, 0.4]))
+        assert mock_validate_bounds.call_args_list[4][0][1] == "y_true"
+        assert "'y_true' values must lie between" in mock_validate_bounds.call_args_list[4][1]["error_message"]
+
+        np.testing.assert_array_equal(mock_validate_bounds.call_args_list[5][0][0], y_proxy)
+        assert mock_validate_bounds.call_args_list[5][0][1] == "y_proxy"
+        assert "'y_proxy' values must lie between" in mock_validate_bounds.call_args_list[5][1]["error_message"]
+
+        assert mock_validate_bounds.call_args_list[6][0] == (2, "y_true")
+        assert mock_validate_bounds.call_args_list[6][1]["lower"] == 2
+        assert (
+            "'y_true' must have at least 2 labeled values per batch"
+            in mock_validate_bounds.call_args_list[6][1]["error_message"]
+        )
+
+        assert mock_validate_bounds.call_args_list[7][0] == (2, "y_true")
+        assert mock_validate_bounds.call_args_list[7][1]["lower"] == 2
+        assert (
+            "'y_true' must have at least 2 unlabeled values per batch"
+            in mock_validate_bounds.call_args_list[7][1]["error_message"]
+        )
+
+
+def test_preprocess_known_output(monitor, y_true, y_proxy, batches):
+    risk_y_true, risk_y_proxy, risk_threshold, batch_codes, batch_n_true, batch_n_proxy = monitor._preprocess(
+        y_true,
+        y_proxy,
+        batches,
+        higher_is_better=False,
+        threshold=0.5,
+        confidence_level=0.8,
+        max_tuning_parameter=1.0,
+        metric_lower_bound=0.0,
+        metric_upper_bound=1.0,
+    )
+
+    np.testing.assert_allclose(risk_y_true, y_true)
+    np.testing.assert_allclose(risk_y_proxy, y_proxy)
+    assert risk_threshold == pytest.approx(0.5)
+    np.testing.assert_array_equal(batch_codes, np.array([0, 0, 0, 0, 1, 1, 1, 1]))
+    np.testing.assert_array_equal(batch_n_true, np.array([2, 2]))
+    np.testing.assert_array_equal(batch_n_proxy, np.array([4, 4]))
+
+
+def test_preprocess_raises_on_too_few_labeled_in_batch(monitor, y_proxy, batches):
+    y_true = np.array([0.1, np.nan, np.nan, np.nan, 0.2, 0.4, np.nan, np.nan])
+    with pytest.raises(ValueError, match="'y_true' must have at least 2 labeled values per batch"):
+        monitor._preprocess(
+            y_true,
+            y_proxy,
+            batches,
+            higher_is_better=False,
+            threshold=0.5,
+            confidence_level=0.8,
+            max_tuning_parameter=1.0,
+            metric_lower_bound=0.0,
+            metric_upper_bound=1.0,
+        )
+
+
+def test_preprocess_raises_on_too_few_unlabeled_in_batch(monitor, y_proxy, batches):
+    y_true = np.array([0.1, 0.3, 0.15, np.nan, 0.2, 0.4, np.nan, np.nan])
+    with pytest.raises(ValueError, match="'y_true' must have at least 2 unlabeled values per batch"):
+        monitor._preprocess(
+            y_true,
+            y_proxy,
+            batches,
+            higher_is_better=False,
+            threshold=0.5,
+            confidence_level=0.8,
+            max_tuning_parameter=1.0,
+            metric_lower_bound=0.0,
+            metric_upper_bound=1.0,
+        )
+
+
+def test_preprocess_raises_on_interleaved_batches(monitor, y_true, y_proxy):
+    batches = np.array(["A", "B", "A", "B", "A", "B", "A", "B"])
+    with pytest.raises(ValueError, match="'batches' must be grouped into contiguous blocks"):
+        monitor._preprocess(
+            y_true,
+            y_proxy,
+            batches,
+            higher_is_better=False,
+            threshold=0.5,
+            confidence_level=0.8,
+            max_tuning_parameter=1.0,
+            metric_lower_bound=0.0,
+            metric_upper_bound=1.0,
+        )
+
+
+# --- _postprocess ---
+
+
+def test_postprocess_delegates_to_scaling(monitor):
+    risk_running_means = np.array([0.2, 0.25])
+    risk_confidence_bounds = np.array([0.1, 0.2])
+    risk_batch_mean_estimates = np.array([0.2, 0.3])
+
+    with patch.object(ppi_module, "_scale_from_unit_risk") as mock_scale_from_unit_risk:
+        monitor._postprocess(
+            risk_running_means,
+            risk_confidence_bounds,
+            risk_batch_mean_estimates,
+            higher_is_better=True,
+            metric_lower_bound=0.0,
+            metric_upper_bound=1.0,
+        )
+
+    assert mock_scale_from_unit_risk.call_count == 3
+    np.testing.assert_array_equal(mock_scale_from_unit_risk.call_args_list[0][0][0], risk_running_means)
+    np.testing.assert_array_equal(mock_scale_from_unit_risk.call_args_list[1][0][0], risk_confidence_bounds)
+    np.testing.assert_array_equal(mock_scale_from_unit_risk.call_args_list[2][0][0], risk_batch_mean_estimates)
+
+
+# --- detect ---
+
+
+def test_detect_is_valid_monitoring_result(monitor, y_true, y_proxy, batches):
+    result = monitor.detect(y_true, y_proxy, batches, higher_is_better=False, threshold=0.5)
+
+    assert isinstance(result, PredictionPoweredMeanMonitoringResult)
+    assert isinstance(result.confidence_sequence, EmpiricalBernsteinConfidenceSequence)
+    assert result.monitor_name == "PPIMeanMonitor"
+    assert np.isfinite(result.running_means).all()
+    assert (result.running_means >= result.confidence_bounds).all()
+
+
+def test_detect_metadata(monitor, y_true, y_proxy, batches):
+    result = monitor.detect(
+        y_true, y_proxy, batches, higher_is_better=True, threshold=0.5, metric_name="accuracy", confidence_level=0.85
+    )
+
+    assert result.metric_name == "accuracy"
+    assert result.monitor_name == "PPIMeanMonitor"
+    assert result.higher_is_better is True
+    assert result.alarm_threshold == 0.5
+    assert result.confidence_level == 0.85
+    np.testing.assert_array_equal(result.batch_n_true, np.array([2, 2]))
+    np.testing.assert_array_equal(result.batch_n_proxy, np.array([4, 4]))
+
+
+def test_detect_custom_confidence_level(monitor, y_true, y_proxy, batches):
+    expected_running_means = np.array([0.25, 0.292647])
+    expected_confidence_bounds = np.array([-10.627208, -5.147835])
+
+    result = monitor.detect(
+        y_true, y_proxy, batches, higher_is_better=False, threshold=0.5, metric_name="risk", confidence_level=0.90
+    )
+
+    assert result.confidence_level == 0.90
+    np.testing.assert_allclose(result.running_means, expected_running_means, atol=1e-6)
+    np.testing.assert_allclose(result.confidence_bounds, expected_confidence_bounds, atol=1e-6)
+
+
+def test_detect_power_tuning_false_uses_classic_weight(monitor, y_true, y_proxy, batches):
+    expected_batch_mean_estimates = np.array([0.25, 0.35])
+
+    result = monitor.detect(y_true, y_proxy, batches, higher_is_better=False, threshold=0.5, power_tuning=False)
+
+    np.testing.assert_allclose(result.batch_mean_estimates, expected_batch_mean_estimates)
+
+
+def test_detect_first_batch_uses_classic_weight_regardless_of_power_tuning(monitor, y_true, y_proxy, batches):
+    power_tuned = monitor.detect(y_true, y_proxy, batches, higher_is_better=False, threshold=0.5, power_tuning=True)
+    classic = monitor.detect(y_true, y_proxy, batches, higher_is_better=False, threshold=0.5, power_tuning=False)
+
+    assert power_tuned.batch_mean_estimates[0] == pytest.approx(classic.batch_mean_estimates[0])
+
+
+def test_detect_power_tuning_uses_prior_batches_only(monitor):
+    y_true = np.array([0.1, 0.3, np.nan, np.nan, 0.2, 0.4, np.nan, np.nan, 0.5, 0.6, np.nan, np.nan])
+    y_proxy = np.array([0.1, 0.3, 0.15, 0.35, 0.2, 0.4, 0.25, 0.45, 0.5, 0.6, 0.55, 0.65])
+    batches = np.array([0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2])
+
+    original = monitor.detect(y_true, y_proxy, batches, higher_is_better=False, threshold=0.5)
+
+    y_true_altered = y_true.copy()
+    y_proxy_altered = y_proxy.copy()
+    y_true_altered[8:10] = np.array([0.99, 0.98])
+    y_proxy_altered[8:] = np.array([0.9, 0.95, 0.92, 0.97])
+    altered = monitor.detect(y_true_altered, y_proxy_altered, batches, higher_is_better=False, threshold=0.5)
+
+    np.testing.assert_allclose(altered.batch_mean_estimates[:2], original.batch_mean_estimates[:2])
+    assert altered.batch_mean_estimates[2] != pytest.approx(original.batch_mean_estimates[2])

--- a/tests/unit/monitors/test_ppi.py
+++ b/tests/unit/monitors/test_ppi.py
@@ -148,54 +148,6 @@ def test_preprocess_known_output(monitor, y_true, y_proxy, batches):
     np.testing.assert_array_equal(batch_n_proxy, np.array([4, 4]))
 
 
-def test_preprocess_raises_on_too_few_labeled_in_batch(monitor, y_proxy, batches):
-    y_true = np.array([0.1, np.nan, np.nan, np.nan, 0.2, 0.4, np.nan, np.nan])
-    with pytest.raises(ValueError, match="'y_true' must have at least 2 labeled values per batch"):
-        monitor._preprocess(
-            y_true,
-            y_proxy,
-            batches,
-            higher_is_better=False,
-            threshold=0.5,
-            confidence_level=0.8,
-            max_tuning_parameter=1.0,
-            metric_lower_bound=0.0,
-            metric_upper_bound=1.0,
-        )
-
-
-def test_preprocess_raises_on_too_few_unlabeled_in_batch(monitor, y_proxy, batches):
-    y_true = np.array([0.1, 0.3, 0.15, np.nan, 0.2, 0.4, np.nan, np.nan])
-    with pytest.raises(ValueError, match="'y_true' must have at least 2 unlabeled values per batch"):
-        monitor._preprocess(
-            y_true,
-            y_proxy,
-            batches,
-            higher_is_better=False,
-            threshold=0.5,
-            confidence_level=0.8,
-            max_tuning_parameter=1.0,
-            metric_lower_bound=0.0,
-            metric_upper_bound=1.0,
-        )
-
-
-def test_preprocess_raises_on_interleaved_batches(monitor, y_true, y_proxy):
-    batches = np.array(["A", "B", "A", "B", "A", "B", "A", "B"])
-    with pytest.raises(ValueError, match="'batches' must be grouped into contiguous blocks"):
-        monitor._preprocess(
-            y_true,
-            y_proxy,
-            batches,
-            higher_is_better=False,
-            threshold=0.5,
-            confidence_level=0.8,
-            max_tuning_parameter=1.0,
-            metric_lower_bound=0.0,
-            metric_upper_bound=1.0,
-        )
-
-
 # --- _postprocess ---
 
 
@@ -256,37 +208,5 @@ def test_detect_custom_confidence_level(monitor, y_true, y_proxy, batches):
     )
 
     assert result.confidence_level == 0.90
-    np.testing.assert_allclose(result.running_means, expected_running_means, atol=1e-6)
-    np.testing.assert_allclose(result.confidence_bounds, expected_confidence_bounds, atol=1e-6)
-
-
-def test_detect_power_tuning_false_uses_classic_weight(monitor, y_true, y_proxy, batches):
-    expected_batch_mean_estimates = np.array([0.25, 0.35])
-
-    result = monitor.detect(y_true, y_proxy, batches, higher_is_better=False, threshold=0.5, power_tuning=False)
-
-    np.testing.assert_allclose(result.batch_mean_estimates, expected_batch_mean_estimates)
-
-
-def test_detect_first_batch_uses_classic_weight_regardless_of_power_tuning(monitor, y_true, y_proxy, batches):
-    power_tuned = monitor.detect(y_true, y_proxy, batches, higher_is_better=False, threshold=0.5, power_tuning=True)
-    classic = monitor.detect(y_true, y_proxy, batches, higher_is_better=False, threshold=0.5, power_tuning=False)
-
-    assert power_tuned.batch_mean_estimates[0] == pytest.approx(classic.batch_mean_estimates[0])
-
-
-def test_detect_power_tuning_uses_prior_batches_only(monitor):
-    y_true = np.array([0.1, 0.3, np.nan, np.nan, 0.2, 0.4, np.nan, np.nan, 0.5, 0.6, np.nan, np.nan])
-    y_proxy = np.array([0.1, 0.3, 0.15, 0.35, 0.2, 0.4, 0.25, 0.45, 0.5, 0.6, 0.55, 0.65])
-    batches = np.array([0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2])
-
-    original = monitor.detect(y_true, y_proxy, batches, higher_is_better=False, threshold=0.5)
-
-    y_true_altered = y_true.copy()
-    y_proxy_altered = y_proxy.copy()
-    y_true_altered[8:10] = np.array([0.99, 0.98])
-    y_proxy_altered[8:] = np.array([0.9, 0.95, 0.92, 0.97])
-    altered = monitor.detect(y_true_altered, y_proxy_altered, batches, higher_is_better=False, threshold=0.5)
-
-    np.testing.assert_allclose(altered.batch_mean_estimates[:2], original.batch_mean_estimates[:2])
-    assert altered.batch_mean_estimates[2] != pytest.approx(original.batch_mean_estimates[2])
+    np.testing.assert_allclose(result.running_means, expected_running_means, atol=0.001)
+    np.testing.assert_allclose(result.confidence_bounds, expected_confidence_bounds, atol=0.001)

--- a/tests/unit/monitors/test_ppi_core.py
+++ b/tests/unit/monitors/test_ppi_core.py
@@ -49,17 +49,15 @@ def test_compute_clipped_tuning_parameter_known_value(data):
 # --- _normalize_to_unit_interval / _denormalize_from_unit_interval ---
 
 
-def test_normalize_to_unit_interval():
-    values = np.array([-1.0, 0.0, 2.0])
+def test_normalize_to_unit_interval_delegates():
+    with patch("glide.monitors.ppi_core._scale_to_unit_risk") as mock_scale_to_unit_risk:
+        _normalize_to_unit_interval(2.0, max_tuning_parameter=1.0)
 
-    normalized = _normalize_to_unit_interval(values, max_tuning_parameter=1.0)
-
-    np.testing.assert_allclose(normalized, np.array([0.0, 1.0 / 3.0, 1.0]))
+    mock_scale_to_unit_risk.assert_called_once_with(2.0, -1.0, 2.0, higher_is_better=False)
 
 
-def test_denormalize_from_unit_interval():
-    values = np.array([0.0, 1.0 / 3.0, 1.0])
+def test_denormalize_from_unit_interval_delegates():
+    with patch("glide.monitors.ppi_core._scale_from_unit_risk") as mock_scale_from_unit_risk:
+        _denormalize_from_unit_interval(0.5, max_tuning_parameter=1.0)
 
-    original = _denormalize_from_unit_interval(values, max_tuning_parameter=1.0)
-
-    np.testing.assert_allclose(original, np.array([-1.0, 0.0, 2.0]))
+    mock_scale_from_unit_risk.assert_called_once_with(0.5, -1.0, 2.0, higher_is_better=False)

--- a/tests/unit/monitors/test_ppi_core.py
+++ b/tests/unit/monitors/test_ppi_core.py
@@ -1,0 +1,90 @@
+import numpy as np
+import pytest
+
+from glide.monitors.ppi_core import (
+    _compute_clipped_tuning_parameter,
+    _denormalize_from_unit_interval,
+    _normalize_to_unit_interval,
+)
+
+# --- _compute_clipped_tuning_parameter ---
+
+
+def test_compute_clipped_tuning_parameter_power_tuning_false():
+    y_true_labeled = np.array([0.1, 0.3])
+    y_proxy_labeled = np.array([0.1, 0.3])
+    y_proxy_unlabeled = np.array([0.2, 0.4])
+
+    tuning_parameter = _compute_clipped_tuning_parameter(
+        y_true_labeled, y_proxy_labeled, y_proxy_unlabeled, power_tuning=False, max_tuning_parameter=1.0
+    )
+
+    assert tuning_parameter == pytest.approx(1.0)
+
+
+def test_compute_clipped_tuning_parameter_within_range():
+    y_true_labeled = np.array([0.1, 0.3])
+    y_proxy_labeled = np.array([0.15, 0.25])
+    y_proxy_unlabeled = np.array([0.2, 0.4])
+
+    unclipped = _compute_clipped_tuning_parameter(
+        y_true_labeled, y_proxy_labeled, y_proxy_unlabeled, power_tuning=True, max_tuning_parameter=10.0
+    )
+    clipped = _compute_clipped_tuning_parameter(
+        y_true_labeled, y_proxy_labeled, y_proxy_unlabeled, power_tuning=True, max_tuning_parameter=1.0
+    )
+
+    assert clipped == pytest.approx(unclipped)
+
+
+def test_compute_clipped_tuning_parameter_clips_to_upper_bound():
+    y_true_labeled = np.array([0.0, 1.0])
+    y_proxy_labeled = np.array([0.0, 1.0])
+    y_proxy_unlabeled = np.array([0.0, 1.0])
+
+    tuning_parameter = _compute_clipped_tuning_parameter(
+        y_true_labeled, y_proxy_labeled, y_proxy_unlabeled, power_tuning=True, max_tuning_parameter=0.5
+    )
+
+    assert tuning_parameter == pytest.approx(0.5)
+
+
+def test_compute_clipped_tuning_parameter_clips_to_lower_bound():
+    y_true_labeled = np.array([0.1, 0.3])
+    y_proxy_labeled = np.array([0.4, 0.1])
+    y_proxy_unlabeled = np.array([0.2, 0.4])
+
+    tuning_parameter = _compute_clipped_tuning_parameter(
+        y_true_labeled, y_proxy_labeled, y_proxy_unlabeled, power_tuning=True, max_tuning_parameter=1.0
+    )
+
+    assert tuning_parameter == pytest.approx(0.0)
+
+
+# --- _normalize_to_unit_interval / _denormalize_from_unit_interval ---
+
+
+def test_normalize_to_unit_interval():
+    values = np.array([-1.0, 0.0, 2.0])
+
+    normalized = _normalize_to_unit_interval(values, max_tuning_parameter=1.0)
+
+    np.testing.assert_allclose(normalized, np.array([0.0, 1.0 / 3.0, 1.0]))
+
+
+def test_denormalize_from_unit_interval():
+    values = np.array([0.0, 1.0 / 3.0, 1.0])
+
+    original = _denormalize_from_unit_interval(values, max_tuning_parameter=1.0)
+
+    np.testing.assert_allclose(original, np.array([-1.0, 0.0, 2.0]))
+
+
+def test_normalize_denormalize_round_trip():
+    values = np.array([-0.3, 0.5, 1.2])
+
+    round_tripped = _denormalize_from_unit_interval(
+        _normalize_to_unit_interval(values, max_tuning_parameter=0.7), max_tuning_parameter=0.7
+    )
+
+    np.testing.assert_allclose(round_tripped, values)

--- a/tests/unit/monitors/test_ppi_core.py
+++ b/tests/unit/monitors/test_ppi_core.py
@@ -12,16 +12,24 @@ from glide.monitors.ppi_core import (
 
 # --- fixtures ---
 @pytest.fixture
-def data():
-    return np.array([0.1, 0.3]), np.array([0.15, 0.25]), np.array([0.2, 0.4])
+def y_true_labeled():
+    return np.array([0.1, 0.3])
+
+
+@pytest.fixture
+def y_proxy_labeled():
+    return np.array([0.15, 0.25])
+
+
+@pytest.fixture
+def y_proxy_unlabeled():
+    return np.array([0.2, 0.4])
 
 
 # --- _compute_clipped_tuning_parameter ---
 
 
-def test_compute_clipped_tuning_parameter_delegates(data):
-    y_true_labeled, y_proxy_labeled, y_proxy_unlabeled = data
-
+def test_compute_clipped_tuning_parameter_delegates(y_true_labeled, y_proxy_labeled, y_proxy_unlabeled):
     with patch("glide.monitors.ppi_core._compute_tuning_parameter") as mock_compute_tuning_parameter:
         mock_compute_tuning_parameter.return_value = 0.5
         _compute_clipped_tuning_parameter(
@@ -35,9 +43,7 @@ def test_compute_clipped_tuning_parameter_delegates(data):
     assert mock_compute_tuning_parameter.call_args[0][3] is False
 
 
-def test_compute_clipped_tuning_parameter_known_value(data):
-    y_true_labeled, y_proxy_labeled, y_proxy_unlabeled = data
-
+def test_compute_clipped_tuning_parameter_known_value(y_true_labeled, y_proxy_labeled, y_proxy_unlabeled):
     expected = 0.428
     result = _compute_clipped_tuning_parameter(
         y_true_labeled, y_proxy_labeled, y_proxy_unlabeled, power_tuning=True, max_tuning_parameter=1.0

--- a/tests/unit/monitors/test_ppi_core.py
+++ b/tests/unit/monitors/test_ppi_core.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 import numpy as np
 import pytest
 
@@ -7,58 +9,41 @@ from glide.monitors.ppi_core import (
     _normalize_to_unit_interval,
 )
 
+
+# --- fixtures ---
+@pytest.fixture
+def data():
+    return np.array([0.1, 0.3]), np.array([0.15, 0.25]), np.array([0.2, 0.4])
+
+
 # --- _compute_clipped_tuning_parameter ---
 
 
-def test_compute_clipped_tuning_parameter_power_tuning_false():
-    y_true_labeled = np.array([0.1, 0.3])
-    y_proxy_labeled = np.array([0.1, 0.3])
-    y_proxy_unlabeled = np.array([0.2, 0.4])
+def test_compute_clipped_tuning_parameter_delegates(data):
+    y_true_labeled, y_proxy_labeled, y_proxy_unlabeled = data
 
-    tuning_parameter = _compute_clipped_tuning_parameter(
-        y_true_labeled, y_proxy_labeled, y_proxy_unlabeled, power_tuning=False, max_tuning_parameter=1.0
-    )
+    with patch("glide.monitors.ppi_core._compute_tuning_parameter") as mock_compute_tuning_parameter:
+        mock_compute_tuning_parameter.return_value = 0.5
+        _compute_clipped_tuning_parameter(
+            y_true_labeled, y_proxy_labeled, y_proxy_unlabeled, power_tuning=False, max_tuning_parameter=1.0
+        )
 
-    assert tuning_parameter == pytest.approx(1.0)
+    mock_compute_tuning_parameter.assert_called_once()
+    np.testing.assert_array_equal(mock_compute_tuning_parameter.call_args[0][0], y_true_labeled)
+    np.testing.assert_array_equal(mock_compute_tuning_parameter.call_args[0][1], y_proxy_labeled)
+    np.testing.assert_array_equal(mock_compute_tuning_parameter.call_args[0][2], y_proxy_unlabeled)
+    assert mock_compute_tuning_parameter.call_args[0][3] is False
 
 
-def test_compute_clipped_tuning_parameter_within_range():
-    y_true_labeled = np.array([0.1, 0.3])
-    y_proxy_labeled = np.array([0.15, 0.25])
-    y_proxy_unlabeled = np.array([0.2, 0.4])
+def test_compute_clipped_tuning_parameter_known_value(data):
+    y_true_labeled, y_proxy_labeled, y_proxy_unlabeled = data
 
-    unclipped = _compute_clipped_tuning_parameter(
-        y_true_labeled, y_proxy_labeled, y_proxy_unlabeled, power_tuning=True, max_tuning_parameter=10.0
-    )
-    clipped = _compute_clipped_tuning_parameter(
+    expected = 0.428
+    result = _compute_clipped_tuning_parameter(
         y_true_labeled, y_proxy_labeled, y_proxy_unlabeled, power_tuning=True, max_tuning_parameter=1.0
     )
 
-    assert clipped == pytest.approx(unclipped)
-
-
-def test_compute_clipped_tuning_parameter_clips_to_upper_bound():
-    y_true_labeled = np.array([0.0, 1.0])
-    y_proxy_labeled = np.array([0.0, 1.0])
-    y_proxy_unlabeled = np.array([0.0, 1.0])
-
-    tuning_parameter = _compute_clipped_tuning_parameter(
-        y_true_labeled, y_proxy_labeled, y_proxy_unlabeled, power_tuning=True, max_tuning_parameter=0.5
-    )
-
-    assert tuning_parameter == pytest.approx(0.5)
-
-
-def test_compute_clipped_tuning_parameter_clips_to_lower_bound():
-    y_true_labeled = np.array([0.1, 0.3])
-    y_proxy_labeled = np.array([0.4, 0.1])
-    y_proxy_unlabeled = np.array([0.2, 0.4])
-
-    tuning_parameter = _compute_clipped_tuning_parameter(
-        y_true_labeled, y_proxy_labeled, y_proxy_unlabeled, power_tuning=True, max_tuning_parameter=1.0
-    )
-
-    assert tuning_parameter == pytest.approx(0.0)
+    assert result == pytest.approx(expected, abs=0.001)
 
 
 # --- _normalize_to_unit_interval / _denormalize_from_unit_interval ---
@@ -78,13 +63,3 @@ def test_denormalize_from_unit_interval():
     original = _denormalize_from_unit_interval(values, max_tuning_parameter=1.0)
 
     np.testing.assert_allclose(original, np.array([-1.0, 0.0, 2.0]))
-
-
-def test_normalize_denormalize_round_trip():
-    values = np.array([-0.3, 0.5, 1.2])
-
-    round_tripped = _denormalize_from_unit_interval(
-        _normalize_to_unit_interval(values, max_tuning_parameter=0.7), max_tuning_parameter=0.7
-    )
-
-    np.testing.assert_allclose(round_tripped, values)


### PR DESCRIPTION

### Description

- Adds `PPIMeanMonitor` to `glide.monitors`: an anytime-valid drift monitor over batched production data that combines a small set of true labels with a large set of proxy labels via a per-batch prediction-powered inference (PPI) estimate. It builds a running empirical-Bernstein confidence sequence and raises a drift alarm when the sequence crosses a user-supplied threshold, staying valid under repeated calls as new batches arrive.
- Adds `glide/monitors/ppi_core.py` with shared internals (tuning-parameter clipping, unit-interval normalization) used by the monitor.
- Handles this [ticket](https://github.com/orgs/EmertonData/projects/26/views/2?pane=issue&itemId=176217941&issue=EmertonData%7Cglide%7C317) Closes #317

### Checklist

Quality gates that must be satisfied before requesting a review:

- [x] I have read `CONTRIBUTING.md`
- [x] `make lint` passes
- [x] `make type-check` passes
- [x] `make tests` passes
- [x] `make coverage` reports 100% coverage
- [x] `make test-notebooks` passes
- [x] New public API has numpy-style docstrings
- [x] New public API is inserted in the API reference section of the documentation
- [x] Docs build without warnings (`make doc`)
- [x] `CHANGELOG.md` updated if the change is user-facing

### LLM usage

Disclose if an LLM was used in writing this PR:
- [ ] No LLM used
- [x] I used an LLM and I went through and validated all the code myself