### PR TITLE
Publish the Pages site from an explicit allow-list

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -33,13 +33,16 @@ jobs:
       - name: Configure GitHub Pages
         uses: actions/configure-pages@v6
 
-      - name: Copy shared assets into landing page
-        run: cp -r docs/assets docs/landing/
+      - name: Stage site
+        run: |
+          mkdir -p _site/assets
+          cp docs/landing/index.html _site/
+          cp docs/assets/*.png docs/assets/*.jpg _site/assets/
 
       - name: Upload landing page as Pages artifact
         uses: actions/upload-pages-artifact@v5
         with:
-          path: docs/landing/
+          path: _site/
 
       - name: Deploy to GitHub Pages
         id: deployment


### PR DESCRIPTION

### Description

- Flips the Pages deployment workflow from publish-by-default to publish-by-intent: instead of copying all of `docs/assets` into `docs/landing/` and uploading the whole directory, a new "Stage site" step allow-lists only `index.html` and the `.png`/`.jpg` assets it references into a fresh `_site/` directory, which is then uploaded as the Pages artifact.
- This stops `docs/assets/glide-decision-tree.pptx` (and any future non-web files added under `docs/landing/`) from being served on the public site.
- Closes #322

### Checklist

Quality gates that must be satisfied before requesting a review:

- [x] I have read `CONTRIBUTING.md`
- [ ] `make lint` passes
- [ ] `make type-check` passes
- [ ] `make tests` passes
- [ ] `make coverage` reports 100% coverage
- [ ] `make test-notebooks` passes
- [ ] New public API has numpy-style docstrings
- [ ] New public API is inserted in the API reference section of the documentation
- [ ] Docs build without warnings (`make doc`)
- [ ] `CHANGELOG.md` updated if the change is user-facing

### LLM usage

Disclose if an LLM was used in writing this PR:
- [ ] No LLM used
- [x] I used an LLM and I went through and validated all the code myself