### PR TITLE
Shorten deep dive notebook titles

### DIFF
--- a/docs/deep_dive/case_studies/r_judge.ipynb
+++ b/docs/deep_dive/case_studies/r_judge.ipynb
@@ -5,7 +5,7 @@
    "id": "0",
    "metadata": {},
    "source": [
-    "# Case Study: Agentic System Evaluation on R-Judge\n",
+    "# Agentic System Evaluation on R-Judge\n",
     "\n",
     "**Context.** GLIDE combines a small set of expert-labeled samples with a large pool of proxy labels to produce confidence intervals that are valid and narrower than classical intervals built from labeled data alone.\n",
     "\n",

--- a/docs/deep_dive/case_studies/spider.ipynb
+++ b/docs/deep_dive/case_studies/spider.ipynb
@@ -5,7 +5,7 @@
    "id": "0",
    "metadata": {},
    "source": [
-    "# Case Study: Text-to-SQL Accuracy Estimation on Spider 1.0\n",
+    "# Text-to-SQL Accuracy Estimation on Spider 1.0\n",
     "\n",
     "**Context.** GLIDE combines a small set of ground truth annotations with a large pool of proxy labels to produce confidence intervals that are valid and narrower than purely classical intervals built from labeled data alone.\n",
     "\n",

--- a/docs/deep_dive/scientific_validation/estimators/asi.ipynb
+++ b/docs/deep_dive/scientific_validation/estimators/asi.ipynb
@@ -5,7 +5,7 @@
    "id": "0",
    "metadata": {},
    "source": [
-    "# Scientific Validity of ASI for Mean Estimation\n",
+    "# ASI for Mean Estimation\n",
     "\n",
     "This notebook provides empirical evidence that GLIDE's **Active Statistical Inference (ASI)** implementation is statistically valid.\n",
     "\n",
@@ -608,7 +608,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "glide-py",
+   "display_name": "glide-py (3.12.12)",
    "language": "python",
    "name": "python3"
   },

--- a/docs/deep_dive/scientific_validation/estimators/asi.ipynb
+++ b/docs/deep_dive/scientific_validation/estimators/asi.ipynb
@@ -5,7 +5,7 @@
    "id": "0",
    "metadata": {},
    "source": [
-    "# ASI for Mean Estimation\n",
+    "# Active Statistical Inference (ASI)\n",
     "\n",
     "This notebook provides empirical evidence that GLIDE's **Active Statistical Inference (ASI)** implementation is statistically valid.\n",
     "\n",

--- a/docs/deep_dive/scientific_validation/estimators/clustered_ppi.ipynb
+++ b/docs/deep_dive/scientific_validation/estimators/clustered_ppi.ipynb
@@ -5,7 +5,7 @@
    "id": "0",
    "metadata": {},
    "source": [
-    "# Scientific Validity of Clustered PPI++ for Mean Estimation\n",
+    "# Clustered PPI++ for Mean Estimation\n",
     "\n",
     "This notebook provides empirical evidence that GLIDE's **Clustered Prediction-Powered Inference (Clustered PPI++)** implementation is statistically valid.\n",
     "\n",

--- a/docs/deep_dive/scientific_validation/estimators/clustered_ppi.ipynb
+++ b/docs/deep_dive/scientific_validation/estimators/clustered_ppi.ipynb
@@ -5,7 +5,7 @@
    "id": "0",
    "metadata": {},
    "source": [
-    "# Clustered PPI++ for Mean Estimation\n",
+    "# Clustered PPI++\n",
     "\n",
     "This notebook provides empirical evidence that GLIDE's **Clustered Prediction-Powered Inference (Clustered PPI++)** implementation is statistically valid.\n",
     "\n",

--- a/docs/deep_dive/scientific_validation/estimators/clustered_ptd.ipynb
+++ b/docs/deep_dive/scientific_validation/estimators/clustered_ptd.ipynb
@@ -5,7 +5,7 @@
    "id": "0",
    "metadata": {},
    "source": [
-    "# Clustered PTD for Mean Estimation\n",
+    "# Clustered PTD\n",
     "\n",
     "This notebook provides empirical evidence that GLIDE's **Clustered Predict-Then-Debias (Clustered PTD)** implementation is statistically valid.\n",
     "\n",

--- a/docs/deep_dive/scientific_validation/estimators/clustered_ptd.ipynb
+++ b/docs/deep_dive/scientific_validation/estimators/clustered_ptd.ipynb
@@ -5,7 +5,7 @@
    "id": "0",
    "metadata": {},
    "source": [
-    "# Scientific Validity of Clustered PTD for Mean Estimation\n",
+    "# Clustered PTD for Mean Estimation\n",
     "\n",
     "This notebook provides empirical evidence that GLIDE's **Clustered Predict-Then-Debias (Clustered PTD)** implementation is statistically valid.\n",
     "\n",

--- a/docs/deep_dive/scientific_validation/estimators/ipwptd.ipynb
+++ b/docs/deep_dive/scientific_validation/estimators/ipwptd.ipynb
@@ -5,7 +5,7 @@
    "id": "0",
    "metadata": {},
    "source": [
-    "# Scientific Validity of IPW PTD for Mean Estimation\n",
+    "# IPW PTD for Mean Estimation\n",
     "\n",
     "This notebook provides empirical evidence that GLIDE's **Inverse Probability Weighted Predict-Then-Debias (IPW PTD)** implementation is statistically valid.\n",
     "\n",

--- a/docs/deep_dive/scientific_validation/estimators/ipwptd.ipynb
+++ b/docs/deep_dive/scientific_validation/estimators/ipwptd.ipynb
@@ -5,7 +5,7 @@
    "id": "0",
    "metadata": {},
    "source": [
-    "# IPW PTD for Mean Estimation\n",
+    "# Inverse Probability Weighted PTD\n",
     "\n",
     "This notebook provides empirical evidence that GLIDE's **Inverse Probability Weighted Predict-Then-Debias (IPW PTD)** implementation is statistically valid.\n",
     "\n",

--- a/docs/deep_dive/scientific_validation/estimators/multi_ppi.ipynb
+++ b/docs/deep_dive/scientific_validation/estimators/multi_ppi.ipynb
@@ -5,7 +5,7 @@
    "id": "0",
    "metadata": {},
    "source": [
-    "# Scientific Validity of Multi-PPI++ for Mean Estimation\n",
+    "# Multi-PPI++ for Mean Estimation\n",
     "\n",
     "This notebook provides empirical evidence that GLIDE's **Multi Proxy Prediction-Powered Inference (Multi-PPI++)** implementation is statistically valid.\n",
     "\n",

--- a/docs/deep_dive/scientific_validation/estimators/multi_ppi.ipynb
+++ b/docs/deep_dive/scientific_validation/estimators/multi_ppi.ipynb
@@ -5,7 +5,7 @@
    "id": "0",
    "metadata": {},
    "source": [
-    "# Multi-PPI++ for Mean Estimation\n",
+    "# Multi-PPI++\n",
     "\n",
     "This notebook provides empirical evidence that GLIDE's **Multi Proxy Prediction-Powered Inference (Multi-PPI++)** implementation is statistically valid.\n",
     "\n",

--- a/docs/deep_dive/scientific_validation/estimators/multi_ptd.ipynb
+++ b/docs/deep_dive/scientific_validation/estimators/multi_ptd.ipynb
@@ -5,7 +5,7 @@
    "id": "0",
    "metadata": {},
    "source": [
-    "# Multi-PTD for Mean Estimation\n",
+    "# Multi-PTD\n",
     "\n",
     "This notebook provides empirical evidence that GLIDE's **Multi Proxy Predict-Then-Debias (Multi-PTD)** implementation is statistically valid.\n",
     "\n",

--- a/docs/deep_dive/scientific_validation/estimators/multi_ptd.ipynb
+++ b/docs/deep_dive/scientific_validation/estimators/multi_ptd.ipynb
@@ -5,7 +5,7 @@
    "id": "0",
    "metadata": {},
    "source": [
-    "# Scientific Validity of Multi-PTD for Mean Estimation\n",
+    "# Multi-PTD for Mean Estimation\n",
     "\n",
     "This notebook provides empirical evidence that GLIDE's **Multi Proxy Predict-Then-Debias (Multi-PTD)** implementation is statistically valid.\n",
     "\n",
@@ -537,7 +537,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "glide-py",
+   "display_name": "glide-py (3.12.12)",
    "language": "python",
    "name": "python3"
   },

--- a/docs/deep_dive/scientific_validation/estimators/ppi.ipynb
+++ b/docs/deep_dive/scientific_validation/estimators/ppi.ipynb
@@ -5,7 +5,7 @@
    "id": "0",
    "metadata": {},
    "source": [
-    "# PPI++ for Mean Estimation\n",
+    "# Prediction-Powered Inference (PPI++)\n",
     "\n",
     "This notebook provides empirical evidence that GLIDE's **Prediction-Powered Inference (PPI++)** implementation is statistically valid.\n",
     "\n",

--- a/docs/deep_dive/scientific_validation/estimators/ppi.ipynb
+++ b/docs/deep_dive/scientific_validation/estimators/ppi.ipynb
@@ -5,7 +5,7 @@
    "id": "0",
    "metadata": {},
    "source": [
-    "# Scientific Validity of PPI++ for Mean Estimation\n",
+    "# PPI++ for Mean Estimation\n",
     "\n",
     "This notebook provides empirical evidence that GLIDE's **Prediction-Powered Inference (PPI++)** implementation is statistically valid.\n",
     "\n",

--- a/docs/deep_dive/scientific_validation/estimators/ptd.ipynb
+++ b/docs/deep_dive/scientific_validation/estimators/ptd.ipynb
@@ -5,7 +5,7 @@
    "id": "0",
    "metadata": {},
    "source": [
-    "# Scientific Validity of PTD for Mean Estimation\n",
+    "# PTD for Mean Estimation\n",
     "\n",
     "This notebook provides empirical evidence that GLIDE's **Predict-Then-Debias (PTD)** implementation is statistically valid.\n",
     "\n",

--- a/docs/deep_dive/scientific_validation/estimators/ptd.ipynb
+++ b/docs/deep_dive/scientific_validation/estimators/ptd.ipynb
@@ -5,7 +5,7 @@
    "id": "0",
    "metadata": {},
    "source": [
-    "# PTD for Mean Estimation\n",
+    "# Predict-Then-Debias (PTD)\n",
     "\n",
     "This notebook provides empirical evidence that GLIDE's **Predict-Then-Debias (PTD)** implementation is statistically valid.\n",
     "\n",

--- a/docs/deep_dive/scientific_validation/estimators/stratified_ppi.ipynb
+++ b/docs/deep_dive/scientific_validation/estimators/stratified_ppi.ipynb
@@ -5,7 +5,7 @@
    "id": "0",
    "metadata": {},
    "source": [
-    "# Stratified PPI++ for Mean Estimation\n",
+    "# Stratified PPI++\n",
     "\n",
     "This notebook provides empirical evidence that GLIDE's **Stratified Prediction-Powered Inference (Stratified PPI++)** implementation is statistically valid.\n",
     "\n",

--- a/docs/deep_dive/scientific_validation/estimators/stratified_ppi.ipynb
+++ b/docs/deep_dive/scientific_validation/estimators/stratified_ppi.ipynb
@@ -5,7 +5,7 @@
    "id": "0",
    "metadata": {},
    "source": [
-    "# Scientific Validity of Stratified PPI++ for Mean Estimation\n",
+    "# Stratified PPI++ for Mean Estimation\n",
     "\n",
     "This notebook provides empirical evidence that GLIDE's **Stratified Prediction-Powered Inference (Stratified PPI++)** implementation is statistically valid.\n",
     "\n",

--- a/docs/deep_dive/scientific_validation/estimators/stratified_ptd.ipynb
+++ b/docs/deep_dive/scientific_validation/estimators/stratified_ptd.ipynb
@@ -5,7 +5,7 @@
    "id": "0",
    "metadata": {},
    "source": [
-    "# Stratified PTD for Mean Estimation\n",
+    "# Stratified PTD\n",
     "\n",
     "This notebook provides empirical evidence that GLIDE's **Stratified Predict-Then-Debias (Stratified PTD)** implementation is statistically valid.\n",
     "\n",

--- a/docs/deep_dive/scientific_validation/estimators/stratified_ptd.ipynb
+++ b/docs/deep_dive/scientific_validation/estimators/stratified_ptd.ipynb
@@ -5,7 +5,7 @@
    "id": "0",
    "metadata": {},
    "source": [
-    "# Scientific Validity of Stratified PTD for Mean Estimation\n",
+    "# Stratified PTD for Mean Estimation\n",
     "\n",
     "This notebook provides empirical evidence that GLIDE's **Stratified Predict-Then-Debias (Stratified PTD)** implementation is statistically valid.\n",
     "\n",

--- a/docs/deep_dive/scientific_validation/monitors/asymptotic_pprm.ipynb
+++ b/docs/deep_dive/scientific_validation/monitors/asymptotic_pprm.ipynb
@@ -5,7 +5,7 @@
    "id": "0",
    "metadata": {},
    "source": [
-    "# Scientific Validity of Asymptotic PPRM\n",
+    "# Asymptotic Prediction-Powered Risk Monitoring\n",
     "\n",
     "This notebook provides empirical evidence that GLIDE's Asymptotic Prediction-Powered Risk Monitoring (Asymptotic PPRM) implementation is statistically valid.\n",
     "\n",

--- a/docs/deep_dive/scientific_validation/monitors/asymptotic_pprm.ipynb
+++ b/docs/deep_dive/scientific_validation/monitors/asymptotic_pprm.ipynb
@@ -5,7 +5,7 @@
    "id": "0",
    "metadata": {},
    "source": [
-    "# Asymptotic Prediction-Powered Risk Monitoring\n",
+    "# Asymptotic PPRM\n",
     "\n",
     "This notebook provides empirical evidence that GLIDE's Asymptotic Prediction-Powered Risk Monitoring (Asymptotic PPRM) implementation is statistically valid.\n",
     "\n",

--- a/docs/deep_dive/scientific_validation/monitors/empirical_pprm.ipynb
+++ b/docs/deep_dive/scientific_validation/monitors/empirical_pprm.ipynb
@@ -5,7 +5,7 @@
    "id": "0",
    "metadata": {},
    "source": [
-    "# Empirical Prediction-Powered Risk Monitoring\n",
+    "# Empirical PPRM\n",
     "\n",
     "This notebook provides empirical evidence that GLIDE's Empirical Prediction-Powered Risk Monitoring (Empirical PPRM) implementation is statistically valid.\n",
     "\n",

--- a/docs/deep_dive/scientific_validation/monitors/empirical_pprm.ipynb
+++ b/docs/deep_dive/scientific_validation/monitors/empirical_pprm.ipynb
@@ -5,7 +5,7 @@
    "id": "0",
    "metadata": {},
    "source": [
-    "# Scientific Validity of Empirical PPRM\n",
+    "# Empirical Prediction-Powered Risk Monitoring\n",
     "\n",
     "This notebook provides empirical evidence that GLIDE's Empirical Prediction-Powered Risk Monitoring (Empirical PPRM) implementation is statistically valid.\n",
     "\n",


### PR DESCRIPTION

### Description

- Removes the redundant "Scientific Validity of" prefix from deep dive notebook titles, since the deep_dive/scientific_validation path already conveys that context.
- Handles this [ticket](https://github.com/orgs/EmertonData/projects/26/views/2?pane=issue&itemId=216837990)

### Checklist

Quality gates that must be satisfied before requesting a review:

- [x] I have read `CONTRIBUTING.md`
- [ ] `make lint` passes
- [ ] `make type-check` passes
- [ ] `make tests` passes
- [ ] `make coverage` reports 100% coverage
- [ ] `make test-notebooks` passes
- [ ] New public API has numpy-style docstrings
- [ ] New public API is inserted in the API reference section of the documentation
- [x] Docs build without warnings (`make doc`)
- [ ] `CHANGELOG.md` updated if the change is user-facing

### LLM usage

Disclose if an LLM was used in writing this PR:
- [ ] No LLM used
- [x] I used an LLM and I went through and validated all the code myself