### PR TITLE
Fix arXiv search URLs and listing coverage in /watch skill

### DIFF
--- a/.claude/skills/watch/SKILL.md
+++ b/.claude/skills/watch/SKILL.md
@@ -44,19 +44,25 @@ arXiv IDs use `YYMM.NNNNN` format — the YYMM prefix encodes the submission yea
 
 **Longer window (> 3 days):** for each month in scope (from the Date range section above), fetch `https://arxiv.org/list/stat/YYYY-MM?skip=0&show=2000` — where `YYYY-MM` is the four-digit year and two-digit month (e.g., `2025-02` for February 2025). If the window spans multiple months, fire all fetches in a **single message**. Extract all paper entries: arXiv ID, title, authors, and submission date. Date filtering to the exact window happens in Step 5.
 
+> Note: for short windows, also fetch `https://arxiv.org/list/stat.ME/recent?skip=0&show=2000` and `https://arxiv.org/list/stat.ML/recent?skip=0&show=2000` in the same message as the `stat/recent` fetch. WebFetch summarises each listing rather than returning it whole, and the three listings surface *different* subsets of the same batch — several in-window papers appeared only in stat.ME or stat.ML. Treat the union as the batch.
+
 > Note: the monthly listing is unreliable for the *current* month's most recent days. WebFetch summarises only the beginning of the listing (oldest IDs of the month), so late-month / recent submissions never surface no matter the `skip` value. When the window's end is within the last few days of today (a recent window that happens to exceed 3 days), do NOT rely on the monthly listing — instead use the `stat/recent` listing (covers the last ~3 announcement days) plus the Step 2–3 searches ordered by `-announced_date_first` (which surface the newest papers first) as the authoritative sources. Reserve the monthly listing for windows fully in past months.
 
 ## Step 2 — Parallel topic searches
 
 In a **single message**, fire all 5 WebFetch calls simultaneously:
 
-1. `https://arxiv.org/search/?query=prediction-powered+inference&searchtype=all&start=0&order=-announced_date_first`
-2. `https://arxiv.org/search/?query=active+statistical+inference&searchtype=all&start=0&order=-announced_date_first`
-3. `https://arxiv.org/search/?query=semi-supervised+inference+debiasing&searchtype=all&start=0&order=-announced_date_first`
-4. `https://arxiv.org/search/?query=LLM+annotation+bias+correction+inference&searchtype=all&start=0&order=-announced_date_first`
-5. `https://arxiv.org/search/?query=proxy+labels+imputation+inference&searchtype=all&start=0&order=-announced_date_first`
+1. `https://arxiv.org/search/?query=%22prediction-powered+inference%22&searchtype=abstract&start=0&order=-announced_date_first`
+2. `https://arxiv.org/search/?query=%22active+statistical+inference%22&searchtype=abstract&start=0&order=-announced_date_first`
+3. `https://arxiv.org/search/?query=%22semi-supervised+inference%22&searchtype=abstract&start=0&order=-announced_date_first`
+4. `https://arxiv.org/search/?query=%22proxy+labels%22+OR+%22LLM+annotations%22+OR+%22surrogate+outcomes%22&searchtype=abstract&start=0&order=-announced_date_first`
+5. `https://arxiv.org/search/?query=%22confidence+sequence%22+OR+%22anytime-valid%22&searchtype=abstract&start=0&order=-announced_date_first`
 
 For each result extract: arXiv ID, title, authors, submission date.
+
+> Note: use `searchtype=abstract` with the phrase in `%22`…`%22` quotes, not `searchtype=all` with a bare term list. `searchtype=all` matches each word independently across the full text and returns almost pure noise (a query for "prediction-powered inference" returned gravitational-lensing and video-segmentation papers, and zero actual PPI papers). The quoted-abstract form returns a clean, dense list of genuine hits.
+
+> Note: do NOT use the advanced-search URL form (`terms-0-operator=AND&terms-0-term=…&terms-0-field=abstract`). It returns the arXiv search *help page* rather than results. The simple `query=…&searchtype=abstract` form above is the one that works.
 
 ## Step 3 — Parallel author searches
 


### PR DESCRIPTION
### Description

Fixes the arXiv query construction in the `/watch` skill, which was silently returning irrelevant results.

The five topic searches in Step 2 used `searchtype=all` with bare term lists. That form matches each word independently across the full text, so the query for `prediction-powered inference` came back with gravitational-lensing and video-segmentation papers and **zero** actual PPI papers. They now use quoted phrases with `searchtype=abstract`, which returns a clean, dense list of genuine hits. Two of the five queries were also retargeted (`proxy labels`/`LLM annotations`/`surrogate outcomes`, and `confidence sequence`/`anytime-valid`) to cover topics the old set missed.

Two further notes were recorded from the same run:
- The advanced-search URL form (`terms-0-operator=AND&terms-0-term=…&terms-0-field=abstract`) returns the arXiv search *help page* instead of results, so it must not be used.
- `stat.ME/recent` and `stat.ML/recent` surface different subsets of a batch than `stat/recent`, because WebFetch summarises each listing rather than returning it whole. Step 1 now fetches all three for short windows and treats the union as the batch.

No issue: N/A — these were found while running `/watch`, and the skill's self-improvement section directs fixes back into the file.

No `CHANGELOG.md` entry: this touches only the Claude Code skill definition, not the `glide` package, so it is not user-facing.

### Checklist

Quality gates that must be satisfied before requesting a review:

- [x] I have read `CONTRIBUTING.md`
- [ ] `make lint` passes
- [ ] `make type-check` passes
- [ ] `make tests` passes
- [ ] `make coverage` reports 100% coverage
- [ ] `make test-notebooks` passes
- [ ] New public API has numpy-style docstrings
- [ ] New public API is inserted in the API reference section of the documentation
- [ ] Docs build without warnings (`make doc`)
- [ ] `CHANGELOG.md` updated if the change is user-facing

_No Python, notebooks, or docs are touched by this PR, so the code quality gates do not apply._

### LLM usage

Disclose if an LLM was used in writing this PR:
- [ ] No LLM used
- [x] I used an LLM and I went through and validated all the code myself