### PR TITLE
Add AsymptoticClassicalMeanMonitor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ## [Next release]
 
 ### ✨ Added
+- `AsymptoticClassicalMeanMonitor`, a label-only drift monitor built on `AsymptoticConfidenceSequence` and using the batch estimates' standard errors.
 - `AsymptoticConfidenceSequence`, an anytime-valid confidence sequence whose width scales with the known standard errors of per-batch estimates.
 
 ### 🔄 Changed

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -55,6 +55,7 @@
 | Class | Description |
 |-------|-------------|
 | [`EmpiricalClassicalMeanMonitor`](monitors.md#glide.monitors.empirical_classical.EmpiricalClassicalMeanMonitor) | Anytime-valid drift monitor over batched labels, without proxy predictions |
+| [`AsymptoticClassicalMeanMonitor`](monitors.md#glide.monitors.asymptotic_classical.AsymptoticClassicalMeanMonitor) | Anytime-valid drift monitor over batched labels via an asymptotic confidence sequence, without proxy predictions |
 
 ### Prediction-Powered
 

--- a/docs/api/monitors.md
+++ b/docs/api/monitors.md
@@ -5,3 +5,7 @@
 ---
 
 ::: glide.monitors.empirical_ppi.EmpiricalPPIMeanMonitor
+
+---
+
+::: glide.monitors.asymptotic_classical.AsymptoticClassicalMeanMonitor

--- a/glide/monitors/__init__.py
+++ b/glide/monitors/__init__.py
@@ -1,7 +1,9 @@
+from glide.monitors.asymptotic_classical import AsymptoticClassicalMeanMonitor
 from glide.monitors.empirical_classical import EmpiricalClassicalMeanMonitor
 from glide.monitors.empirical_ppi import EmpiricalPPIMeanMonitor
 
 __all__ = [
+    "AsymptoticClassicalMeanMonitor",
     "EmpiricalClassicalMeanMonitor",
     "EmpiricalPPIMeanMonitor",
 ]

--- a/glide/monitors/asymptotic_classical.py
+++ b/glide/monitors/asymptotic_classical.py
@@ -12,13 +12,13 @@ class AsymptoticClassicalMeanMonitor:
     """Anytime-valid label-only drift monitor leveraging each batch estimate's
     standard deviation.
 
-    It computes a per-batch sample mean of the labeled values and monitors the
-    running mean of those estimates against a user-supplied ``threshold``,
-    through a Gaussian-mixture asymptotic confidence sequence whose width scales
-    with the standard error of each batch mean, so genuine drifts are detected
-    early. The false-alarm guarantee is asymptotic: each batch needs enough
-    labeled samples (preferably tens) for its sample mean to be approximately
-    Gaussian with a consistently estimated variance.
+    It computes a per-batch sample mean of the labeled values, then tracks the
+    running mean of those estimates against a user-supplied ``threshold``. The
+    comparison uses a Gaussian-mixture asymptotic confidence sequence whose
+    width scales with the standard error of each batch mean, so genuine drifts
+    get flagged early. The false-alarm guarantee is asymptotic: each batch
+    needs enough labeled samples (preferably tens) for its sample mean to be
+    approximately Gaussian with a consistently estimated variance.
 
     References
     ----------

--- a/glide/monitors/asymptotic_classical.py
+++ b/glide/monitors/asymptotic_classical.py
@@ -146,7 +146,7 @@ class AsymptoticClassicalMeanMonitor:
         risk_y, _, batch_codes, batch_n = _preprocess(
             y, batches, higher_is_better, threshold, confidence_level, metric_lower_bound, metric_upper_bound
         )
-        batch_mean_estimates, batch_std_estimates = _compute_batch_estimates(risk_y, batch_codes)
+        batch_mean_estimates, batch_std_estimates = _compute_batch_estimates(risk_y, batch_codes, batch_n)
         miscoverage = 1.0 - confidence_level
         risk_running_means, risk_lower_bounds = _compute_asymptotic_bounds(
             batch_mean_estimates, batch_std_estimates, miscoverage, tightest_at_batch

--- a/glide/monitors/asymptotic_classical.py
+++ b/glide/monitors/asymptotic_classical.py
@@ -68,10 +68,10 @@ class AsymptoticClassicalMeanMonitor:
         every call makes the anytime-valid guarantee hold jointly over all calls.
         Alternatively the data may be restricted to the most recent batches, in which
         case the guarantee holds within each restriction but not across the moving
-        history as a whole. When the history is shorter than ``tightest_at_batch``,
-        the tuning target moves with it, so bounds up to that batch recalibrate
-        between successive calls; from ``tightest_at_batch`` onward they are
-        prefix-consistent.
+        history as a whole. When the history has fewer batches than ``tightest_at_batch``,
+        the tuning target is set to the last batch. Prefix-consistency only holds between
+        calls using the same ``tightest_at_batch`` value and with histories containing
+        at least ``tightest_at_batch`` batches.
 
         Parameters
         ----------
@@ -146,7 +146,7 @@ class AsymptoticClassicalMeanMonitor:
         risk_y, _, batch_codes, batch_n = _preprocess(
             y, batches, higher_is_better, threshold, confidence_level, metric_lower_bound, metric_upper_bound
         )
-        batch_mean_estimates, batch_std_estimates = _compute_batch_estimates(risk_y, batch_codes, batch_n)
+        batch_mean_estimates, batch_std_estimates = _compute_batch_estimates(risk_y, batch_codes)
         miscoverage = 1.0 - confidence_level
         risk_running_means, risk_lower_bounds = _compute_asymptotic_bounds(
             batch_mean_estimates, batch_std_estimates, miscoverage, tightest_at_batch

--- a/glide/monitors/asymptotic_classical.py
+++ b/glide/monitors/asymptotic_classical.py
@@ -1,53 +1,45 @@
 from numpy.typing import NDArray
 
-from glide.confidence_sequences import EmpiricalBernsteinConfidenceSequence
-from glide.confidence_sequences.empirical_bernstein import _compute_empirical_bernstein_bounds
+from glide.confidence_sequences import AsymptoticConfidenceSequence
+from glide.confidence_sequences.asymptotic import _compute_asymptotic_bounds
+from glide.core.validation import _validate_bounds
 from glide.mean_monitoring_results import ClassicalMeanMonitoringResult
 from glide.monitors.classical_core import _compute_batch_estimates, _preprocess
 from glide.monitors.core import _postprocess
 
 
-class EmpiricalClassicalMeanMonitor:
-    """Anytime-valid drift monitor over a batched dataset of labels.
+class AsymptoticClassicalMeanMonitor:
+    """Anytime-valid label-only drift monitor leveraging each batch estimate's
+    standard deviation.
 
-    It uses the plain sample mean per batch. Unlabeled entries are passed as
-    ``np.nan`` and dropped per batch. To be used on accumulated non-overlapping
-    production batches by calling :meth:`detect` on the whole accumulated dataset at
-    any time. Data is passed oldest batch first, and every batch is monitored. The
-    monitor computes a sample-mean estimate per batch, builds an anytime-valid
-    confidence sequence on the running mean of those estimates, and raises a drift
-    alarm when it crosses a user-supplied ``threshold`` (the worst tolerable metric value).
-    Because the bounds are valid at all times simultaneously, :meth:`detect` may be called
-    after every new batch without inflating the false-alarm probability.
+    It computes a per-batch sample mean of the labeled values and monitors the
+    running mean of those estimates against a user-supplied ``threshold``,
+    through a Gaussian-mixture asymptotic confidence sequence whose width scales
+    with the standard error of each batch mean, so genuine drifts are detected
+    early. The false-alarm guarantee is asymptotic: each batch needs enough
+    labeled samples (preferably tens) for its sample mean to be approximately
+    Gaussian with a consistently estimated variance.
 
     References
     ----------
-    Howard, Steven R., Aaditya Ramdas, Jon McAuliffe, and Jasjeet Sekhon. "Time-uniform,
-    nonparametric, nonasymptotic confidence sequences." The Annals of Statistics 49,
-    no. 2 (2021): 1055-1080.
-
-    Podkopaev, Aleksandr, and Aaditya Ramdas. "Tracking the risk of a deployed model
-    and detecting harmful distribution shifts." International Conference on Learning
-    Representations (ICLR), 2022.
-
-    Waudby-Smith, Ian, and Aaditya Ramdas. "Estimating means of bounded random
-    variables by betting." Journal of the Royal Statistical Society Series B:
-    Statistical Methodology 86, no. 1 (2024): 1-27.
+    Waudby-Smith, Ian, David Arbour, Ritwik Sinha, Edward H. Kennedy, and Aaditya
+    Ramdas. "Time-uniform central limit theory and asymptotic confidence
+    sequences." The Annals of Statistics 52, no. 6 (2024): 2613-2640.
 
     Examples
     --------
     >>> import numpy as np
-    >>> from glide.monitors import EmpiricalClassicalMeanMonitor
+    >>> from glide.monitors import AsymptoticClassicalMeanMonitor
     >>> pre_drift_batch = np.array([0.0, 0.2, np.nan, np.nan])
     >>> post_drift_batch = np.array([0.8, 1.0, np.nan, np.nan])
     >>> y = np.hstack([pre_drift_batch, np.tile(post_drift_batch, 50)])
     >>> batches = np.repeat(np.arange(51), 4)
-    >>> monitor = EmpiricalClassicalMeanMonitor()
+    >>> monitor = AsymptoticClassicalMeanMonitor()
     >>> result = monitor.detect(y, batches, higher_is_better=False, threshold=0.5)
     >>> result.drift_detected
     True
     >>> result.first_alarm_index
-    11
+    3
     """
 
     def detect(
@@ -60,13 +52,14 @@ class EmpiricalClassicalMeanMonitor:
         confidence_level: float = 0.8,
         metric_lower_bound: float = 0.0,
         metric_upper_bound: float = 1.0,
+        tightest_at_batch: int = 10,
     ) -> ClassicalMeanMonitoringResult:
         """Detect a drift of the running mean across a batched dataset.
 
-        Splits the data by batch, computes a sample-mean estimate per batch, and
-        builds an anytime-valid empirical-Bernstein confidence sequence on the
-        running mean of those estimates. An alarm is raised at every batch where the
-        sequence crosses the user-supplied ``threshold``.
+        Splits the data by batch, computes a sample-mean estimate and its standard
+        error per batch, and builds an anytime-valid asymptotic confidence sequence
+        on the running mean of those estimates. An alarm is raised at every batch
+        where the sequence crosses the user-supplied ``threshold``.
 
         Rows must be ordered oldest batch first and grouped into contiguous blocks;
         identifier values are not compared, so any label type works. Batches must be
@@ -75,14 +68,18 @@ class EmpiricalClassicalMeanMonitor:
         every call makes the anytime-valid guarantee hold jointly over all calls.
         Alternatively the data may be restricted to the most recent batches, in which
         case the guarantee holds within each restriction but not across the moving
-        history as a whole.
+        history as a whole. When the history is shorter than ``tightest_at_batch``,
+        the tuning target moves with it, so bounds up to that batch recalibrate
+        between successive calls; from ``tightest_at_batch`` onward they are
+        prefix-consistent.
 
         Parameters
         ----------
         y : NDArray
             Array of observations, shape ``(n_samples,)``. Unlabeled entries are
             ``np.nan`` and are dropped per batch; every batch must keep at least 2
-            labeled entries.
+            labeled entries, though tens are recommended in practice for the
+            asymptotic guarantee to hold.
         batches : NDArray
             Array of batch identifiers, shape ``(n_samples,)``. Rows must be ordered
             oldest batch first and grouped into contiguous blocks. Identifier values
@@ -104,11 +101,15 @@ class EmpiricalClassicalMeanMonitor:
             raises "80% confident" alarms: under no drift it has at most a 20% chance
             of raising a false alarm. Raising this value demands more evidence before
             alarming, so alarms become more trustworthy but arrive later; lowering it
-            detects sooner at the cost of more false alarms.
+            detects sooner at the cost of more false alarms. Must be in ``(0.5, 1)``.
         metric_lower_bound : float, optional
             Known lower bound of the metric. Defaults to ``0.0``.
         metric_upper_bound : float, optional
             Known upper bound of the metric. Defaults to ``1.0``.
+        tightest_at_batch : int, optional
+            The batch index (1-indexed) at which the confidence sequence is tuned to
+            be tightest. Defaults to ``10``. Only affects tightness, not validity:
+            bounds stay anytime-valid at every batch regardless of this choice.
 
         Returns
         -------
@@ -123,32 +124,42 @@ class EmpiricalClassicalMeanMonitor:
             - If ``y`` is empty.
             - If ``y`` and ``batches`` have different lengths.
             - If ``batches`` contains NaN values (numeric dtype) or None values (non-numeric dtype).
-            - If ``confidence_level`` is not in (0, 1).
+            - If ``confidence_level`` is not in ``(0.5, 1)``.
             - If ``metric_lower_bound >= metric_upper_bound``.
             - If ``threshold`` falls outside ``[metric_lower_bound, metric_upper_bound]``.
             - If any labeled value falls outside ``[metric_lower_bound, metric_upper_bound]``.
             - If batches are interleaved rather than grouped into contiguous blocks.
             - If any batch has fewer than 2 labeled (non-NaN) samples.
+            - If the accumulated variance of the batch estimates up to ``tightest_at_batch`` is zero.
         """
-        risk_y, risk_threshold, batch_codes, batch_n = _preprocess(
+        _validate_bounds(
+            confidence_level,
+            "confidence_level",
+            lower=0.5,
+            upper=1,
+            left_inclusive=False,
+            right_inclusive=False,
+            error_message=(
+                f"'confidence_level' must be in (0.5, 1) for the asymptotic monitor; got {confidence_level!r}."
+            ),
+        )
+        risk_y, _, batch_codes, batch_n = _preprocess(
             y, batches, higher_is_better, threshold, confidence_level, metric_lower_bound, metric_upper_bound
         )
-        risk_batch_mean_estimates, _ = _compute_batch_estimates(risk_y, batch_codes)
-
+        batch_mean_estimates, batch_std_estimates = _compute_batch_estimates(risk_y, batch_codes)
         miscoverage = 1.0 - confidence_level
-        risk_running_means, risk_confidence_bounds = _compute_empirical_bernstein_bounds(
-            risk_batch_mean_estimates, risk_threshold, miscoverage
+        risk_running_means, risk_lower_bounds = _compute_asymptotic_bounds(
+            batch_mean_estimates, batch_std_estimates, miscoverage, tightest_at_batch
         )
-
-        running_means, confidence_bounds, batch_mean_estimates = _postprocess(
+        running_means, confidence_bounds, metric_batch_estimates = _postprocess(
             risk_running_means,
-            risk_confidence_bounds,
-            risk_batch_mean_estimates,
+            risk_lower_bounds,
+            batch_mean_estimates,
             higher_is_better,
             metric_lower_bound,
             metric_upper_bound,
         )
-        confidence_sequence = EmpiricalBernsteinConfidenceSequence(
+        confidence_sequence = AsymptoticConfidenceSequence(
             running_mean_estimates=running_means,
             confidence_bounds=confidence_bounds,
         )
@@ -158,7 +169,7 @@ class EmpiricalClassicalMeanMonitor:
             higher_is_better=higher_is_better,
             alarm_threshold=threshold,
             confidence_level=confidence_level,
-            batch_mean_estimates=batch_mean_estimates,
+            batch_mean_estimates=metric_batch_estimates,
             confidence_sequence=confidence_sequence,
             batch_n=batch_n,
         )

--- a/glide/monitors/classical_core.py
+++ b/glide/monitors/classical_core.py
@@ -1,0 +1,86 @@
+from typing import Tuple
+
+import numpy as np
+from numpy.typing import NDArray
+
+from glide.core.validation import _validate_bounds, _validate_equal_lengths, _validate_has_no_nan, _validate_non_empty
+from glide.monitors.core import _scale_to_unit_risk, _unique_ordered_batches
+
+
+def _preprocess(
+    y: NDArray,
+    batches: NDArray,
+    higher_is_better: bool,
+    threshold: float,
+    confidence_level: float,
+    metric_lower_bound: float,
+    metric_upper_bound: float,
+) -> Tuple[NDArray, float, NDArray, NDArray]:
+    _validate_non_empty(y, "y")
+    _validate_equal_lengths(y, batches, names=["y", "batches"])
+    _validate_has_no_nan(batches, "batches")
+    _validate_bounds(
+        confidence_level, "confidence_level", lower=0, upper=1, left_inclusive=False, right_inclusive=False
+    )
+    _validate_bounds(
+        metric_lower_bound,
+        "metric_lower_bound",
+        upper=metric_upper_bound,
+        right_inclusive=False,
+        error_message=(
+            f"'metric_lower_bound' must be strictly smaller than 'metric_upper_bound'; "
+            f"got {metric_lower_bound!r} and {metric_upper_bound!r}."
+        ),
+    )
+    _validate_bounds(
+        threshold,
+        "threshold",
+        lower=metric_lower_bound,
+        upper=metric_upper_bound,
+        error_message=(
+            f"'threshold' must lie between 'metric_lower_bound'={metric_lower_bound!r} and "
+            f"'metric_upper_bound'={metric_upper_bound!r}."
+        ),
+    )
+    labeled_mask = ~np.isnan(y)
+    labeled_values = y[labeled_mask]
+    _validate_bounds(
+        labeled_values,
+        "y",
+        lower=metric_lower_bound,
+        upper=metric_upper_bound,
+        error_message=(
+            f"'y' values must lie between 'metric_lower_bound'={metric_lower_bound!r} and "
+            f"'metric_upper_bound'={metric_upper_bound!r}; got values in "
+            f"[{labeled_values.min()!r}, {labeled_values.max()!r}]."
+        ),
+    )
+    batches_labeled = batches[labeled_mask]
+    batch_identifiers, batch_codes = _unique_ordered_batches(batches_labeled)
+    batch_n = np.bincount(batch_codes)
+    worst_batch_position = np.argmin(batch_n)
+    _validate_bounds(
+        batch_n[worst_batch_position],
+        "y",
+        lower=2,
+        error_message=(
+            f"'y' must have at least 2 non-NaN values per batch; got {batch_n[worst_batch_position]} "
+            f"in batch '{batch_identifiers[worst_batch_position]}'."
+        ),
+    )
+    risk_y = _scale_to_unit_risk(labeled_values, metric_lower_bound, metric_upper_bound, higher_is_better)
+    risk_threshold = _scale_to_unit_risk(threshold, metric_lower_bound, metric_upper_bound, higher_is_better)
+    return risk_y, risk_threshold, batch_codes, batch_n
+
+
+def _compute_batch_estimates(
+    risk_y: NDArray,
+    batch_codes: NDArray,
+) -> Tuple[NDArray, NDArray]:
+    batch_n = np.bincount(batch_codes)
+    batch_sums = np.bincount(batch_codes, weights=risk_y)
+    batch_mean_estimates = batch_sums / batch_n
+    batch_squared_sums = np.bincount(batch_codes, weights=risk_y**2)
+    batch_variances = np.maximum(batch_squared_sums - batch_n * batch_mean_estimates**2, 0.0) / (batch_n - 1)
+    batch_std_estimates = np.sqrt(batch_variances / batch_n)
+    return batch_mean_estimates, batch_std_estimates

--- a/glide/monitors/classical_core.py
+++ b/glide/monitors/classical_core.py
@@ -84,11 +84,12 @@ def _preprocess(
 def _compute_batch_estimates(
     risk_y: NDArray,
     batch_codes: NDArray,
-    batch_n: NDArray,
 ) -> Tuple[NDArray, NDArray]:
+    batch_n = np.bincount(batch_codes)
     batch_sums = np.bincount(batch_codes, weights=risk_y)
     batch_mean_estimates = batch_sums / batch_n
-    batch_squared_sums = np.bincount(batch_codes, weights=risk_y**2)
-    batch_variances = np.maximum(batch_squared_sums - batch_n * batch_mean_estimates**2, 0.0) / (batch_n - 1)
+    batch_deviations = risk_y - batch_mean_estimates[batch_codes]
+    batch_sum_squared_deviations = np.bincount(batch_codes, weights=batch_deviations**2)
+    batch_variances = batch_sum_squared_deviations / (batch_n - 1)
     batch_std_estimates = np.sqrt(batch_variances / batch_n)
     return batch_mean_estimates, batch_std_estimates

--- a/glide/monitors/classical_core.py
+++ b/glide/monitors/classical_core.py
@@ -3,7 +3,13 @@ from typing import Tuple
 import numpy as np
 from numpy.typing import NDArray
 
-from glide.core.validation import _validate_bounds, _validate_equal_lengths, _validate_has_no_nan, _validate_non_empty
+from glide.core.validation import (
+    _validate_bounds,
+    _validate_equal_lengths,
+    _validate_has_no_nan,
+    _validate_min_samples,
+    _validate_non_empty,
+)
 from glide.monitors.core import _scale_to_unit_risk, _unique_ordered_batches
 
 
@@ -44,6 +50,8 @@ def _preprocess(
     )
     labeled_mask = ~np.isnan(y)
     labeled_values = y[labeled_mask]
+    _validate_min_samples(labeled_values, "y")
+
     _validate_bounds(
         labeled_values,
         "y",
@@ -76,8 +84,8 @@ def _preprocess(
 def _compute_batch_estimates(
     risk_y: NDArray,
     batch_codes: NDArray,
+    batch_n: NDArray,
 ) -> Tuple[NDArray, NDArray]:
-    batch_n = np.bincount(batch_codes)
     batch_sums = np.bincount(batch_codes, weights=risk_y)
     batch_mean_estimates = batch_sums / batch_n
     batch_squared_sums = np.bincount(batch_codes, weights=risk_y**2)

--- a/glide/monitors/empirical_classical.py
+++ b/glide/monitors/empirical_classical.py
@@ -133,7 +133,7 @@ class EmpiricalClassicalMeanMonitor:
         risk_y, risk_threshold, batch_codes, batch_n = _preprocess(
             y, batches, higher_is_better, threshold, confidence_level, metric_lower_bound, metric_upper_bound
         )
-        risk_batch_mean_estimates, _ = _compute_batch_estimates(risk_y, batch_codes)
+        risk_batch_mean_estimates, _ = _compute_batch_estimates(risk_y, batch_codes, batch_n)
 
         miscoverage = 1.0 - confidence_level
         risk_running_means, risk_confidence_bounds = _compute_empirical_bernstein_bounds(

--- a/glide/monitors/empirical_classical.py
+++ b/glide/monitors/empirical_classical.py
@@ -133,7 +133,7 @@ class EmpiricalClassicalMeanMonitor:
         risk_y, risk_threshold, batch_codes, batch_n = _preprocess(
             y, batches, higher_is_better, threshold, confidence_level, metric_lower_bound, metric_upper_bound
         )
-        risk_batch_mean_estimates, _ = _compute_batch_estimates(risk_y, batch_codes, batch_n)
+        risk_batch_mean_estimates, _ = _compute_batch_estimates(risk_y, batch_codes)
 
         miscoverage = 1.0 - confidence_level
         risk_running_means, risk_confidence_bounds = _compute_empirical_bernstein_bounds(

--- a/tests/functional/monitors/test_asymptotic_classical.py
+++ b/tests/functional/monitors/test_asymptotic_classical.py
@@ -1,0 +1,63 @@
+"""Functional tests for AsymptoticClassicalMeanMonitor.
+
+These tests verify end-to-end statistical properties rather than implementation
+details, and therefore require larger datasets to hold reliably.
+"""
+
+import numpy as np
+import pytest
+
+from glide.estimators import ClassicalMeanEstimator
+from glide.monitors import AsymptoticClassicalMeanMonitor
+from glide.simulators import generate_binary_dataset
+
+# ── fixtures ───────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def y():
+    y_true, _ = generate_binary_dataset(n_total=20, true_mean=0.5, random_seed=0)
+    return y_true
+
+
+@pytest.fixture
+def batches():
+    return np.repeat(np.arange(5), 4)
+
+
+# ── tests ──────────────────────────────────────────────────────────────────────
+
+
+def test_detect_batch_mean_estimates_match_classical_estimator(y, batches):
+    """Each batch estimate equals the classical estimator computed on that batch alone."""
+    result = AsymptoticClassicalMeanMonitor().detect(y, batches, higher_is_better=False, threshold=0.5)
+    n_batches = len(np.unique(batches))
+    estimator_means = np.zeros(n_batches)
+    for batch_id in range(n_batches):
+        batch_mask = batches == batch_id
+        estimator_result = ClassicalMeanEstimator().estimate(y[batch_mask])
+        estimator_means[batch_id] = estimator_result.mean
+
+    np.testing.assert_allclose(result.batch_mean_estimates, estimator_means)
+
+
+def test_detect_prefix_consistency(y, batches):
+    """Detecting on a growing history is prefix-consistent with detecting on the full history."""
+    monitor = AsymptoticClassicalMeanMonitor()
+    full = monitor.detect(y, batches, higher_is_better=False, threshold=0.5, tightest_at_batch=2)
+    prefix_mask = batches <= 2
+    prefix = monitor.detect(
+        y[prefix_mask], batches[prefix_mask], higher_is_better=False, threshold=0.5, tightest_at_batch=2
+    )
+
+    np.testing.assert_allclose(prefix.running_means, full.running_means[:3])
+    np.testing.assert_allclose(prefix.confidence_bounds, full.confidence_bounds[:3])
+
+
+def test_detect_higher_is_better_symmetry(y, batches):
+    """Monitoring a performance is the mirror image of monitoring its complement as a risk."""
+    risk = AsymptoticClassicalMeanMonitor().detect(y, batches, higher_is_better=False, threshold=0.3)
+    performance = AsymptoticClassicalMeanMonitor().detect(1.0 - y, batches, higher_is_better=True, threshold=0.7)
+
+    np.testing.assert_array_equal(performance.alarms, risk.alarms)
+    np.testing.assert_allclose(performance.confidence_bounds, 1.0 - risk.confidence_bounds)

--- a/tests/unit/monitors/test_asymptotic_classical.py
+++ b/tests/unit/monitors/test_asymptotic_classical.py
@@ -81,8 +81,3 @@ def test_detect_custom_confidence_level(monitor, y, batches):
     assert result.confidence_level == 0.85
     np.testing.assert_allclose(result.running_means, expected_running_means, atol=0.001)
     np.testing.assert_allclose(result.confidence_bounds, expected_confidence_bounds, atol=0.001)
-
-
-def test_detect_invalid_confidence_level(monitor, y, batches):
-    with pytest.raises(ValueError, match=r"'confidence_level' must be in \(0.5, 1\) for the asymptotic monitor"):
-        monitor.detect(y, batches, higher_is_better=False, threshold=0.5, confidence_level=0.5)

--- a/tests/unit/monitors/test_asymptotic_classical.py
+++ b/tests/unit/monitors/test_asymptotic_classical.py
@@ -1,0 +1,88 @@
+from unittest.mock import patch
+
+import numpy as np
+import pytest
+
+import glide.monitors.asymptotic_classical as asymptotic_classical_module
+from glide.confidence_sequences import AsymptoticConfidenceSequence
+from glide.mean_monitoring_results import ClassicalMeanMonitoringResult
+from glide.monitors import AsymptoticClassicalMeanMonitor
+
+
+@pytest.fixture
+def y():
+    return np.array([0.49, 0.51, 0.5, 0.54])
+
+
+@pytest.fixture
+def batches():
+    return np.array([0, 0, 1, 1])
+
+
+@pytest.fixture
+def monitor():
+    return AsymptoticClassicalMeanMonitor()
+
+
+# --- detect ---
+
+
+def test_detect_delegates_to_validation(monitor, y, batches):
+    with patch.object(asymptotic_classical_module, "_validate_bounds") as mock_validate_bounds:
+        monitor.detect(y, batches, higher_is_better=False, threshold=0.5)
+
+        mock_validate_bounds.assert_called_once_with(
+            0.8,
+            "confidence_level",
+            lower=0.5,
+            upper=1,
+            left_inclusive=False,
+            right_inclusive=False,
+            error_message="'confidence_level' must be in (0.5, 1) for the asymptotic monitor; got 0.8.",
+        )
+
+
+def test_detect_is_valid_monitoring_result(monitor, y, batches):
+    result = monitor.detect(
+        y,
+        batches,
+        higher_is_better=False,
+        threshold=0.5,
+    )
+
+    assert isinstance(result, ClassicalMeanMonitoringResult)
+    assert isinstance(result.confidence_sequence, AsymptoticConfidenceSequence)
+    assert result.monitor_name == "AsymptoticClassicalMeanMonitor"
+    assert np.isfinite(result.running_means).all()
+    assert (result.running_means >= result.confidence_bounds).all()
+
+
+def test_detect_metadata(monitor, y, batches):
+    result = monitor.detect(
+        y, batches, higher_is_better=True, threshold=0.5, metric_name="accuracy", confidence_level=0.85
+    )
+
+    assert result.metric_name == "accuracy"
+    assert result.monitor_name == "AsymptoticClassicalMeanMonitor"
+    assert result.higher_is_better is True
+    assert result.alarm_threshold == 0.5
+    assert result.confidence_level == 0.85
+    np.testing.assert_array_equal(result.batch_n, np.array([2, 2]))
+
+
+def test_detect_custom_confidence_level(monitor, y, batches):
+    expected_running_means = np.array([0.5, 0.51])
+    expected_confidence_bounds = np.array([0.472, 0.484])
+
+    result = monitor.detect(
+        y, batches, higher_is_better=False, threshold=0.5, metric_name="perf", confidence_level=0.85
+    )
+
+    assert result.confidence_level == 0.85
+    np.testing.assert_allclose(result.running_means, expected_running_means, atol=0.001)
+    np.testing.assert_allclose(result.confidence_bounds, expected_confidence_bounds, atol=0.001)
+
+
+def test_detect_invalid_confidence_level(monitor, y, batches):
+    with pytest.raises(ValueError, match=r"'confidence_level' must be in \(0.5, 1\) for the asymptotic monitor"):
+        monitor.detect(y, batches, higher_is_better=False, threshold=0.5, confidence_level=0.5)

--- a/tests/unit/monitors/test_classical_core.py
+++ b/tests/unit/monitors/test_classical_core.py
@@ -17,6 +17,11 @@ def batches():
     return np.array([0, 0, 1, 1])
 
 
+@pytest.fixture
+def batch_n():
+    return np.array([2, 2])
+
+
 # --- _preprocess ---
 
 
@@ -25,6 +30,7 @@ def test_preprocess_delegates_to_validation(y, batches):
         patch.object(classical_core_module, "_validate_equal_lengths") as mock_validate_equal_lengths,
         patch.object(classical_core_module, "_validate_non_empty") as mock_validate_non_empty,
         patch.object(classical_core_module, "_validate_has_no_nan") as mock_validate_has_no_nan,
+        patch.object(classical_core_module, "_validate_min_samples") as mock_validate_min_samples,
         patch.object(classical_core_module, "_validate_bounds") as mock_validate_bounds,
         patch.object(classical_core_module, "_unique_ordered_batches") as mock_unique_ordered_batches,
     ):
@@ -51,6 +57,10 @@ def test_preprocess_delegates_to_validation(y, batches):
         mock_validate_has_no_nan.assert_called_once()
         np.testing.assert_array_equal(mock_validate_has_no_nan.call_args[0][0], batches)
         assert mock_validate_has_no_nan.call_args[0][1] == "batches"
+
+        mock_validate_min_samples.assert_called_once()
+        np.testing.assert_array_equal(mock_validate_min_samples.call_args[0][0], y)
+        assert mock_validate_min_samples.call_args[0][1] == "y"
 
         assert mock_validate_bounds.call_count == 5
 
@@ -113,11 +123,11 @@ def test_preprocess_known_output(y, batches):
 # --- _compute_batch_estimates ---
 
 
-def test_compute_batch_estimates(y, batches):
+def test_compute_batch_estimates(y, batches, batch_n):
     expected_batch_mean_estimates = np.array([0.5, 0.52])
     expected_batch_std_estimates = np.array([0.01, 0.02])
 
-    batch_mean_estimates, batch_std_estimates = _compute_batch_estimates(y, batches)
+    batch_mean_estimates, batch_std_estimates = _compute_batch_estimates(y, batches, batch_n)
 
     np.testing.assert_allclose(batch_mean_estimates, expected_batch_mean_estimates)
     np.testing.assert_allclose(batch_std_estimates, expected_batch_std_estimates, atol=1e-10)

--- a/tests/unit/monitors/test_classical_core.py
+++ b/tests/unit/monitors/test_classical_core.py
@@ -1,0 +1,123 @@
+from unittest.mock import patch
+
+import numpy as np
+import pytest
+
+import glide.monitors.classical_core as classical_core_module
+from glide.monitors.classical_core import _compute_batch_estimates, _preprocess
+
+
+@pytest.fixture
+def y():
+    return np.array([0.49, 0.51, 0.5, 0.54])
+
+
+@pytest.fixture
+def batches():
+    return np.array([0, 0, 1, 1])
+
+
+# --- _preprocess ---
+
+
+def test_preprocess_delegates_to_validation(y, batches):
+    with (
+        patch.object(classical_core_module, "_validate_equal_lengths") as mock_validate_equal_lengths,
+        patch.object(classical_core_module, "_validate_non_empty") as mock_validate_non_empty,
+        patch.object(classical_core_module, "_validate_has_no_nan") as mock_validate_has_no_nan,
+        patch.object(classical_core_module, "_validate_bounds") as mock_validate_bounds,
+        patch.object(classical_core_module, "_unique_ordered_batches") as mock_unique_ordered_batches,
+    ):
+        mock_unique_ordered_batches.return_value = (np.array([0, 1]), np.array([0, 0, 1, 1]))
+        _preprocess(
+            y,
+            batches,
+            higher_is_better=False,
+            threshold=0.5,
+            confidence_level=0.8,
+            metric_lower_bound=0.0,
+            metric_upper_bound=1.0,
+        )
+
+        mock_validate_non_empty.assert_called_once()
+        np.testing.assert_array_equal(mock_validate_non_empty.call_args[0][0], y)
+        assert mock_validate_non_empty.call_args[0][1] == "y"
+
+        mock_validate_equal_lengths.assert_called_once()
+        np.testing.assert_array_equal(mock_validate_equal_lengths.call_args[0][0], y)
+        np.testing.assert_array_equal(mock_validate_equal_lengths.call_args[0][1], batches)
+        assert mock_validate_equal_lengths.call_args[1] == {"names": ["y", "batches"]}
+
+        mock_validate_has_no_nan.assert_called_once()
+        np.testing.assert_array_equal(mock_validate_has_no_nan.call_args[0][0], batches)
+        assert mock_validate_has_no_nan.call_args[0][1] == "batches"
+
+        assert mock_validate_bounds.call_count == 5
+
+        assert mock_validate_bounds.call_args_list[0][0] == (0.8, "confidence_level")
+        assert mock_validate_bounds.call_args_list[0][1] == {
+            "lower": 0,
+            "upper": 1,
+            "left_inclusive": False,
+            "right_inclusive": False,
+        }
+
+        assert mock_validate_bounds.call_args_list[1][0] == (0.0, "metric_lower_bound")
+        assert mock_validate_bounds.call_args_list[1][1]["upper"] == 1.0
+        assert mock_validate_bounds.call_args_list[1][1]["right_inclusive"] is False
+        assert (
+            "'metric_lower_bound' must be strictly smaller than 'metric_upper_bound'"
+            in mock_validate_bounds.call_args_list[1][1]["error_message"]
+        )
+
+        assert mock_validate_bounds.call_args_list[2][0] == (0.5, "threshold")
+        assert mock_validate_bounds.call_args_list[2][1]["lower"] == 0.0
+        assert mock_validate_bounds.call_args_list[2][1]["upper"] == 1.0
+        assert "'threshold' must lie between" in mock_validate_bounds.call_args_list[2][1]["error_message"]
+
+        mock_unique_ordered_batches.assert_called_once()
+        np.testing.assert_array_equal(mock_unique_ordered_batches.call_args[0][0], batches)
+
+        np.testing.assert_array_equal(mock_validate_bounds.call_args_list[3][0][0], y)
+        assert mock_validate_bounds.call_args_list[3][0][1] == "y"
+        assert mock_validate_bounds.call_args_list[3][1]["lower"] == 0.0
+        assert mock_validate_bounds.call_args_list[3][1]["upper"] == 1.0
+        assert "'y' values must lie between" in mock_validate_bounds.call_args_list[3][1]["error_message"]
+
+        assert mock_validate_bounds.call_args_list[4][0][0] == 2
+        assert mock_validate_bounds.call_args_list[4][0][1] == "y"
+        assert mock_validate_bounds.call_args_list[4][1]["lower"] == 2
+        assert (
+            "'y' must have at least 2 non-NaN values per batch"
+            in mock_validate_bounds.call_args_list[4][1]["error_message"]
+        )
+
+
+def test_preprocess_known_output(y, batches):
+    risk_y, risk_threshold, batch_codes, batch_n = _preprocess(
+        y,
+        batches,
+        higher_is_better=False,
+        threshold=0.5,
+        confidence_level=0.8,
+        metric_lower_bound=0.0,
+        metric_upper_bound=1.0,
+    )
+
+    np.testing.assert_allclose(risk_y, y)
+    assert risk_threshold == pytest.approx(0.5)
+    np.testing.assert_array_equal(batch_codes, np.array([0, 0, 1, 1]))
+    np.testing.assert_array_equal(batch_n, np.array([2, 2]))
+
+
+# --- _compute_batch_estimates ---
+
+
+def test_compute_batch_estimates(y, batches):
+    expected_batch_mean_estimates = np.array([0.5, 0.52])
+    expected_batch_std_estimates = np.array([0.01, 0.02])
+
+    batch_mean_estimates, batch_std_estimates = _compute_batch_estimates(y, batches)
+
+    np.testing.assert_allclose(batch_mean_estimates, expected_batch_mean_estimates)
+    np.testing.assert_allclose(batch_std_estimates, expected_batch_std_estimates, atol=1e-10)

--- a/tests/unit/monitors/test_classical_core.py
+++ b/tests/unit/monitors/test_classical_core.py
@@ -17,11 +17,6 @@ def batches():
     return np.array([0, 0, 1, 1])
 
 
-@pytest.fixture
-def batch_n():
-    return np.array([2, 2])
-
-
 # --- _preprocess ---
 
 
@@ -123,11 +118,11 @@ def test_preprocess_known_output(y, batches):
 # --- _compute_batch_estimates ---
 
 
-def test_compute_batch_estimates(y, batches, batch_n):
+def test_compute_batch_estimates(y, batches):
     expected_batch_mean_estimates = np.array([0.5, 0.52])
     expected_batch_std_estimates = np.array([0.01, 0.02])
 
-    batch_mean_estimates, batch_std_estimates = _compute_batch_estimates(y, batches, batch_n)
+    batch_mean_estimates, batch_std_estimates = _compute_batch_estimates(y, batches)
 
     np.testing.assert_allclose(batch_mean_estimates, expected_batch_mean_estimates)
     np.testing.assert_allclose(batch_std_estimates, expected_batch_std_estimates, atol=1e-10)

--- a/tests/unit/monitors/test_empirical_classical.py
+++ b/tests/unit/monitors/test_empirical_classical.py
@@ -1,9 +1,6 @@
-from unittest.mock import patch
-
 import numpy as np
 import pytest
 
-import glide.monitors.empirical_classical as empirical_classical_module
 from glide.confidence_sequences import EmpiricalBernsteinConfidenceSequence
 from glide.mean_monitoring_results import ClassicalMeanMonitoringResult
 from glide.monitors import EmpiricalClassicalMeanMonitor
@@ -22,99 +19,6 @@ def batches():
 @pytest.fixture
 def monitor():
     return EmpiricalClassicalMeanMonitor()
-
-
-# --- _preprocess ---
-
-
-def test_preprocess_delegates_to_validation(monitor, y, batches):
-    with (
-        patch.object(empirical_classical_module, "_validate_equal_lengths") as mock_validate_equal_lengths,
-        patch.object(empirical_classical_module, "_validate_non_empty") as mock_validate_non_empty,
-        patch.object(empirical_classical_module, "_validate_has_no_nan") as mock_validate_has_no_nan,
-        patch.object(empirical_classical_module, "_validate_bounds") as mock_validate_bounds,
-        patch.object(empirical_classical_module, "_unique_ordered_batches") as mock_unique_ordered_batches,
-    ):
-        mock_unique_ordered_batches.return_value = (np.array([0, 1]), np.array([0, 0, 1, 1]))
-        monitor._preprocess(
-            y,
-            batches,
-            higher_is_better=False,
-            threshold=0.5,
-            confidence_level=0.8,
-            metric_lower_bound=0.0,
-            metric_upper_bound=1.0,
-        )
-
-        mock_validate_non_empty.assert_called_once()
-        np.testing.assert_array_equal(mock_validate_non_empty.call_args[0][0], y)
-        assert mock_validate_non_empty.call_args[0][1] == "y"
-
-        mock_validate_equal_lengths.assert_called_once()
-        np.testing.assert_array_equal(mock_validate_equal_lengths.call_args[0][0], y)
-        np.testing.assert_array_equal(mock_validate_equal_lengths.call_args[0][1], batches)
-        assert mock_validate_equal_lengths.call_args[1] == {"names": ["y", "batches"]}
-
-        mock_validate_has_no_nan.assert_called_once()
-        np.testing.assert_array_equal(mock_validate_has_no_nan.call_args[0][0], batches)
-        assert mock_validate_has_no_nan.call_args[0][1] == "batches"
-
-        assert mock_validate_bounds.call_count == 5
-
-        assert mock_validate_bounds.call_args_list[0][0] == (0.8, "confidence_level")
-        assert mock_validate_bounds.call_args_list[0][1] == {
-            "lower": 0,
-            "upper": 1,
-            "left_inclusive": False,
-            "right_inclusive": False,
-        }
-
-        assert mock_validate_bounds.call_args_list[1][0] == (0.0, "metric_lower_bound")
-        assert mock_validate_bounds.call_args_list[1][1]["upper"] == 1.0
-        assert mock_validate_bounds.call_args_list[1][1]["right_inclusive"] is False
-        assert (
-            "'metric_lower_bound' must be strictly smaller than 'metric_upper_bound'"
-            in mock_validate_bounds.call_args_list[1][1]["error_message"]
-        )
-
-        assert mock_validate_bounds.call_args_list[2][0] == (0.5, "threshold")
-        assert mock_validate_bounds.call_args_list[2][1]["lower"] == 0.0
-        assert mock_validate_bounds.call_args_list[2][1]["upper"] == 1.0
-        assert "'threshold' must lie between" in mock_validate_bounds.call_args_list[2][1]["error_message"]
-
-        mock_unique_ordered_batches.assert_called_once()
-        np.testing.assert_array_equal(mock_unique_ordered_batches.call_args[0][0], batches)
-
-        np.testing.assert_array_equal(mock_validate_bounds.call_args_list[3][0][0], y)
-        assert mock_validate_bounds.call_args_list[3][0][1] == "y"
-        assert mock_validate_bounds.call_args_list[3][1]["lower"] == 0.0
-        assert mock_validate_bounds.call_args_list[3][1]["upper"] == 1.0
-        assert "'y' values must lie between" in mock_validate_bounds.call_args_list[3][1]["error_message"]
-
-        assert mock_validate_bounds.call_args_list[4][0][0] == 2
-        assert mock_validate_bounds.call_args_list[4][0][1] == "y"
-        assert mock_validate_bounds.call_args_list[4][1]["lower"] == 2
-        assert (
-            "'y' must have at least 2 non-NaN values per batch"
-            in mock_validate_bounds.call_args_list[4][1]["error_message"]
-        )
-
-
-def test_preprocess_known_output(monitor, y, batches):
-    risk_y, risk_threshold, batch_codes, batch_n = monitor._preprocess(
-        y,
-        batches,
-        higher_is_better=False,
-        threshold=0.5,
-        confidence_level=0.8,
-        metric_lower_bound=0.0,
-        metric_upper_bound=1.0,
-    )
-
-    np.testing.assert_allclose(risk_y, y)
-    assert risk_threshold == pytest.approx(0.5)
-    np.testing.assert_array_equal(batch_codes, np.array([0, 0, 1, 1]))
-    np.testing.assert_array_equal(batch_n, np.array([2, 2]))
 
 
 # --- detect ---


### PR DESCRIPTION

### Description

- Adds `AsymptoticClassicalMeanMonitor`, a label-only drift monitor built on `AsymptoticConfidenceSequence`, using the batch estimates' standard errors instead of the empirical-Bernstein bound used by `EmpiricalClassicalMeanMonitor`.
- Factors out the internals shared between `EmpiricalClassicalMeanMonitor` and the new monitor into `glide/monitors/classical_core.py`.
- Handles this [ticket](https://github.com/orgs/EmertonData/projects/26/views/2?pane=issue&itemId=214000585&issue=EmertonData%7Cglide%7C349) Closes #349

Any noteworthy implementation decisions or trade-offs?
- The asymptotic monitor doesn't actually need the metric lower/upper bounds, which are used elsewhere to scale and unscale the data, since there's no boundedness assumption behind the asymptotic method. The bound-handling code was factorized with the pre-existing `EmpiricalClassicalMeanMonitor` though. This doesn't invalidate the asymptotic monitor's behavior, but it does force users to supply valid lower/upper bounds on their data even though the asymptotic method doesn't strictly need them. Surgically restricting the bound checks/normalization to only the monitors that need them would make the code messy, so that's left to a possible future refactor.

### Checklist

Quality gates that must be satisfied before requesting a review:

- [x] I have read `CONTRIBUTING.md`
- [x] `make lint` passes
- [x] `make type-check` passes
- [x] `make tests` passes
- [x] `make coverage` reports 100% coverage
- [x] `make test-notebooks` passes
- [x] New public API has numpy-style docstrings
- [x] New public API is inserted in the API reference section of the documentation
- [x] Docs build without warnings (`make doc`)
- [x] `CHANGELOG.md` updated if the change is user-facing

### LLM usage

Disclose if an LLM was used in writing this PR:
- [ ] No LLM used
- [x] I used an LLM and I went through and validated all the code myself