### PR TITLE
Release v0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,18 +9,25 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ## [Next release]
 
 ### ✨ Added
-- `MultiPTDMeanEstimator`: generalizes `PTDMeanEstimator` to combine multiple proxy predictors via a bootstrap-tuned weight vector.
-- `AsymptoticPPRM`, a prediction-powered drift monitor built on `AsymptoticConfidenceSequence` and using the batch estimates' standard errors.
-- `AsymptoticClassicalMeanMonitor`, a label-only drift monitor built on `AsymptoticConfidenceSequence` and using the batch estimates' standard errors.
-- `AsymptoticConfidenceSequence`, an anytime-valid confidence sequence whose width scales with the known standard errors of per-batch estimates.
 
 ### 🔄 Changed
-- `ConfidenceSequence` is now a concrete base class rather than a structural protocol.
-- Renamed `PPIMeanMonitor` to `EmpiricalPPRM` (`glide.monitors.ppi` → `glide.monitors.empirical_pprm`) and `ClassicalMeanMonitor` to `EmpiricalClassicalMeanMonitor` (`glide.monitors.classical` → `glide.monitors.empirical_classical`).
 
 ### 🐛 Fixed
 
 ### 💛 Contributors
+
+## [0.10.0] – 2026-07-27
+
+### ✨ Added
+- `MultiPTDMeanEstimator`: generalizes `PTDMeanEstimator` to combine multiple proxy predictors via a bootstrap-tuned weight vector.
+- `AsymptoticPPRM` and `AsymptoticClassicalMeanMonitor`, new drift monitors (prediction-powered and label-only) built on `AsymptoticConfidenceSequence`, an anytime-valid confidence sequence whose width scales with the known standard errors of per-batch estimates.
+
+### 🔄 Changed
+- Renamed `PPIMeanMonitor` to `EmpiricalPPRM` and `ClassicalMeanMonitor` to `EmpiricalClassicalMeanMonitor` for consistency with the new asymptotic monitors.
+- `ConfidenceSequence` is now a concrete base class instead of a structural protocol.
+
+### 💛 Contributors
+Thank you to everyone who contributed to this release: @gmartinon-ed, @imerad
 
 ## [0.9.0] – 2026-07-16
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,7 +12,7 @@ authors:
 repository-code: "https://github.com/EmertonData/glide"
 url: "https://glide-py.readthedocs.io"
 license: Apache-2.0
-version: 0.9.0
+version: 0.10.0
 date-released: 2026-06-01
 preferred-citation:
   type: article

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "glide-py"
-version = "0.9.0"
+version = "0.10.0"
 authors = [
   {name = "Grégoire Martinon", email = "gregoire.martinon@emerton-data.com"},
   {name = "Ibrahim Merad", email = "ibrahim.merad@emerton-data.com"},
@@ -83,7 +83,7 @@ respect-type-ignore-comments = true
 addopts = "--import-mode=importlib --doctest-modules"
 
 [tool.bumpversion]
-current_version = "0.9.0"
+current_version = "0.10.0"
 commit = false
 tag = false
 

--- a/uv.lock
+++ b/uv.lock
@@ -858,7 +858,7 @@ wheels = [
 
 [[package]]
 name = "glide-py"
-version = "0.9.0"
+version = "0.10.0"
 source = { editable = "." }
 dependencies = [
     { name = "scipy" },


### PR DESCRIPTION
### Description

- Release PR for v0.10.0: bumps the version and moves the `[Next release]` changelog entries into a versioned section.
- Handles this [ticket](https://github.com/orgs/EmertonData/projects/26/views/2?pane=issue&itemId=217666020)

## [0.10.0] – 2026-07-27

### ✨ Added
- `MultiPTDMeanEstimator`: generalizes `PTDMeanEstimator` to combine multiple proxy predictors via a bootstrap-tuned weight vector.
- `AsymptoticPPRM` and `AsymptoticClassicalMeanMonitor`, new drift monitors (prediction-powered and label-only) built on `AsymptoticConfidenceSequence`, an anytime-valid confidence sequence whose width scales with the known standard errors of per-batch estimates.

### 🔄 Changed
- Renamed `PPIMeanMonitor` to `EmpiricalPPRM` and `ClassicalMeanMonitor` to `EmpiricalClassicalMeanMonitor` for consistency with the new asymptotic monitors.
- `ConfidenceSequence` is now a concrete base class instead of a structural protocol.

### 💛 Contributors
Thank you to everyone who contributed to this release: @gmartinon-ed, @imerad

### Checklist

Quality gates that must be satisfied before requesting a review:

- [x] I have read `CONTRIBUTING.md`
- [x] `make lint` passes
- [x] `make type-check` passes
- [x] `make tests` passes
- [x] `make coverage` reports 100% coverage
- [x] `make test-notebooks` passes
- [ ] New public API has numpy-style docstrings
- [ ] New public API is inserted in the API reference section of the documentation
- [x] Docs build without warnings (`make doc`)
- [x] `CHANGELOG.md` updated if the change is user-facing

### LLM usage

Disclose if an LLM was used in writing this PR:
- [ ] No LLM used
- [x] I used an LLM and I went through and validated all the code myself