### PR TITLE
Add AsymptoticPPIMeanMonitor

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -146,6 +146,7 @@ Only add a comment when the *why* is non-obvious: a hidden constraint, a subtle 
 - Update `CHANGELOG.md` for any user-facing changes (Keep a Changelog format, SemVer)
 - Always add elements to the "Added" or "Changed" sections of `CHANGELOG.md` at the top of the existing list
 - Keep the `CHANGELOG.md` user-friendly and concise
+- Whenever a new public estimator, sampler, or monitor class is added, update the "Implemented Algorithms" table in `README.md` in the same PR, but only for classes implementing a published method, e.g. PPI (`estimators.PPIMeanEstimator`) or PPRM (`monitors.EmpiricalPPIMeanMonitor`) get an entry, a classical baseline (e.g. `estimators.ClassicalMeanEstimator`) does not. Add a row to the table and append any newly cited papers to the numbered References list, reusing existing reference numbers if applicable. A row's reference numbers should correspond to the papers cited in that class's own docstring.
 - Avoid using and escaping underscores in math mode in jupyter notebooks.
 - Avoid making excessive use of dashes like this — when writing documentation and notebooks. Prefer commas, colons and parentheses where possible.
 - In documentation and tutorials, always spell out "confidence interval" instead of using "CI", which is easily confused with "continuous integration".

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ## [Next release]
 
 ### ✨ Added
+- `AsymptoticPPIMeanMonitor`, a prediction-powered drift monitor built on `AsymptoticConfidenceSequence` and using the batch estimates' standard errors.
 - `AsymptoticClassicalMeanMonitor`, a label-only drift monitor built on `AsymptoticConfidenceSequence` and using the batch estimates' standard errors.
 - `AsymptoticConfidenceSequence`, an anytime-valid confidence sequence whose width scales with the known standard errors of per-batch estimates.
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,8 @@ If you use GLIDE in your work, please cite us using the "Cite this repository" b
 | Stratified Predict-Then-Debias | `estimators.StratifiedPTDMeanEstimator` | [[7]](#ref-7) | [Link](https://github.com/DanKluger/PTDBoot) |
 | Clustered Predict-Then-Debias | `estimators.ClusteredPTDMeanEstimator` | [[7]](#ref-7) | [Link](https://github.com/DanKluger/PTDBoot) |
 | IPW Predict-Then-Debias | `estimators.IPWPTDMeanEstimator` | [[7]](#ref-7) | [Link](https://github.com/DanKluger/PTDBoot) |
-| Prediction-Powered Risk Monitoring (PPRM) | `monitors.EmpiricalPPIMeanMonitor` | [[9]](#ref-9), [[10]](#ref-10) | — |
+| Prediction-Powered Risk Monitoring (PPRM) | `monitors.EmpiricalPPIMeanMonitor` | [[9]](#ref-9), [[10]](#ref-10), [[11]](#ref-11) | — |
+| Asymptotic Prediction-Powered Risk Monitoring | `monitors.AsymptoticPPIMeanMonitor` | [[9]](#ref-9), [[12]](#ref-12) | — |
 
 ### 📖 References
 
@@ -111,6 +112,10 @@ If you use GLIDE in your work, please cite us using the "Cite this repository" b
 <a id="ref-9"></a>[9] <a href="https://arxiv.org/abs/2602.02229">Zhang, Guangyi, Yunlong Cai, Guanding Yu, and Osvaldo Simeone. "Prediction-Powered Risk Monitoring of Deployed Models for Detecting Harmful Distribution Shifts." arXiv preprint arXiv:2602.02229 (2026).</a>
 
 <a id="ref-10"></a>[10] <a href="https://arxiv.org/abs/2110.06177">Podkopaev, Aleksandr, and Aaditya Ramdas. "Tracking the risk of a deployed model and detecting harmful distribution shifts." International Conference on Learning Representations (ICLR), 2022.</a>
+
+<a id="ref-11"></a>[11] <a href="https://doi.org/10.1093/jrsssb/qkad009">Waudby-Smith, Ian, and Aaditya Ramdas. "Estimating means of bounded random variables by betting." Journal of the Royal Statistical Society Series B: Statistical Methodology 86, no. 1 (2024): 1-27.</a>
+
+<a id="ref-12"></a>[12] <a href="https://doi.org/10.1214/24-AOS2408">Waudby-Smith, Ian, David Arbour, Ritwik Sinha, Edward H. Kennedy, and Aaditya Ramdas. "Time-uniform central limit theory and asymptotic confidence sequences." The Annals of Statistics 52, no. 6 (2024): 2613-2640.</a>
 
 ## 📬 Stay Updated
 

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -62,6 +62,7 @@
 | Class | Description |
 |-------|-------------|
 | [`EmpiricalPPIMeanMonitor`](monitors.md#glide.monitors.empirical_ppi.EmpiricalPPIMeanMonitor) | Anytime-valid drift monitor combining true and proxy labels |
+| [`AsymptoticPPIMeanMonitor`](monitors.md#glide.monitors.asymptotic_ppi.AsymptoticPPIMeanMonitor) | Anytime-valid drift monitor combining true and proxy labels via an asymptotic confidence sequence |
 
 ## Confidence Intervals
 

--- a/docs/api/monitors.md
+++ b/docs/api/monitors.md
@@ -4,11 +4,11 @@
 
 ---
 
-::: glide.monitors.empirical_ppi.EmpiricalPPIMeanMonitor
+::: glide.monitors.asymptotic_classical.AsymptoticClassicalMeanMonitor
 
 ---
 
-::: glide.monitors.asymptotic_classical.AsymptoticClassicalMeanMonitor
+::: glide.monitors.empirical_ppi.EmpiricalPPIMeanMonitor
 
 ---
 

--- a/docs/api/monitors.md
+++ b/docs/api/monitors.md
@@ -9,3 +9,7 @@
 ---
 
 ::: glide.monitors.asymptotic_classical.AsymptoticClassicalMeanMonitor
+
+---
+
+::: glide.monitors.asymptotic_ppi.AsymptoticPPIMeanMonitor

--- a/glide/monitors/__init__.py
+++ b/glide/monitors/__init__.py
@@ -1,9 +1,11 @@
 from glide.monitors.asymptotic_classical import AsymptoticClassicalMeanMonitor
+from glide.monitors.asymptotic_ppi import AsymptoticPPIMeanMonitor
 from glide.monitors.empirical_classical import EmpiricalClassicalMeanMonitor
 from glide.monitors.empirical_ppi import EmpiricalPPIMeanMonitor
 
 __all__ = [
     "AsymptoticClassicalMeanMonitor",
+    "AsymptoticPPIMeanMonitor",
     "EmpiricalClassicalMeanMonitor",
     "EmpiricalPPIMeanMonitor",
 ]

--- a/glide/monitors/asymptotic_classical.py
+++ b/glide/monitors/asymptotic_classical.py
@@ -32,8 +32,8 @@ class AsymptoticClassicalMeanMonitor:
     >>> from glide.monitors import AsymptoticClassicalMeanMonitor
     >>> pre_drift_batch = np.array([0.0, 0.2, np.nan, np.nan])
     >>> post_drift_batch = np.array([0.8, 1.0, np.nan, np.nan])
-    >>> y = np.hstack([pre_drift_batch, np.tile(post_drift_batch, 50)])
-    >>> batches = np.repeat(np.arange(51), 4)
+    >>> y = np.hstack([pre_drift_batch, np.tile(post_drift_batch, 5)])
+    >>> batches = np.repeat(np.arange(6), 4)
     >>> monitor = AsymptoticClassicalMeanMonitor()
     >>> result = monitor.detect(y, batches, higher_is_better=False, threshold=0.5)
     >>> result.drift_detected

--- a/glide/monitors/asymptotic_ppi.py
+++ b/glide/monitors/asymptotic_ppi.py
@@ -9,7 +9,7 @@ from glide.monitors.ppi_core import _compute_batch_estimates, _preprocess
 
 
 class AsymptoticPPIMeanMonitor:
-    """Anytime-valid drift monitor leveraging the error bar of each batch estimate.
+    """Anytime-valid drift monitor leveraging the variance of each batch estimate.
 
     It computes a per-batch Prediction-Powered Inference (PPI) estimate: a small set
     of true labels and a large set of proxy labels, combined with a power-tuning
@@ -40,9 +40,9 @@ class AsymptoticPPIMeanMonitor:
     >>> pre_drift_y_proxy = np.array([0.0, 0.2, 0.0, 0.2])
     >>> post_drift_y_true = np.array([0.8, 1.0, np.nan, np.nan])
     >>> post_drift_y_proxy = np.array([0.8, 1.0, 0.8, 1.0])
-    >>> y_true = np.hstack([pre_drift_y_true, np.tile(post_drift_y_true, 50)])
-    >>> y_proxy = np.hstack([pre_drift_y_proxy, np.tile(post_drift_y_proxy, 50)])
-    >>> batches = np.repeat(np.arange(51), 4)
+    >>> y_true = np.hstack([pre_drift_y_true, np.tile(post_drift_y_true, 5)])
+    >>> y_proxy = np.hstack([pre_drift_y_proxy, np.tile(post_drift_y_proxy, 5)])
+    >>> batches = np.repeat(np.arange(6), 4)
     >>> monitor = AsymptoticPPIMeanMonitor()
     >>> result = monitor.detect(y_true, y_proxy, batches, higher_is_better=False, threshold=0.5)
     >>> result.drift_detected

--- a/glide/monitors/asymptotic_ppi.py
+++ b/glide/monitors/asymptotic_ppi.py
@@ -1,40 +1,41 @@
-import numpy as np
 from numpy.typing import NDArray
 
-from glide.confidence_sequences import EmpiricalBernsteinConfidenceSequence
-from glide.confidence_sequences.empirical_bernstein import _compute_empirical_bernstein_bounds
+from glide.confidence_sequences import AsymptoticConfidenceSequence
+from glide.confidence_sequences.asymptotic import _compute_asymptotic_bounds
+from glide.core.validation import _validate_bounds
 from glide.mean_monitoring_results import PredictionPoweredMeanMonitoringResult
 from glide.monitors.core import _postprocess
 from glide.monitors.ppi_core import _compute_batch_estimates, _preprocess
 
 
-class EmpiricalPPIMeanMonitor:
-    """Anytime-valid drift monitor over a batched dataset of true and proxy labels.
+class AsymptoticPPIMeanMonitor:
+    """Anytime-valid drift monitor leveraging the error bar of each batch estimate.
 
-    It uses a per-batch Prediction-Powered Inference (PPI) estimate: a small set of
-    true labels and a large set of proxy labels, combined with a power-tuning
+    It computes a per-batch Prediction-Powered Inference (PPI) estimate: a small set
+    of true labels and a large set of proxy labels, combined with a power-tuning
     parameter fitted on the batches that strictly precede it (predictable, as
-    required for validity). The monitor builds an anytime-valid confidence sequence
-    on the running mean of the per-batch PPI estimates, and raises a drift alarm
-    when it crosses a user-supplied ``threshold`` (the worst tolerable metric
-    value). Because the bounds are valid at all times simultaneously, :meth:`detect`
-    may be called after every new batch without inflating the false-alarm
-    probability.
+    required for validity), together with the standard error of that estimate. The
+    monitor tracks the running mean of the per-batch estimates against a
+    user-supplied ``threshold``, through a Gaussian-mixture asymptotic confidence
+    sequence whose width scales with the standard error of each batch estimate, so
+    genuine drifts get flagged early. The false-alarm guarantee is asymptotic: each
+    batch needs enough labeled and proxy samples for its PPI estimate to be
+    approximately Gaussian with a consistently estimated variance.
 
     References
     ----------
+    Waudby-Smith, Ian, David Arbour, Ritwik Sinha, Edward H. Kennedy, and Aaditya
+    Ramdas. "Time-uniform central limit theory and asymptotic confidence
+    sequences." The Annals of Statistics 52, no. 6 (2024): 2613-2640.
+
     Zhang, Guangyi, Yunlong Cai, Guanding Yu, and Osvaldo Simeone. "Prediction-powered
     risk monitoring of deployed models for detecting harmful distribution shifts."
     arXiv preprint arXiv:2602.02229 (2026).
 
-    Howard, Steven R., Aaditya Ramdas, Jon McAuliffe, and Jasjeet Sekhon. "Time-uniform,
-    nonparametric, nonasymptotic confidence sequences." The Annals of Statistics 49,
-    no. 2 (2021): 1055-1080.
-
     Examples
     --------
     >>> import numpy as np
-    >>> from glide.monitors import EmpiricalPPIMeanMonitor
+    >>> from glide.monitors import AsymptoticPPIMeanMonitor
     >>> pre_drift_y_true = np.array([0.0, 0.2, np.nan, np.nan])
     >>> pre_drift_y_proxy = np.array([0.0, 0.2, 0.0, 0.2])
     >>> post_drift_y_true = np.array([0.8, 1.0, np.nan, np.nan])
@@ -42,12 +43,12 @@ class EmpiricalPPIMeanMonitor:
     >>> y_true = np.hstack([pre_drift_y_true, np.tile(post_drift_y_true, 50)])
     >>> y_proxy = np.hstack([pre_drift_y_proxy, np.tile(post_drift_y_proxy, 50)])
     >>> batches = np.repeat(np.arange(51), 4)
-    >>> monitor = EmpiricalPPIMeanMonitor()
+    >>> monitor = AsymptoticPPIMeanMonitor()
     >>> result = monitor.detect(y_true, y_proxy, batches, higher_is_better=False, threshold=0.5)
     >>> result.drift_detected
     True
     >>> result.first_alarm_index
-    11
+    2
     """
 
     def detect(
@@ -62,13 +63,14 @@ class EmpiricalPPIMeanMonitor:
         power_tuning: bool = True,
         metric_lower_bound: float = 0.0,
         metric_upper_bound: float = 1.0,
+        tightest_at_batch: int = 10,
     ) -> PredictionPoweredMeanMonitoringResult:
         """Detect a drift of the running mean across a batched dataset.
 
-        Splits the data by batch, computes a prediction-powered estimate per batch,
-        and builds an anytime-valid empirical-Bernstein confidence sequence on the
-        running mean of those estimates. An alarm is raised at every batch where the
-        sequence crosses the user-supplied ``threshold``.
+        Splits the data by batch, computes a prediction-powered estimate and its
+        standard error per batch, and builds an anytime-valid asymptotic confidence
+        sequence on the running mean of those estimates. An alarm is raised at every
+        batch where the sequence crosses the user-supplied ``threshold``.
 
         Rows must be ordered oldest batch first and grouped into contiguous blocks;
         identifier values are not compared, so any label type works. Batches must be
@@ -77,7 +79,10 @@ class EmpiricalPPIMeanMonitor:
         every call makes the anytime-valid guarantee hold jointly over all calls.
         Alternatively the data may be restricted to the most recent batches, in which
         case the guarantee holds within each restriction but not across the moving
-        history as a whole.
+        history as a whole. When the history has fewer batches than ``tightest_at_batch``,
+        the tuning target is set to the last batch. Prefix-consistency only holds between
+        calls using the same ``tightest_at_batch`` value and with histories containing
+        at least ``tightest_at_batch`` batches.
 
         Parameters
         ----------
@@ -108,7 +113,7 @@ class EmpiricalPPIMeanMonitor:
             raises "80% confident" alarms: under no drift it has at most a 20% chance
             of raising a false alarm. Raising this value demands more evidence before
             alarming, so alarms become more trustworthy but arrive later; lowering it
-            detects sooner at the cost of more false alarms.
+            detects sooner at the cost of more false alarms. Must be in ``(0.5, 1)``.
         power_tuning : bool, optional
             If ``True`` (default), compute the power-tuning parameter of each batch on
             all previous batches (the first batch, having no predecessor, uses
@@ -117,6 +122,11 @@ class EmpiricalPPIMeanMonitor:
             Known lower bound of the metric. Defaults to ``0.0``.
         metric_upper_bound : float, optional
             Known upper bound of the metric. Defaults to ``1.0``.
+        tightest_at_batch : int, optional
+            The batch index (1-indexed) at which the confidence sequence is tuned to
+            be tightest. Defaults to ``10``, which is safe to leave alone: this
+            setting affects tightness only, never the false-alarm guarantee, and the
+            width penalty for being off by a factor of 10 is below 10%.
 
         Returns
         -------
@@ -131,16 +141,27 @@ class EmpiricalPPIMeanMonitor:
             - If ``y_true`` is empty.
             - If ``y_true``, ``y_proxy`` and ``batches`` have different lengths.
             - If ``batches`` contains NaN values (numeric dtype) or None values (non-numeric dtype).
-            - If ``confidence_level`` is not in (0, 1).
+            - If ``confidence_level`` is not in ``(0.5, 1)``.
             - If ``metric_lower_bound >= metric_upper_bound``.
             - If ``threshold`` falls outside ``[metric_lower_bound, metric_upper_bound]``.
             - If any proxy value is NaN or all proxy values are identical.
             - If labeled ``y_true`` values are constant.
-            - If any value falls outside ``[metric_lower_bound, metric_upper_bound]``.
             - If batches are interleaved rather than grouped into contiguous blocks.
             - If any batch has fewer than 2 labeled or fewer than 2 unlabeled samples.
             - If proxy values are constant across the prior batches (with ``power_tuning=True``).
+            - If the accumulated variance of the batch estimates up to ``tightest_at_batch`` is zero.
         """
+        _validate_bounds(
+            confidence_level,
+            "confidence_level",
+            lower=0.5,
+            upper=1,
+            left_inclusive=False,
+            right_inclusive=False,
+            error_message=(
+                f"'confidence_level' must be in (0.5, 1) for the asymptotic monitor; got {confidence_level!r}."
+            ),
+        )
         risk_y_true, risk_y_proxy, risk_threshold, batch_codes, batch_n_true, batch_n_proxy = _preprocess(
             y_true,
             y_proxy,
@@ -151,22 +172,22 @@ class EmpiricalPPIMeanMonitor:
             metric_lower_bound,
             metric_upper_bound,
         )
-        risk_batch_estimates, _ = _compute_batch_estimates(risk_y_true, risk_y_proxy, batch_codes, power_tuning)
-        clipped_risk_batch_estimates = np.clip(risk_batch_estimates, 0.0, 1.0)
-
-        miscoverage = 1.0 - confidence_level
-        risk_running_means, risk_lower_bounds = _compute_empirical_bernstein_bounds(
-            clipped_risk_batch_estimates, risk_threshold, miscoverage
+        batch_mean_estimates, batch_std_estimates = _compute_batch_estimates(
+            risk_y_true, risk_y_proxy, batch_codes, power_tuning
         )
-        running_means, confidence_bounds, batch_mean_estimates = _postprocess(
+        miscoverage = 1.0 - confidence_level
+        risk_running_means, risk_lower_bounds = _compute_asymptotic_bounds(
+            batch_mean_estimates, batch_std_estimates, miscoverage, tightest_at_batch
+        )
+        running_means, confidence_bounds, metric_batch_estimates = _postprocess(
             risk_running_means,
             risk_lower_bounds,
-            risk_batch_estimates,
+            batch_mean_estimates,
             higher_is_better,
             metric_lower_bound,
             metric_upper_bound,
         )
-        confidence_sequence = EmpiricalBernsteinConfidenceSequence(
+        confidence_sequence = AsymptoticConfidenceSequence(
             running_mean_estimates=running_means,
             confidence_bounds=confidence_bounds,
         )
@@ -176,7 +197,7 @@ class EmpiricalPPIMeanMonitor:
             higher_is_better=higher_is_better,
             alarm_threshold=threshold,
             confidence_level=confidence_level,
-            batch_mean_estimates=batch_mean_estimates,
+            batch_mean_estimates=metric_batch_estimates,
             confidence_sequence=confidence_sequence,
             batch_n_true=batch_n_true,
             batch_n_proxy=batch_n_proxy,

--- a/glide/monitors/asymptotic_ppi.py
+++ b/glide/monitors/asymptotic_ppi.py
@@ -146,6 +146,7 @@ class AsymptoticPPIMeanMonitor:
             - If ``threshold`` falls outside ``[metric_lower_bound, metric_upper_bound]``.
             - If any proxy value is NaN or all proxy values are identical.
             - If labeled ``y_true`` values are constant.
+            - If any value falls outside ``[metric_lower_bound, metric_upper_bound]``.
             - If batches are interleaved rather than grouped into contiguous blocks.
             - If any batch has fewer than 2 labeled or fewer than 2 unlabeled samples.
             - If proxy values are constant across the prior batches (with ``power_tuning=True``).

--- a/glide/monitors/empirical_classical.py
+++ b/glide/monitors/empirical_classical.py
@@ -40,8 +40,8 @@ class EmpiricalClassicalMeanMonitor:
     >>> from glide.monitors import EmpiricalClassicalMeanMonitor
     >>> pre_drift_batch = np.array([0.0, 0.2, np.nan, np.nan])
     >>> post_drift_batch = np.array([0.8, 1.0, np.nan, np.nan])
-    >>> y = np.hstack([pre_drift_batch, np.tile(post_drift_batch, 50)])
-    >>> batches = np.repeat(np.arange(51), 4)
+    >>> y = np.hstack([pre_drift_batch, np.tile(post_drift_batch, 15)])
+    >>> batches = np.repeat(np.arange(16), 4)
     >>> monitor = EmpiricalClassicalMeanMonitor()
     >>> result = monitor.detect(y, batches, higher_is_better=False, threshold=0.5)
     >>> result.drift_detected

--- a/glide/monitors/empirical_ppi.py
+++ b/glide/monitors/empirical_ppi.py
@@ -39,9 +39,9 @@ class EmpiricalPPIMeanMonitor:
     >>> pre_drift_y_proxy = np.array([0.0, 0.2, 0.0, 0.2])
     >>> post_drift_y_true = np.array([0.8, 1.0, np.nan, np.nan])
     >>> post_drift_y_proxy = np.array([0.8, 1.0, 0.8, 1.0])
-    >>> y_true = np.hstack([pre_drift_y_true, np.tile(post_drift_y_true, 50)])
-    >>> y_proxy = np.hstack([pre_drift_y_proxy, np.tile(post_drift_y_proxy, 50)])
-    >>> batches = np.repeat(np.arange(51), 4)
+    >>> y_true = np.hstack([pre_drift_y_true, np.tile(post_drift_y_true, 15)])
+    >>> y_proxy = np.hstack([pre_drift_y_proxy, np.tile(post_drift_y_proxy, 15)])
+    >>> batches = np.repeat(np.arange(16), 4)
     >>> monitor = EmpiricalPPIMeanMonitor()
     >>> result = monitor.detect(y_true, y_proxy, batches, higher_is_better=False, threshold=0.5)
     >>> result.drift_detected

--- a/glide/monitors/ppi_core.py
+++ b/glide/monitors/ppi_core.py
@@ -1,0 +1,146 @@
+from typing import Tuple
+
+import numpy as np
+from numpy.typing import NDArray
+
+from glide.core.validation import (
+    _validate_bounds,
+    _validate_equal_lengths,
+    _validate_has_no_nan,
+    _validate_non_empty,
+    _validate_y_proxy,
+    _validate_y_true,
+)
+from glide.estimators.core import _split_labeled_unlabeled
+from glide.estimators.ppi_core import _compute_mean_estimate, _compute_std_estimate, _compute_tuning_parameter
+from glide.monitors.core import _scale_to_unit_risk, _unique_ordered_batches
+
+
+def _preprocess(
+    y_true: NDArray,
+    y_proxy: NDArray,
+    batches: NDArray,
+    higher_is_better: bool,
+    threshold: float,
+    confidence_level: float,
+    metric_lower_bound: float,
+    metric_upper_bound: float,
+) -> Tuple[NDArray, NDArray, float, NDArray, NDArray, NDArray]:
+    _validate_non_empty(y_true, "y_true")
+    _validate_equal_lengths(y_true, y_proxy, batches, names=["y_true", "y_proxy", "batches"])
+    _validate_has_no_nan(batches, "batches")
+    _validate_bounds(
+        confidence_level, "confidence_level", lower=0, upper=1, left_inclusive=False, right_inclusive=False
+    )
+    _validate_bounds(
+        metric_lower_bound,
+        "metric_lower_bound",
+        upper=metric_upper_bound,
+        right_inclusive=False,
+        error_message=(
+            f"'metric_lower_bound' must be strictly smaller than 'metric_upper_bound'; "
+            f"got {metric_lower_bound!r} and {metric_upper_bound!r}."
+        ),
+    )
+    _validate_bounds(
+        threshold,
+        "threshold",
+        lower=metric_lower_bound,
+        upper=metric_upper_bound,
+        error_message=(
+            f"'threshold' must lie between 'metric_lower_bound'={metric_lower_bound!r} and "
+            f"'metric_upper_bound'={metric_upper_bound!r}; got {threshold!r}."
+        ),
+    )
+    _validate_y_proxy(y_proxy)
+    _validate_y_true(y_true)
+    labeled_mask = ~np.isnan(y_true)
+    labeled_values = y_true[labeled_mask]
+    _validate_bounds(
+        labeled_values,
+        "y_true",
+        lower=metric_lower_bound,
+        upper=metric_upper_bound,
+        error_message=(
+            f"'y_true' values must lie between 'metric_lower_bound'={metric_lower_bound!r} and "
+            f"'metric_upper_bound'={metric_upper_bound!r}; got values in "
+            f"[{labeled_values.min()!r}, {labeled_values.max()!r}]."
+        ),
+    )
+    _validate_bounds(
+        y_proxy,
+        "y_proxy",
+        lower=metric_lower_bound,
+        upper=metric_upper_bound,
+        error_message=(
+            f"'y_proxy' values must lie between 'metric_lower_bound'={metric_lower_bound!r} and "
+            f"'metric_upper_bound'={metric_upper_bound!r}; got values in "
+            f"[{y_proxy.min()!r}, {y_proxy.max()!r}]."
+        ),
+    )
+    batch_identifiers, batch_codes = _unique_ordered_batches(batches)
+    n_batches = len(batch_identifiers)
+    batch_n_true = np.bincount(batch_codes[labeled_mask], minlength=n_batches)
+    batch_n_proxy = np.bincount(batch_codes, minlength=n_batches)
+    batch_n_unlabeled = batch_n_proxy - batch_n_true
+
+    worst_labeled_position = np.argmin(batch_n_true)
+    _validate_bounds(
+        batch_n_true[worst_labeled_position],
+        "y_true",
+        lower=2,
+        error_message=(
+            f"'y_true' must have at least 2 labeled values per batch; got "
+            f"{batch_n_true[worst_labeled_position]} in batch '{batch_identifiers[worst_labeled_position]}'."
+        ),
+    )
+    worst_unlabeled_position = np.argmin(batch_n_unlabeled)
+    _validate_bounds(
+        batch_n_unlabeled[worst_unlabeled_position],
+        "y_true",
+        lower=2,
+        error_message=(
+            f"'y_true' must have at least 2 unlabeled values per batch; got "
+            f"{batch_n_unlabeled[worst_unlabeled_position]} in batch "
+            f"'{batch_identifiers[worst_unlabeled_position]}'."
+        ),
+    )
+
+    risk_y_true = _scale_to_unit_risk(y_true, metric_lower_bound, metric_upper_bound, higher_is_better)
+    risk_y_proxy = _scale_to_unit_risk(y_proxy, metric_lower_bound, metric_upper_bound, higher_is_better)
+    risk_threshold = _scale_to_unit_risk(threshold, metric_lower_bound, metric_upper_bound, higher_is_better)
+    return risk_y_true, risk_y_proxy, risk_threshold, batch_codes, batch_n_true, batch_n_proxy
+
+
+def _compute_batch_estimates(
+    risk_y_true: NDArray,
+    risk_y_proxy: NDArray,
+    batch_codes: NDArray,
+    power_tuning: bool,
+) -> Tuple[NDArray, NDArray]:
+    n_batches = batch_codes[-1] + 1
+    batch_mean_estimates = np.empty(n_batches)
+    batch_std_estimates = np.empty(n_batches)
+    for position in range(n_batches):
+        if position == 0 or (not power_tuning):
+            tuning_parameter = 1.0
+        else:
+            earlier_mask = batch_codes < position
+            y_true_earlier, y_proxy_labeled_earlier, y_proxy_unlabeled_earlier, _ = _split_labeled_unlabeled(
+                risk_y_true[earlier_mask], risk_y_proxy[earlier_mask]
+            )
+            tuning_parameter = _compute_tuning_parameter(
+                y_true_earlier, y_proxy_labeled_earlier, y_proxy_unlabeled_earlier, power_tuning
+            )
+
+        batch_mask = batch_codes == position
+        y_true_labeled, y_proxy_labeled, y_proxy_unlabeled, _ = _split_labeled_unlabeled(
+            risk_y_true[batch_mask], risk_y_proxy[batch_mask]
+        )
+        batch_mean_estimates[position] = _compute_mean_estimate(
+            y_true_labeled, y_proxy_labeled, y_proxy_unlabeled, tuning_parameter
+        )
+        batch_std_estimates[position] = _compute_std_estimate(
+            y_true_labeled, y_proxy_labeled, y_proxy_unlabeled, tuning_parameter
+        )
+    return batch_mean_estimates, batch_std_estimates

--- a/tests/functional/monitors/test_asymptotic_ppi.py
+++ b/tests/functional/monitors/test_asymptotic_ppi.py
@@ -1,0 +1,94 @@
+"""Functional tests for AsymptoticPPIMeanMonitor.
+
+These tests verify end-to-end statistical properties rather than implementation
+details, and therefore require larger datasets to hold reliably.
+"""
+
+import numpy as np
+import pytest
+
+from glide.estimators import PPIMeanEstimator
+from glide.monitors import AsymptoticPPIMeanMonitor
+from glide.simulators import generate_stratified_binary_dataset, simulate_annotation
+
+# ── fixtures ───────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def dataset():
+    n_batches = 5
+    batch_size = 20
+    n_labeled_per_batch = 8
+
+    y_true_oracle, y_proxy, batches = generate_stratified_binary_dataset(
+        n_total=[batch_size] * n_batches,
+        true_mean=[0.5] * n_batches,
+        proxy_mean=[0.6] * n_batches,
+        correlation=[0.8] * n_batches,
+        random_seed=0,
+    )
+    rng = np.random.default_rng(seed=1)
+    xis = []
+    for _ in range(n_batches):
+        xi_batch = np.zeros(batch_size)
+        labeled_indices = rng.choice(batch_size, size=n_labeled_per_batch)
+        xi_batch[labeled_indices] = 1
+        xis.append(xi_batch)
+    xi = np.hstack(xis)
+    y_true = simulate_annotation(y_true_oracle, xi)
+    return y_true, y_proxy, batches
+
+
+# ── tests ──────────────────────────────────────────────────────────────────────
+
+
+def test_detect_batch_estimates_match_ppi_estimator(dataset):
+    """Each batch estimate equals the PPI estimator computed on that batch alone when power tuning is disabled."""
+    y_true, y_proxy, batches = dataset
+    monitor_result = AsymptoticPPIMeanMonitor().detect(
+        y_true,
+        y_proxy,
+        batches,
+        higher_is_better=False,
+        threshold=0.5,
+        power_tuning=False,
+    )
+    n_batches = len(np.unique(batches))
+    estimator_means = np.zeros(n_batches)
+    for batch_id in range(n_batches):
+        batch_mask = batches == batch_id
+        estimator_result = PPIMeanEstimator().estimate(y_true[batch_mask], y_proxy[batch_mask], power_tuning=False)
+        estimator_means[batch_id] = estimator_result.mean
+
+    np.testing.assert_allclose(monitor_result.batch_mean_estimates, estimator_means)
+
+
+def test_detect_prefix_consistency(dataset):
+    """Detecting on a growing history is prefix-consistent with detecting on the full history."""
+    y_true, y_proxy, batches = dataset
+    monitor = AsymptoticPPIMeanMonitor()
+    full = monitor.detect(y_true, y_proxy, batches, higher_is_better=False, threshold=0.5, tightest_at_batch=2)
+    prefix_mask = batches <= 2
+    prefix = monitor.detect(
+        y_true[prefix_mask],
+        y_proxy[prefix_mask],
+        batches[prefix_mask],
+        higher_is_better=False,
+        threshold=0.5,
+        tightest_at_batch=2,
+    )
+
+    np.testing.assert_allclose(prefix.running_means, full.running_means[:3])
+    np.testing.assert_allclose(prefix.confidence_bounds, full.confidence_bounds[:3])
+
+
+def test_detect_higher_is_better_symmetry(dataset):
+    """Monitoring a performance is the mirror image of monitoring its negation as a risk."""
+    y_true, y_proxy, batches = dataset
+    risk = AsymptoticPPIMeanMonitor().detect(y_true, y_proxy, batches, higher_is_better=False, threshold=0.3)
+    performance = AsymptoticPPIMeanMonitor().detect(
+        1 - y_true, 1 - y_proxy, batches, higher_is_better=True, threshold=0.7
+    )
+
+    np.testing.assert_array_equal(performance.alarms, risk.alarms)
+    np.testing.assert_allclose(performance.confidence_bounds, 1 - risk.confidence_bounds)

--- a/tests/unit/monitors/test_asymptotic_ppi.py
+++ b/tests/unit/monitors/test_asymptotic_ppi.py
@@ -1,9 +1,12 @@
+from unittest.mock import patch
+
 import numpy as np
 import pytest
 
-from glide.confidence_sequences import EmpiricalBernsteinConfidenceSequence
+import glide.monitors.asymptotic_ppi as asymptotic_ppi_module
+from glide.confidence_sequences import AsymptoticConfidenceSequence
 from glide.mean_monitoring_results import PredictionPoweredMeanMonitoringResult
-from glide.monitors import EmpiricalPPIMeanMonitor
+from glide.monitors import AsymptoticPPIMeanMonitor
 
 
 @pytest.fixture
@@ -23,18 +26,33 @@ def batches():
 
 @pytest.fixture
 def monitor():
-    return EmpiricalPPIMeanMonitor()
+    return AsymptoticPPIMeanMonitor()
 
 
 # --- detect ---
+
+
+def test_detect_delegates_to_validation(monitor, y_true, y_proxy, batches):
+    with patch.object(asymptotic_ppi_module, "_validate_bounds") as mock_validate_bounds:
+        monitor.detect(y_true, y_proxy, batches, higher_is_better=False, threshold=0.5)
+
+        mock_validate_bounds.assert_called_once_with(
+            0.8,
+            "confidence_level",
+            lower=0.5,
+            upper=1,
+            left_inclusive=False,
+            right_inclusive=False,
+            error_message="'confidence_level' must be in (0.5, 1) for the asymptotic monitor; got 0.8.",
+        )
 
 
 def test_detect_is_valid_monitoring_result(monitor, y_true, y_proxy, batches):
     result = monitor.detect(y_true, y_proxy, batches, higher_is_better=False, threshold=0.5)
 
     assert isinstance(result, PredictionPoweredMeanMonitoringResult)
-    assert isinstance(result.confidence_sequence, EmpiricalBernsteinConfidenceSequence)
-    assert result.monitor_name == "EmpiricalPPIMeanMonitor"
+    assert isinstance(result.confidence_sequence, AsymptoticConfidenceSequence)
+    assert result.monitor_name == "AsymptoticPPIMeanMonitor"
     assert np.isfinite(result.running_means).all()
     assert (result.running_means >= result.confidence_bounds).all()
 
@@ -45,7 +63,7 @@ def test_detect_metadata(monitor, y_true, y_proxy, batches):
     )
 
     assert result.metric_name == "accuracy"
-    assert result.monitor_name == "EmpiricalPPIMeanMonitor"
+    assert result.monitor_name == "AsymptoticPPIMeanMonitor"
     assert result.higher_is_better is True
     assert result.alarm_threshold == 0.5
     assert result.confidence_level == 0.85
@@ -55,12 +73,12 @@ def test_detect_metadata(monitor, y_true, y_proxy, batches):
 
 def test_detect_custom_confidence_level(monitor, y_true, y_proxy, batches):
     expected_running_means = np.array([0.52, 0.52])
-    expected_confidence_bounds = np.array([0.312, 0.416])
+    expected_confidence_bounds = np.array([0.446, 0.477])
 
     result = monitor.detect(
-        y_true, y_proxy, batches, higher_is_better=False, threshold=0.5, metric_name="risk", confidence_level=0.10
+        y_true, y_proxy, batches, higher_is_better=False, threshold=0.5, metric_name="risk", confidence_level=0.85
     )
 
-    assert result.confidence_level == 0.10
+    assert result.confidence_level == 0.85
     np.testing.assert_allclose(result.running_means, expected_running_means, atol=0.001)
     np.testing.assert_allclose(result.confidence_bounds, expected_confidence_bounds, atol=0.001)

--- a/tests/unit/monitors/test_ppi_core.py
+++ b/tests/unit/monitors/test_ppi_core.py
@@ -1,0 +1,159 @@
+from unittest.mock import patch
+
+import numpy as np
+import pytest
+
+import glide.monitors.ppi_core as ppi_core_module
+from glide.monitors.ppi_core import _compute_batch_estimates, _preprocess
+
+
+@pytest.fixture
+def y_true():
+    return np.array([0.49, 0.51, np.nan, np.nan, 0.5, 0.54, np.nan, np.nan])
+
+
+@pytest.fixture
+def y_proxy():
+    return np.array([0.5, 0.5, 0.49, 0.55, 0.52, 0.48, 0.5, 0.52])
+
+
+@pytest.fixture
+def batches():
+    return np.array([0, 0, 0, 0, 1, 1, 1, 1])
+
+
+# --- _preprocess ---
+
+
+def test_preprocess_delegates_to_validation(y_true, y_proxy, batches):
+    with (
+        patch.object(ppi_core_module, "_validate_non_empty") as mock_validate_non_empty,
+        patch.object(ppi_core_module, "_validate_equal_lengths") as mock_validate_equal_lengths,
+        patch.object(ppi_core_module, "_validate_has_no_nan") as mock_validate_has_no_nan,
+        patch.object(ppi_core_module, "_validate_bounds") as mock_validate_bounds,
+        patch.object(ppi_core_module, "_validate_y_proxy") as mock_validate_y_proxy,
+        patch.object(ppi_core_module, "_validate_y_true") as mock_validate_y_true,
+        patch.object(ppi_core_module, "_unique_ordered_batches") as mock_unique_ordered_batches,
+    ):
+        mock_unique_ordered_batches.return_value = (np.array([0, 1]), np.array([0, 0, 0, 0, 1, 1, 1, 1]))
+        _preprocess(
+            y_true,
+            y_proxy,
+            batches,
+            higher_is_better=False,
+            threshold=0.5,
+            confidence_level=0.8,
+            metric_lower_bound=0.0,
+            metric_upper_bound=1.0,
+        )
+
+        mock_validate_non_empty.assert_called_once()
+        np.testing.assert_array_equal(mock_validate_non_empty.call_args[0][0], y_true)
+        assert mock_validate_non_empty.call_args[0][1] == "y_true"
+
+        mock_validate_equal_lengths.assert_called_once()
+        np.testing.assert_array_equal(mock_validate_equal_lengths.call_args[0][0], y_true)
+        np.testing.assert_array_equal(mock_validate_equal_lengths.call_args[0][1], y_proxy)
+        np.testing.assert_array_equal(mock_validate_equal_lengths.call_args[0][2], batches)
+        assert mock_validate_equal_lengths.call_args[1] == {"names": ["y_true", "y_proxy", "batches"]}
+
+        mock_validate_has_no_nan.assert_called_once()
+        np.testing.assert_array_equal(mock_validate_has_no_nan.call_args[0][0], batches)
+        assert mock_validate_has_no_nan.call_args[0][1] == "batches"
+
+        mock_validate_y_proxy.assert_called_once()
+        np.testing.assert_array_equal(mock_validate_y_proxy.call_args[0][0], y_proxy)
+
+        mock_validate_y_true.assert_called_once()
+        np.testing.assert_array_equal(mock_validate_y_true.call_args[0][0], y_true)
+
+        mock_unique_ordered_batches.assert_called_once()
+        np.testing.assert_array_equal(mock_unique_ordered_batches.call_args[0][0], batches)
+
+        assert mock_validate_bounds.call_count == 7
+
+        assert mock_validate_bounds.call_args_list[0][0] == (0.8, "confidence_level")
+        assert mock_validate_bounds.call_args_list[0][1] == {
+            "lower": 0,
+            "upper": 1,
+            "left_inclusive": False,
+            "right_inclusive": False,
+        }
+
+        assert mock_validate_bounds.call_args_list[1][0] == (0.0, "metric_lower_bound")
+        assert mock_validate_bounds.call_args_list[1][1]["upper"] == 1.0
+        assert mock_validate_bounds.call_args_list[1][1]["right_inclusive"] is False
+        assert (
+            "'metric_lower_bound' must be strictly smaller than 'metric_upper_bound'"
+            in mock_validate_bounds.call_args_list[1][1]["error_message"]
+        )
+
+        assert mock_validate_bounds.call_args_list[2][0] == (0.5, "threshold")
+        assert mock_validate_bounds.call_args_list[2][1]["lower"] == 0.0
+        assert mock_validate_bounds.call_args_list[2][1]["upper"] == 1.0
+        assert "'threshold' must lie between" in mock_validate_bounds.call_args_list[2][1]["error_message"]
+
+        np.testing.assert_array_equal(mock_validate_bounds.call_args_list[3][0][0], np.array([0.49, 0.51, 0.5, 0.54]))
+        assert mock_validate_bounds.call_args_list[3][0][1] == "y_true"
+        assert "'y_true' values must lie between" in mock_validate_bounds.call_args_list[3][1]["error_message"]
+
+        np.testing.assert_array_equal(mock_validate_bounds.call_args_list[4][0][0], y_proxy)
+        assert mock_validate_bounds.call_args_list[4][0][1] == "y_proxy"
+        assert "'y_proxy' values must lie between" in mock_validate_bounds.call_args_list[4][1]["error_message"]
+
+        assert mock_validate_bounds.call_args_list[5][0] == (2, "y_true")
+        assert mock_validate_bounds.call_args_list[5][1]["lower"] == 2
+        assert (
+            "'y_true' must have at least 2 labeled values per batch"
+            in mock_validate_bounds.call_args_list[5][1]["error_message"]
+        )
+
+        assert mock_validate_bounds.call_args_list[6][0] == (2, "y_true")
+        assert mock_validate_bounds.call_args_list[6][1]["lower"] == 2
+        assert (
+            "'y_true' must have at least 2 unlabeled values per batch"
+            in mock_validate_bounds.call_args_list[6][1]["error_message"]
+        )
+
+
+def test_preprocess_known_output(y_true, y_proxy, batches):
+    risk_y_true, risk_y_proxy, risk_threshold, batch_codes, batch_n_true, batch_n_proxy = _preprocess(
+        y_true,
+        y_proxy,
+        batches,
+        higher_is_better=False,
+        threshold=0.5,
+        confidence_level=0.8,
+        metric_lower_bound=0.0,
+        metric_upper_bound=1.0,
+    )
+
+    np.testing.assert_allclose(risk_y_true, y_true)
+    np.testing.assert_allclose(risk_y_proxy, y_proxy)
+    assert risk_threshold == pytest.approx(0.5)
+    np.testing.assert_array_equal(batch_codes, np.array([0, 0, 0, 0, 1, 1, 1, 1]))
+    np.testing.assert_array_equal(batch_n_true, np.array([2, 2]))
+    np.testing.assert_array_equal(batch_n_proxy, np.array([4, 4]))
+
+
+# --- _compute_batch_estimates ---
+
+
+def test_compute_batch_estimates(y_true, y_proxy, batches):
+    expected_batch_mean_estimates = np.array([0.52, 0.52])
+    expected_batch_std_estimates = np.array([0.03162277660168379, 0.02])
+
+    batch_mean_estimates, batch_std_estimates = _compute_batch_estimates(y_true, y_proxy, batches, power_tuning=True)
+
+    np.testing.assert_allclose(batch_mean_estimates, expected_batch_mean_estimates)
+    np.testing.assert_allclose(batch_std_estimates, expected_batch_std_estimates, atol=1e-3)
+
+
+def test_compute_batch_estimates_power_tuning_false(y_true, y_proxy, batches):
+    expected_batch_mean_estimates = np.array([0.52, 0.53])
+    expected_batch_std_estimates = np.array([0.031, 0.041])
+
+    batch_mean_estimates, batch_std_estimates = _compute_batch_estimates(y_true, y_proxy, batches, power_tuning=False)
+
+    np.testing.assert_allclose(batch_mean_estimates, expected_batch_mean_estimates)
+    np.testing.assert_allclose(batch_std_estimates, expected_batch_std_estimates, atol=1e-3)


### PR DESCRIPTION

### Description

- Adds `AsymptoticPPIMeanMonitor`, a prediction-powered drift monitor built on `AsymptoticConfidenceSequence` that uses the batch estimates' standard errors for faster drift detection than the empirical-Bernstein based monitor.
- Extracts the logic shared with `EmpiricalPPIMeanMonitor` into `glide/monitors/ppi_core.py`.
- Handles this [ticket](https://github.com/orgs/EmertonData/projects/26/views/2?pane=issue&itemId=214000832&issue=EmertonData%7Cglide%7C350) Closes #350

### Checklist

Quality gates that must be satisfied before requesting a review:

- [x] I have read `CONTRIBUTING.md`
- [x] `make lint` passes
- [x] `make type-check` passes
- [x] `make tests` passes
- [x] `make coverage` reports 100% coverage
- [x] `make test-notebooks` passes
- [x] New public API has numpy-style docstrings
- [x] New public API is inserted in the API reference section of the documentation
- [x] Docs build without warnings (`make doc`)
- [x] `CHANGELOG.md` updated if the change is user-facing

### LLM usage

Disclose if an LLM was used in writing this PR:
- [ ] No LLM used
- [x] I used an LLM and I went through and validated all the code myself