### PR TITLE
Add AsymptoticConfidenceSequence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - `AsymptoticConfidenceSequence`, an anytime-valid confidence sequence whose width scales with the known standard errors of per-batch estimates.
 
 ### 🔄 Changed
-- Renamed `PPIMeanMonitor` to `EmpiricalPPIMeanMonitor` (`glide.monitors.ppi` → `glide.monitors.empirical_ppi`) and `ClassicalMeanMonitor` to `EmpiricalClassicalMeanMonitor` (`glide.monitors.classical` → `glide.monitors.empirical_classical`).
 - `ConfidenceSequence` is now a concrete base class rather than a structural protocol.
+- Renamed `PPIMeanMonitor` to `EmpiricalPPIMeanMonitor` (`glide.monitors.ppi` → `glide.monitors.empirical_ppi`) and `ClassicalMeanMonitor` to `EmpiricalClassicalMeanMonitor` (`glide.monitors.classical` → `glide.monitors.empirical_classical`).
 
 ### 🐛 Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ## [Next release]
 
 ### ✨ Added
+- `AsymptoticConfidenceSequence`, an anytime-valid confidence sequence whose width scales with the known standard errors of per-batch estimates.
 
 ### 🔄 Changed
 - Renamed `PPIMeanMonitor` to `EmpiricalPPIMeanMonitor` (`glide.monitors.ppi` → `glide.monitors.empirical_ppi`) and `ClassicalMeanMonitor` to `EmpiricalClassicalMeanMonitor` (`glide.monitors.classical` → `glide.monitors.empirical_classical`).
+- `ConfidenceSequence` is now a concrete base class rather than a structural protocol.
 
 ### 🐛 Fixed
 

--- a/docs/api/confidence_sequences.md
+++ b/docs/api/confidence_sequences.md
@@ -2,3 +2,5 @@
 
 ::: glide.confidence_sequences.empirical_bernstein.EmpiricalBernsteinConfidenceSequence
 
+::: glide.confidence_sequences.asymptotic.AsymptoticConfidenceSequence
+

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -74,6 +74,7 @@
 | Class | Description |
 |-------|-------------|
 | [`EmpiricalBernsteinConfidenceSequence`](confidence_sequences.md#glide.confidence_sequences.empirical_bernstein.EmpiricalBernsteinConfidenceSequence) | Anytime-valid empirical-Bernstein confidence sequence |
+| [`AsymptoticConfidenceSequence`](confidence_sequences.md#glide.confidence_sequences.asymptotic.AsymptoticConfidenceSequence) | Anytime-valid asymptotic confidence sequence |
 
 ## Inference Results
 

--- a/glide/confidence_sequences/__init__.py
+++ b/glide/confidence_sequences/__init__.py
@@ -1,7 +1,9 @@
+from glide.confidence_sequences.asymptotic import AsymptoticConfidenceSequence
 from glide.confidence_sequences.base import ConfidenceSequence
 from glide.confidence_sequences.empirical_bernstein import EmpiricalBernsteinConfidenceSequence
 
 __all__ = [
+    "AsymptoticConfidenceSequence",
     "ConfidenceSequence",
     "EmpiricalBernsteinConfidenceSequence",
 ]

--- a/glide/confidence_sequences/asymptotic.py
+++ b/glide/confidence_sequences/asymptotic.py
@@ -1,10 +1,11 @@
+from dataclasses import dataclass
 from typing import Tuple
 
 import numpy as np
 from numpy.typing import NDArray
 
 from glide.confidence_sequences.base import ConfidenceSequence
-from glide.core.validation import _validate_bounds
+from glide.core.validation import _validate_bounds, _validate_equal_lengths, _validate_is_integer, _validate_non_empty
 
 
 def _compute_asymptotic_bounds(
@@ -13,9 +14,18 @@ def _compute_asymptotic_bounds(
     miscoverage: float,
     tightest_at_batch: int,
 ) -> Tuple[NDArray, NDArray]:
+    _validate_non_empty(batch_estimates, "batch_estimates")
+    _validate_equal_lengths(batch_estimates, batch_std_estimates, names=["batch_estimates", "batch_std_estimates"])
+    _validate_bounds(
+        batch_std_estimates,
+        "batch_std_estimates",
+        lower=0.0,
+        error_message=f"'batch_std_estimates' must be non-negative; got {batch_std_estimates.min()!r}.",
+    )
     # The one-sided boundary uses the two-sided formula at twice the miscoverage,
     # which is only defined below 1, hence the 0.5 upper bound.
     _validate_bounds(miscoverage, "miscoverage", lower=0.0, upper=0.5, left_inclusive=False, right_inclusive=False)
+    _validate_is_integer(tightest_at_batch, "tightest_at_batch")
     _validate_bounds(tightest_at_batch, "tightest_at_batch", lower=1)
     n_batches = len(batch_estimates)
     batch_counts = np.arange(1, n_batches + 1)
@@ -49,6 +59,7 @@ def _compute_asymptotic_bounds(
     return running_mean_estimates, lower_bounds
 
 
+@dataclass
 class AsymptoticConfidenceSequence(ConfidenceSequence):
     """Anytime-valid asymptotic confidence sequence on a running mean.
 

--- a/glide/confidence_sequences/asymptotic.py
+++ b/glide/confidence_sequences/asymptotic.py
@@ -1,0 +1,88 @@
+from typing import Tuple
+
+import numpy as np
+from numpy.typing import NDArray
+
+from glide.confidence_sequences.base import ConfidenceSequence
+from glide.core.validation import _validate_bounds
+
+
+def _compute_asymptotic_bounds(
+    batch_estimates: NDArray,
+    batch_std_estimates: NDArray,
+    miscoverage: float,
+    tightest_at_batch: int,
+) -> Tuple[NDArray, NDArray]:
+    # The one-sided boundary uses the two-sided formula at twice the miscoverage,
+    # which is only defined below 1, hence the 0.5 upper bound.
+    _validate_bounds(miscoverage, "miscoverage", lower=0.0, upper=0.5, left_inclusive=False, right_inclusive=False)
+    _validate_bounds(tightest_at_batch, "tightest_at_batch", lower=1)
+    n_batches = len(batch_estimates)
+    batch_counts = np.arange(1, n_batches + 1)
+    running_mean_estimates = np.cumsum(batch_estimates) / batch_counts
+    # Intrinsic time of the Gaussian approximation: the accumulated squared
+    # standard errors of the batch estimates, not their realized scatter.
+    variance_process = np.cumsum(batch_std_estimates**2)
+    target_position = min(tightest_at_batch, n_batches) - 1
+    target_intrinsic_time = variance_process[target_position]
+    _validate_bounds(
+        target_intrinsic_time,
+        "batch_std_estimates",
+        lower=0.0,
+        left_inclusive=False,
+        error_message=(
+            f"'batch_std_estimates' must accumulate a positive variance by batch {target_position + 1}; "
+            f"got {target_intrinsic_time!r}."
+        ),
+    )
+    doubled_miscoverage = 2.0 * miscoverage
+    log_term = -2.0 * np.log(doubled_miscoverage)
+    tuning_scale_squared = (log_term + np.log(log_term + 1.0)) / target_intrinsic_time
+    scaled_times = variance_process * tuning_scale_squared + 1.0
+    boundary_widths = np.sqrt(
+        2.0
+        * scaled_times
+        / (batch_counts**2 * tuning_scale_squared)
+        * np.log(1.0 + np.sqrt(scaled_times) / doubled_miscoverage)
+    )
+    lower_bounds = running_mean_estimates - boundary_widths
+    return running_mean_estimates, lower_bounds
+
+
+class AsymptoticConfidenceSequence(ConfidenceSequence):
+    """Anytime-valid asymptotic confidence sequence on a running mean.
+
+    A Gaussian-mixture confidence sequence whose width scales with the known
+    standard errors of the per-batch estimates instead of a worst-case bounded
+    range, so the bounds stay tight when per-batch estimates are precise. The
+    price is an asymptotic (rather than exact) time-uniform guarantee: per-batch
+    estimates must be approximately Gaussian with consistently estimated
+    variances.
+
+    Parameters
+    ----------
+    running_mean_estimates : NDArray
+        Per-look running mean of the per-batch estimates, in original metric units.
+    confidence_bounds : NDArray
+        Per-look harmful-side anytime-valid bound, in original metric units.
+
+    References
+    ----------
+    Waudby-Smith, Ian, David Arbour, Ritwik Sinha, Edward H. Kennedy, and Aaditya
+    Ramdas. "Time-uniform central limit theory and asymptotic confidence
+    sequences." arXiv preprint arXiv:2103.06476 (2024).
+
+    Robbins, Herbert. "Statistical methods related to the law of the iterated
+    logarithm." The Annals of Mathematical Statistics 41, no. 5 (1970): 1397-1409.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from glide.confidence_sequences import AsymptoticConfidenceSequence
+    >>> sequence = AsymptoticConfidenceSequence(
+    ...     running_mean_estimates=np.array([0.4, 0.6]),
+    ...     confidence_bounds=np.array([0.1, 0.55]),
+    ... )
+    >>> sequence.test_null_hypothesis(0.5, alternative="larger")
+    array([False,  True])
+    """

--- a/glide/confidence_sequences/asymptotic.py
+++ b/glide/confidence_sequences/asymptotic.py
@@ -22,16 +22,13 @@ def _compute_asymptotic_bounds(
         lower=0.0,
         error_message=f"'batch_std_estimates' must be non-negative; got {batch_std_estimates.min()!r}.",
     )
-    # The one-sided boundary uses the two-sided formula at twice the miscoverage,
-    # which is only defined below 1, hence the 0.5 upper bound.
     _validate_bounds(miscoverage, "miscoverage", lower=0.0, upper=0.5, left_inclusive=False, right_inclusive=False)
     _validate_is_integer(tightest_at_batch, "tightest_at_batch")
     _validate_bounds(tightest_at_batch, "tightest_at_batch", lower=1)
     n_batches = len(batch_estimates)
     batch_counts = np.arange(1, n_batches + 1)
     running_mean_estimates = np.cumsum(batch_estimates) / batch_counts
-    # Intrinsic time of the Gaussian approximation: the accumulated squared
-    # standard errors of the batch estimates, not their realized scatter.
+
     variance_process = np.cumsum(batch_std_estimates**2)
     target_position = min(tightest_at_batch, n_batches) - 1
     target_intrinsic_time = variance_process[target_position]
@@ -81,7 +78,7 @@ class AsymptoticConfidenceSequence(ConfidenceSequence):
     ----------
     Waudby-Smith, Ian, David Arbour, Ritwik Sinha, Edward H. Kennedy, and Aaditya
     Ramdas. "Time-uniform central limit theory and asymptotic confidence
-    sequences." arXiv preprint arXiv:2103.06476 (2024).
+    sequences." The Annals of Statistics 52, no. 6 (2024): 2613-2640.
 
     Robbins, Herbert. "Statistical methods related to the law of the iterated
     logarithm." The Annals of Mathematical Statistics 41, no. 5 (1970): 1397-1409.

--- a/glide/confidence_sequences/base.py
+++ b/glide/confidence_sequences/base.py
@@ -1,15 +1,36 @@
-from typing import Literal, Protocol
+from dataclasses import dataclass
+from typing import Literal
 
 from numpy.typing import NDArray
 
+from glide.core.validation import _validate_literal
 
-class ConfidenceSequence(Protocol):
-    """Structural protocol for anytime-valid confidence sequences.
 
-    The time-uniform analogue of :class:`ConfidenceInterval`: instead of a single
-    bound it carries a bound per look (one per batch), valid simultaneously at all
-    looks. Any class implementing this protocol can be used as a
-    ``confidence_sequence`` in result objects like ``MeanMonitoringResult``.
+@dataclass
+class ConfidenceSequence:
+    """Anytime-valid confidence sequence on a running mean of per-batch estimates.
+
+    Holds the per-look running means and the one-sided anytime-valid bound on the
+    side where drift is harmful. The bounds hold simultaneously at all looks, so
+    testing after every batch does not inflate the false-alarm probability.
+
+    Parameters
+    ----------
+    running_mean_estimates : NDArray
+        Per-look running mean of the per-batch estimates, in original metric units.
+    confidence_bounds : NDArray
+        Per-look harmful-side anytime-valid bound, in original metric units.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from glide.confidence_sequences import ConfidenceSequence
+    >>> sequence = ConfidenceSequence(
+    ...     running_mean_estimates=np.array([0.4, 0.6]),
+    ...     confidence_bounds=np.array([0.1, 0.55]),
+    ... )
+    >>> sequence.test_null_hypothesis(0.5, alternative="larger")
+    array([False,  True])
     """
 
     running_mean_estimates: NDArray
@@ -20,9 +41,34 @@ class ConfidenceSequence(Protocol):
         h0_value: float,
         alternative: Literal["larger", "smaller"] = "larger",
     ) -> NDArray:
-        """Test the running mean against a value at every look.
+        """Test the running mean against ``h0_value`` at every look.
 
-        Returns the boolean per-look alarm vector, with time-uniform family-wise
-        error control over all looks.
+        Parameters
+        ----------
+        h0_value : float
+            The threshold the harmful-side bound is tested against (for a monitor,
+            the user-supplied business threshold).
+        alternative : str, optional
+            ``'larger'`` (default) when the metric is a risk: alarm where the lower
+            bound exceeds ``h0_value``. ``'smaller'`` when it is a performance: alarm
+            where the upper bound falls below ``h0_value``. A confidence sequence is
+            one-sided, so ``'two-sided'`` is not accepted.
+
+        Returns
+        -------
+        NDArray
+            Boolean per-look alarm vector, ``True`` once the bound has crossed
+            ``h0_value``. Time-uniform family-wise error is controlled over all looks.
+
+        Raises
+        ------
+        ValueError
+            If ``alternative`` is not ``'larger'`` or ``'smaller'``.
         """
-        ...
+        alternatives = ["larger", "smaller"]
+        _validate_literal(alternative, "alternative", alternatives)
+        if alternative == alternatives[0]:
+            alarms = self.confidence_bounds > h0_value
+        else:
+            alarms = self.confidence_bounds < h0_value
+        return alarms

--- a/glide/confidence_sequences/empirical_bernstein.py
+++ b/glide/confidence_sequences/empirical_bernstein.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 from typing import Tuple
 
 import numpy as np
@@ -60,6 +61,7 @@ def _compute_empirical_bernstein_bounds(
     return running_mean_estimates, lower_bounds
 
 
+@dataclass
 class EmpiricalBernsteinConfidenceSequence(ConfidenceSequence):
     """Anytime-valid empirical-Bernstein confidence sequence on a running mean.
 

--- a/glide/confidence_sequences/empirical_bernstein.py
+++ b/glide/confidence_sequences/empirical_bernstein.py
@@ -1,12 +1,12 @@
-from dataclasses import dataclass
-from typing import Literal, Tuple
+from typing import Tuple
 
 import numpy as np
 from numpy.typing import NDArray
 from scipy.optimize import brentq
 from scipy.special import gammainc, gammaln
 
-from glide.core.validation import _validate_bounds, _validate_literal
+from glide.confidence_sequences.base import ConfidenceSequence
+from glide.core.validation import _validate_bounds
 
 
 def _compute_mixture_wealth(deviation: float, variance_process_value: float) -> float:
@@ -60,8 +60,7 @@ def _compute_empirical_bernstein_bounds(
     return running_mean_estimates, lower_bounds
 
 
-@dataclass
-class EmpiricalBernsteinConfidenceSequence:
+class EmpiricalBernsteinConfidenceSequence(ConfidenceSequence):
     """Anytime-valid empirical-Bernstein confidence sequence on a running mean.
 
     Holds the per-look running means and the one-sided anytime-valid bound on the
@@ -98,43 +97,3 @@ class EmpiricalBernsteinConfidenceSequence:
     >>> sequence.test_null_hypothesis(0.5, alternative="larger")
     array([False,  True])
     """
-
-    running_mean_estimates: NDArray
-    confidence_bounds: NDArray
-
-    def test_null_hypothesis(
-        self,
-        h0_value: float,
-        alternative: Literal["larger", "smaller"] = "larger",
-    ) -> NDArray:
-        """Test the running mean against ``h0_value`` at every look.
-
-        Parameters
-        ----------
-        h0_value : float
-            The threshold the harmful-side bound is tested against (for a monitor,
-            the user-supplied business threshold).
-        alternative : str, optional
-            ``'larger'`` (default) when the metric is a risk: alarm where the lower
-            bound exceeds ``h0_value``. ``'smaller'`` when it is a performance: alarm
-            where the upper bound falls below ``h0_value``. A confidence sequence is
-            one-sided, so ``'two-sided'`` is not accepted.
-
-        Returns
-        -------
-        NDArray
-            Boolean per-look alarm vector, ``True`` once the bound has crossed
-            ``h0_value``. Time-uniform family-wise error is controlled over all looks.
-
-        Raises
-        ------
-        ValueError
-            If ``alternative`` is not ``'larger'`` or ``'smaller'``.
-        """
-        alternatives = ["larger", "smaller"]
-        _validate_literal(alternative, "alternative", alternatives)
-        if alternative == alternatives[0]:
-            alarms = self.confidence_bounds > h0_value
-        else:
-            alarms = self.confidence_bounds < h0_value
-        return alarms

--- a/tests/unit/confidence_sequences/test_asymptotic.py
+++ b/tests/unit/confidence_sequences/test_asymptotic.py
@@ -20,21 +20,51 @@ def batch_std_estimates():
 
 
 def test_compute_asymptotic_bounds_delegates_to_validation(batch_estimates, batch_std_estimates):
-    with patch.object(asymptotic_module, "_validate_bounds") as mock_validate_bounds:
+    with (
+        patch.object(asymptotic_module, "_validate_non_empty") as mock_validate_non_empty,
+        patch.object(asymptotic_module, "_validate_equal_lengths") as mock_validate_equal_lengths,
+        patch.object(asymptotic_module, "_validate_is_integer") as mock_validate_is_integer,
+        patch.object(asymptotic_module, "_validate_bounds") as mock_validate_bounds,
+    ):
         _compute_asymptotic_bounds(batch_estimates, batch_std_estimates, miscoverage=0.2, tightest_at_batch=1)
 
-        assert mock_validate_bounds.call_count == 3
-        assert mock_validate_bounds.call_args_list[0][0] == (0.2, "miscoverage")
-        assert mock_validate_bounds.call_args_list[0][1] == {
+        mock_validate_non_empty.assert_called_once_with(batch_estimates, "batch_estimates")
+        mock_validate_equal_lengths.assert_called_once()
+        np.testing.assert_array_equal(mock_validate_equal_lengths.call_args[0][0], batch_estimates)
+        np.testing.assert_array_equal(mock_validate_equal_lengths.call_args[0][1], batch_std_estimates)
+        assert mock_validate_equal_lengths.call_args[1] == {"names": ["batch_estimates", "batch_std_estimates"]}
+        mock_validate_is_integer.assert_called_once_with(1, "tightest_at_batch")
+
+        assert mock_validate_bounds.call_count == 4
+        np.testing.assert_array_equal(mock_validate_bounds.call_args_list[0][0][0], batch_std_estimates)
+        assert mock_validate_bounds.call_args_list[0][0][1] == "batch_std_estimates"
+        assert mock_validate_bounds.call_args_list[0][1]["lower"] == 0.0
+        assert mock_validate_bounds.call_args_list[1][0] == (0.2, "miscoverage")
+        assert mock_validate_bounds.call_args_list[1][1] == {
             "lower": 0.0,
             "upper": 0.5,
             "left_inclusive": False,
             "right_inclusive": False,
         }
-        assert mock_validate_bounds.call_args_list[1][0] == (1, "tightest_at_batch")
-        assert mock_validate_bounds.call_args_list[1][1] == {"lower": 1}
-        assert mock_validate_bounds.call_args_list[2][0][1] == "batch_std_estimates"
-        assert "must accumulate a positive variance" in mock_validate_bounds.call_args_list[2][1]["error_message"]
+        assert mock_validate_bounds.call_args_list[2][0] == (1, "tightest_at_batch")
+        assert mock_validate_bounds.call_args_list[2][1] == {"lower": 1}
+        assert mock_validate_bounds.call_args_list[3][0][1] == "batch_std_estimates"
+        assert "must accumulate a positive variance" in mock_validate_bounds.call_args_list[3][1]["error_message"]
+
+
+def test_compute_asymptotic_bounds_empty_batch_estimates():
+    with pytest.raises(ValueError, match="'batch_estimates' must be non-empty"):
+        _compute_asymptotic_bounds(np.array([]), np.array([]), miscoverage=0.2, tightest_at_batch=1)
+
+
+def test_compute_asymptotic_bounds_mismatched_lengths(batch_estimates):
+    with pytest.raises(ValueError, match="must have the same length"):
+        _compute_asymptotic_bounds(batch_estimates, np.array([0.1]), miscoverage=0.2, tightest_at_batch=1)
+
+
+def test_compute_asymptotic_bounds_negative_std(batch_estimates):
+    with pytest.raises(ValueError, match="'batch_std_estimates' must be non-negative"):
+        _compute_asymptotic_bounds(batch_estimates, np.array([-0.1, 0.2]), miscoverage=0.2, tightest_at_batch=1)
 
 
 def test_compute_asymptotic_bounds(batch_estimates, batch_std_estimates):

--- a/tests/unit/confidence_sequences/test_asymptotic.py
+++ b/tests/unit/confidence_sequences/test_asymptotic.py
@@ -1,0 +1,82 @@
+from unittest.mock import patch
+
+import numpy as np
+import pytest
+
+import glide.confidence_sequences.asymptotic as asymptotic_module
+from glide.confidence_sequences import AsymptoticConfidenceSequence
+from glide.confidence_sequences.asymptotic import _compute_asymptotic_bounds
+
+# --- _compute_asymptotic_bounds ---
+
+
+@pytest.fixture
+def batch_estimates():
+    return np.array([0.4, 0.6])
+
+
+@pytest.fixture
+def batch_std_estimates():
+    return np.array([0.1, 0.2])
+
+
+def test_compute_asymptotic_bounds_delegates_to_validation(batch_estimates, batch_std_estimates):
+    with patch.object(asymptotic_module, "_validate_bounds") as mock_validate_bounds:
+        _compute_asymptotic_bounds(batch_estimates, batch_std_estimates, miscoverage=0.2, tightest_at_batch=1)
+
+        assert mock_validate_bounds.call_count == 3
+        assert mock_validate_bounds.call_args_list[0][0] == (0.2, "miscoverage")
+        assert mock_validate_bounds.call_args_list[0][1] == {
+            "lower": 0.0,
+            "upper": 0.5,
+            "left_inclusive": False,
+            "right_inclusive": False,
+        }
+        assert mock_validate_bounds.call_args_list[1][0] == (1, "tightest_at_batch")
+        assert mock_validate_bounds.call_args_list[1][1] == {"lower": 1}
+        assert mock_validate_bounds.call_args_list[2][0][1] == "batch_std_estimates"
+        assert "must accumulate a positive variance" in mock_validate_bounds.call_args_list[2][1]["error_message"]
+
+
+def test_compute_asymptotic_bounds(batch_estimates, batch_std_estimates):
+    running_means, lower_bounds = _compute_asymptotic_bounds(
+        batch_estimates, batch_std_estimates, miscoverage=0.2, tightest_at_batch=1
+    )
+    np.testing.assert_allclose(running_means, np.array([0.4, 0.5]))
+    np.testing.assert_allclose(lower_bounds, np.array([0.181036, 0.247749]), atol=1e-6)
+
+
+def test_compute_asymptotic_bounds_width_shrinks_with_batches():
+    running_means, lower_bounds = _compute_asymptotic_bounds(
+        np.array([0.5, 0.5, 0.5]), np.array([0.05, 0.05, 0.05]), miscoverage=0.2, tightest_at_batch=1
+    )
+    np.testing.assert_allclose(running_means - lower_bounds, np.array([0.109482, 0.076885, 0.063525]), atol=1e-6)
+
+
+def test_compute_asymptotic_bounds_widens_with_confidence(batch_estimates, batch_std_estimates):
+    _, loose = _compute_asymptotic_bounds(batch_estimates, batch_std_estimates, miscoverage=0.3, tightest_at_batch=1)
+    _, tight = _compute_asymptotic_bounds(batch_estimates, batch_std_estimates, miscoverage=0.1, tightest_at_batch=1)
+    np.testing.assert_allclose(loose, np.array([0.195628, 0.274674]), atol=1e-6)
+    np.testing.assert_allclose(tight, np.array([0.150778, 0.209157]), atol=1e-6)
+
+
+def test_compute_asymptotic_bounds_target_clamped_to_last_batch(batch_estimates, batch_std_estimates):
+    _, clamped = _compute_asymptotic_bounds(batch_estimates, batch_std_estimates, miscoverage=0.2, tightest_at_batch=5)
+    _, exact = _compute_asymptotic_bounds(batch_estimates, batch_std_estimates, miscoverage=0.2, tightest_at_batch=2)
+    np.testing.assert_allclose(clamped, exact)
+
+
+# --- AsymptoticConfidenceSequence ---
+
+
+@pytest.fixture
+def sequence():
+    return AsymptoticConfidenceSequence(
+        running_mean_estimates=np.array([0.4, 0.6]),
+        confidence_bounds=np.array([0.1, 0.55]),
+    )
+
+
+def test_sequence_attributes(sequence):
+    np.testing.assert_array_equal(sequence.running_mean_estimates, np.array([0.4, 0.6]))
+    np.testing.assert_array_equal(sequence.confidence_bounds, np.array([0.1, 0.55]))

--- a/tests/unit/confidence_sequences/test_asymptotic.py
+++ b/tests/unit/confidence_sequences/test_asymptotic.py
@@ -4,7 +4,6 @@ import numpy as np
 import pytest
 
 import glide.confidence_sequences.asymptotic as asymptotic_module
-from glide.confidence_sequences import AsymptoticConfidenceSequence
 from glide.confidence_sequences.asymptotic import _compute_asymptotic_bounds
 
 # --- _compute_asymptotic_bounds ---
@@ -46,37 +45,7 @@ def test_compute_asymptotic_bounds(batch_estimates, batch_std_estimates):
     np.testing.assert_allclose(lower_bounds, np.array([0.181036, 0.247749]), atol=1e-6)
 
 
-def test_compute_asymptotic_bounds_width_shrinks_with_batches():
-    running_means, lower_bounds = _compute_asymptotic_bounds(
-        np.array([0.5, 0.5, 0.5]), np.array([0.05, 0.05, 0.05]), miscoverage=0.2, tightest_at_batch=1
-    )
-    np.testing.assert_allclose(running_means - lower_bounds, np.array([0.109482, 0.076885, 0.063525]), atol=1e-6)
-
-
-def test_compute_asymptotic_bounds_widens_with_confidence(batch_estimates, batch_std_estimates):
-    _, loose = _compute_asymptotic_bounds(batch_estimates, batch_std_estimates, miscoverage=0.3, tightest_at_batch=1)
-    _, tight = _compute_asymptotic_bounds(batch_estimates, batch_std_estimates, miscoverage=0.1, tightest_at_batch=1)
-    np.testing.assert_allclose(loose, np.array([0.195628, 0.274674]), atol=1e-6)
-    np.testing.assert_allclose(tight, np.array([0.150778, 0.209157]), atol=1e-6)
-
-
 def test_compute_asymptotic_bounds_target_clamped_to_last_batch(batch_estimates, batch_std_estimates):
     _, clamped = _compute_asymptotic_bounds(batch_estimates, batch_std_estimates, miscoverage=0.2, tightest_at_batch=5)
     _, exact = _compute_asymptotic_bounds(batch_estimates, batch_std_estimates, miscoverage=0.2, tightest_at_batch=2)
     np.testing.assert_allclose(clamped, exact)
-
-
-# --- AsymptoticConfidenceSequence ---
-
-
-@pytest.fixture
-def sequence():
-    return AsymptoticConfidenceSequence(
-        running_mean_estimates=np.array([0.4, 0.6]),
-        confidence_bounds=np.array([0.1, 0.55]),
-    )
-
-
-def test_sequence_attributes(sequence):
-    np.testing.assert_array_equal(sequence.running_mean_estimates, np.array([0.4, 0.6]))
-    np.testing.assert_array_equal(sequence.confidence_bounds, np.array([0.1, 0.55]))

--- a/tests/unit/confidence_sequences/test_asymptotic.py
+++ b/tests/unit/confidence_sequences/test_asymptotic.py
@@ -52,21 +52,6 @@ def test_compute_asymptotic_bounds_delegates_to_validation(batch_estimates, batc
         assert "must accumulate a positive variance" in mock_validate_bounds.call_args_list[3][1]["error_message"]
 
 
-def test_compute_asymptotic_bounds_empty_batch_estimates():
-    with pytest.raises(ValueError, match="'batch_estimates' must be non-empty"):
-        _compute_asymptotic_bounds(np.array([]), np.array([]), miscoverage=0.2, tightest_at_batch=1)
-
-
-def test_compute_asymptotic_bounds_mismatched_lengths(batch_estimates):
-    with pytest.raises(ValueError, match="must have the same length"):
-        _compute_asymptotic_bounds(batch_estimates, np.array([0.1]), miscoverage=0.2, tightest_at_batch=1)
-
-
-def test_compute_asymptotic_bounds_negative_std(batch_estimates):
-    with pytest.raises(ValueError, match="'batch_std_estimates' must be non-negative"):
-        _compute_asymptotic_bounds(batch_estimates, np.array([-0.1, 0.2]), miscoverage=0.2, tightest_at_batch=1)
-
-
 def test_compute_asymptotic_bounds(batch_estimates, batch_std_estimates):
     running_means, lower_bounds = _compute_asymptotic_bounds(
         batch_estimates, batch_std_estimates, miscoverage=0.2, tightest_at_batch=1

--- a/tests/unit/confidence_sequences/test_base.py
+++ b/tests/unit/confidence_sequences/test_base.py
@@ -1,0 +1,34 @@
+from unittest.mock import patch
+
+import numpy as np
+import pytest
+
+import glide.confidence_sequences.base as base_module
+from glide.confidence_sequences import ConfidenceSequence
+
+# --- ConfidenceSequence ---
+
+
+@pytest.fixture
+def sequence():
+    return ConfidenceSequence(
+        running_mean_estimates=np.array([0.4, 0.6]),
+        confidence_bounds=np.array([0.1, 0.55]),
+    )
+
+
+def test_null_hypothesis_delegates_to_validation(sequence):
+    with patch.object(base_module, "_validate_literal") as mock_validate_literal:
+        sequence.test_null_hypothesis(0.5, alternative="larger")
+
+        mock_validate_literal.assert_called_once_with("larger", "alternative", ["larger", "smaller"])
+
+
+def test_null_hypothesis_larger(sequence):
+    alarms = sequence.test_null_hypothesis(0.5, alternative="larger")
+    np.testing.assert_array_equal(alarms, np.array([False, True]))
+
+
+def test_null_hypothesis_smaller(sequence):
+    alarms = sequence.test_null_hypothesis(0.3, alternative="smaller")
+    np.testing.assert_array_equal(alarms, np.array([True, False]))

--- a/tests/unit/confidence_sequences/test_base.py
+++ b/tests/unit/confidence_sequences/test_base.py
@@ -17,6 +17,11 @@ def sequence():
     )
 
 
+def test_sequence_attributes(sequence):
+    np.testing.assert_array_equal(sequence.running_mean_estimates, np.array([0.4, 0.6]))
+    np.testing.assert_array_equal(sequence.confidence_bounds, np.array([0.1, 0.55]))
+
+
 def test_null_hypothesis_delegates_to_validation(sequence):
     with patch.object(base_module, "_validate_literal") as mock_validate_literal:
         sequence.test_null_hypothesis(0.5, alternative="larger")

--- a/tests/unit/confidence_sequences/test_empirical_bernstein.py
+++ b/tests/unit/confidence_sequences/test_empirical_bernstein.py
@@ -89,20 +89,3 @@ def sequence():
 def test_sequence_attributes(sequence):
     np.testing.assert_array_equal(sequence.running_mean_estimates, np.array([0.4, 0.6]))
     np.testing.assert_array_equal(sequence.confidence_bounds, np.array([0.1, 0.55]))
-
-
-def test_null_hypothesis_delegates_to_validation(sequence):
-    with patch.object(empirical_bernstein_module, "_validate_literal") as mock_validate_literal:
-        sequence.test_null_hypothesis(0.5, alternative="larger")
-
-        mock_validate_literal.assert_called_once_with("larger", "alternative", ["larger", "smaller"])
-
-
-def test_null_hypothesis_larger(sequence):
-    alarms = sequence.test_null_hypothesis(0.5, alternative="larger")
-    np.testing.assert_array_equal(alarms, np.array([False, True]))
-
-
-def test_null_hypothesis_smaller(sequence):
-    alarms = sequence.test_null_hypothesis(0.3, alternative="smaller")
-    np.testing.assert_array_equal(alarms, np.array([True, False]))

--- a/tests/unit/confidence_sequences/test_empirical_bernstein.py
+++ b/tests/unit/confidence_sequences/test_empirical_bernstein.py
@@ -4,7 +4,6 @@ import numpy as np
 import pytest
 
 import glide.confidence_sequences.empirical_bernstein as empirical_bernstein_module
-from glide.confidence_sequences import EmpiricalBernsteinConfidenceSequence
 from glide.confidence_sequences.empirical_bernstein import (
     _compute_empirical_bernstein_bounds,
     _compute_mixture_boundary,
@@ -73,19 +72,3 @@ def test_compute_empirical_bernstein_bounds(batch_estimates):
     expected_lower_bound = np.array([0.0, 0.258218, 0.338812])
     np.testing.assert_allclose(running_mean_estimates, np.array([0.4, 0.5, 0.5]))
     np.testing.assert_allclose(lower_bounds, expected_lower_bound, atol=1e-6)
-
-
-# --- EmpiricalBernsteinConfidenceSequence ---
-
-
-@pytest.fixture
-def sequence():
-    return EmpiricalBernsteinConfidenceSequence(
-        running_mean_estimates=np.array([0.4, 0.6]),
-        confidence_bounds=np.array([0.1, 0.55]),
-    )
-
-
-def test_sequence_attributes(sequence):
-    np.testing.assert_array_equal(sequence.running_mean_estimates, np.array([0.4, 0.6]))
-    np.testing.assert_array_equal(sequence.confidence_bounds, np.array([0.1, 0.55]))


### PR DESCRIPTION

### Description

- Adds `AsymptoticConfidenceSequence`, a variance-adaptive anytime-valid confidence sequence that consumes known per-batch standard errors instead of treating each batch estimate as an arbitrary point in `[0, 1]`, tightening drift-detection bounds when batch estimates are precise. `ConfidenceSequence` is converted from a structural protocol into a concrete dataclass base class shared by both `EmpiricalBernsteinConfidenceSequence` and the new `AsymptoticConfidenceSequence`.
- Handles this [ticket](https://github.com/orgs/EmertonData/projects/26/views/2?pane=issue&itemId=214000263) and Closes #348 

### Noteworthy choices 

Factorizing AsymptoticConfidenceSequence and EmpiricalConfidenceSequence into a single class would have implied a significant refactor and removed the opportunity to give details in these two classes' docstrings. It has been set aside and can be considered in the future.

### Checklist

Quality gates that must be satisfied before requesting a review:

- [x] I have read `CONTRIBUTING.md`
- [x] `make lint` passes
- [x] `make type-check` passes
- [x] `make tests` passes
- [x] `make coverage` reports 100% coverage
- [x] `make test-notebooks` passes
- [x] New public API has numpy-style docstrings
- [x] New public API is inserted in the API reference section of the documentation
- [x] Docs build without warnings (`make doc`)
- [x] `CHANGELOG.md` updated if the change is user-facing

### LLM usage

Disclose if an LLM was used in writing this PR:
- [ ] No LLM used
- [x] I used an LLM and I went through and validated all the code myself