### PR TITLE
Skip execution of the slowest deep-dive validation notebooks

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -57,6 +57,10 @@ plugins:
   - mkdocs-jupyter:
       include_source: true
       execute: true
+      execute_ignore:
+        - "*/scientific_validation/estimators/ipwptd.ipynb"
+        - "*/scientific_validation/estimators/clustered_ptd.ipynb"
+        - "*/scientific_validation/monitors/empirical_ppi.ipynb"
 
 markdown_extensions:
   - attr_list


### PR DESCRIPTION

### Description

- **What**: Adds an `execute_ignore` list to the `mkdocs-jupyter` plugin config in `mkdocs.yml`, exempting three notebooks from execution during doc builds: `deep_dive/scientific_validation/estimators/ipwptd.ipynb`, `deep_dive/scientific_validation/estimators/clustered_ptd.ipynb`, and `deep_dive/scientific_validation/monitors/empirical_ppi.ipynb`.
- **How**: `mkdocs-jupyter`'s `execute_ignore` option glob-matches notebook paths against the patterns given; any notebook that matches is rendered without being executed, using whatever output cells are already saved in the committed `.ipynb` file. None of these three notebooks currently have saved outputs committed, so they will render with blank output cells until someone executes and commits them, or removes the entry below.
- **Why**: A full timing pass over all 24 documentation notebooks showed these three among the slowest (70s, 58s, and 55s respectively), together accounting for a large share of total doc build time and contributing to slow documentation deployment.
- **How to reverse**: Remove the `execute_ignore` list (or individual entries) from the `mkdocs-jupyter` plugin block in `mkdocs.yml` to resume executing those notebooks on every doc build.
- No issue to close, this is a standalone documentation build change.

### Checklist

Quality gates that must be satisfied before requesting a review:

- [x] I have read `CONTRIBUTING.md`
- [ ] `make lint` passes
- [ ] `make type-check` passes
- [ ] `make tests` passes
- [ ] `make coverage` reports 100% coverage
- [ ] `make test-notebooks` passes
- [ ] New public API has numpy-style docstrings
- [ ] New public API is inserted in the API reference section of the documentation
- [x] Docs build without warnings (`make doc`)
- [ ] `CHANGELOG.md` updated if the change is user-facing

### LLM usage

Disclose if an LLM was used in writing this PR:
- [ ] No LLM used
- [x] I used an LLM and I went through and validated all the code myself