### PR TITLE
Add rename skill for handling codebase renames

### DIFF
--- a/.claude/skills/rename/SKILL.md
+++ b/.claude/skills/rename/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: rename
+description: Executes a full renaming task in the GLIDE codebase — renaming a class, function, parameter, module, sampler/estimator/monitor, or concept (e.g. `PPIMeanMonitor` → `EmpiricalPPRM`, `cluster_ppi.py` → `clustered_ppi.py`, `n_total` → `n_samples`). Use whenever the user says "rename X to Y", asks to rename a class/function/parameter/module/file, or describes a renaming ticket from the GitHub Projects board — even for a rename that looks trivial, since a bare find-and-replace reliably misses variable names, plot labels, notebook prose, and doc cross-references.
+---
+
+## Overview
+
+- GLIDE has done this exact kind of rename many times, and the pattern is consistent: a rename that looks like a single find-and-replace almost always needs a follow-up cleanup pass.
+- The old name resurfaces in places a mechanical search over `.py` files doesn't reach:
+  - Local variable names in notebooks.
+  - Plot color constants.
+  - f-string labels.
+  - Markdown headers.
+  - Words derived from the same root that aren't the literal renamed token.
+- `CLAUDE.md`'s "Consistency and Propagation" section already says to grep for all sites using the old name before considering a rename done. That principle, stated generically, keeps missing things in practice. It needs:
+  - A concrete, ordered checklist.
+  - A policy of actually reading each affected file rather than trusting grep snippets.
+  - A mandatory second pass.
+- Follow the steps below in order.
+
+## Step 1 — Pin down every rename before touching code
+
+- If the user's request doesn't fully specify old → new for *every* symbol involved, ask before starting.
+- A single conceptual rename is often several literal renames at once — renaming one estimator class can also require renaming its module file, its test file, a related sampler class, and a notebook titled around the old name.
+- Identify explicitly, before starting:
+  - **Every literal symbol renamed**: class name, function/method name, parameter name, module path, file path (glide source, test file, notebook file).
+  - **The root word's surface forms** — for each renamed identifier, how it can appear in prose and code, since every one of these needs its own grep pattern:
+    - PascalCase (`ClusterPPI`)
+    - snake_case (`cluster_ppi`)
+    - space-separated natural language (`Cluster PPI`, `cluster ppi`)
+    - any acronym/abbreviation the concept has (e.g. `PPI` vs `PPRM`)
+    - plural/derived forms sharing the same root — renaming a `Cluster*` class can also touch unrelated prose like "cluster classical estimator"; audit the whole word family, not just the exact old identifier
+  - Whether the rename is a **pure rename** (same behavior, new name) or bundled with other changes, so the CHANGELOG entry doesn't conflate them.
+
+## Step 2 — Rename the core implementation first
+
+- Rename in this order, since everything else propagates from here:
+  1. The class/function/parameter/module itself in `glide/`.
+  2. Its export in the relevant `glide/*/__init__.py` (estimators, samplers, monitors, simulators, etc.).
+  3. If a module or test file's name is derived from the symbol, rename the file with `git mv` (not delete+recreate) so blame/history survives.
+- Grep before moving on, restricted to `glide/`:
+
+  ```bash
+  rg -i '<old_name_surface_forms>' glide/
+  ```
+
+- Anything left here means Step 2 isn't done — don't proceed until this is clean.
+
+## Step 3 — Find every affected file, then fan out across them in parallel
+
+- Run a repo-wide, case-insensitive search for every surface form from Step 1 to build the full list of candidate files:
+
+  ```bash
+  rg -il '<old_name_surface_form_1>|<old_name_surface_form_2>|...' \
+    glide/ tests/ docs/ README.md CONTRIBUTING.md CHANGELOG.md mkdocs.yml
+  ```
+
+- This list typically spans:
+  - **Unit and functional tests** mirroring the `glide/` structure — rename the test file itself with `git mv` if it's named after the symbol, including mock variable names that reference it.
+  - **Docstrings and doctest `Examples` blocks**.
+  - **Tutorial and deep-dive/scientific-validation notebooks** — check headers, bold prose, table cells, imports, variable names, plot labels, f-strings, `print()` statements, dict keys used as legend labels, and color constant names *and* their inline comments. Notebook titles in particular lag behind code renames easily since the first cell is easy to skim past.
+  - **`docs/api/*.md`** — mkdocstrings `:::` directives and summary tables, both the link anchor and the display text.
+  - **`docs/tutorials/index.md`**.
+  - **`mkdocs.yml`** — nav display titles *and* file paths/slugs, which must change if a notebook was renamed.
+  - **`README.md`** — the "Implemented Algorithms" table, citation links.
+  - **`CONTRIBUTING.md`** — the ASCII architecture directory tree lists module filenames like `├── ppi.py`, easy to miss since it reads as prose, not code.
+  - **`CHANGELOG.md`** — add a bullet under `### Changed` in `## [Next release]` at the top of that section's list, per project convention; don't touch the Contributors line. If the symbol was introduced in an already-released version whose changelog entry still names it, ask the user whether to correct that historical entry too — editing released history is unusual, but has been this project's practice for a symbol renamed shortly after its own release.
+- For every candidate file, actually **read the whole file** before editing it:
+  - Never rely on grep's context lines alone — a snippet can hide additional occurrences elsewhere in the file.
+  - Some hits need judgment (is this word derived from the renamed root, or a coincidental unrelated use of the same English word?) that only reading the surrounding content resolves.
+- Once the core rename from Step 2 is done, every remaining file is independent of the others — none of them need to see each other's edits first. This makes them a good fit for parallel dispatch:
+  - Launch one subagent per file (or per small cluster of closely related files, like a notebook and its mirrored test) via the Agent tool, running in parallel rather than one at a time.
+  - Give each subagent: the full old → new mapping and the surface-forms list from Step 1, the specific file path to work on, and the guidance above (read the whole file first, use NotebookEdit for `.ipynb` files rather than raw JSON edits, watch for derived words in prose).
+  - Since each file's task is a bounded, well-specified rename once the mapping is fixed, a cheaper/faster model (`haiku`) is a good fit for most of these dispatches — reserve a stronger model for any file where the rename is entangled with genuinely ambiguous prose.
+  - Have each subagent report back a short summary of what it changed so the changes can be spot-checked.
+
+## Step 4 — Mandatory second-pass verification
+
+- Do this even if Step 3 felt thorough. Rename tasks in this codebase reliably leave stragglers on the first pass, which is exactly why this step exists as a hard requirement rather than an optional sanity check.
+- Re-run the repo-wide grep from Step 3 for every surface form, across the whole tree.
+- Read every remaining hit:
+  - Expect some to be legitimate (e.g. the old name inside an already-released CHANGELOG entry deliberately left untouched, or a genuinely unrelated word that happens to share a substring) — confirm that deliberately for each hit rather than assuming it's fine.
+  - Fix anything unaddressed and re-run the grep.
+- Don't stop until a full sweep comes back clean, net of the deliberate exceptions.
+
+## Step 5 — Run the quality gates
+
+```bash
+make lint
+make type-check
+make tests
+make test-notebooks
+```
+
+- `make tests` runs with `--doctest-modules`, so a stale doctest import or example will fail here — a second independent safety net on top of Step 4's grep.
+
+## Step 6 — Done, and close the loop for next time
+
+- The rename is ready for review once Steps 1–5 pass. The `create-pr` skill can take it from here to open the PR.
+  - Mention to the user that the PR description should note this is a rename (e.g. `Renames X to Y (module_a → module_b), propagating through tests, docs, and tutorials`).
+- Before finishing, explicitly ask the user to flag any missed instance of the old name they spot later (in review, in a follow-up commit, or in a future session) — this checklist was itself built from exactly that kind of feedback, and it stays accurate only if new misses get folded back in.
+- If the user later reports a missed instance, don't just fix that one occurrence and move on:
+  - Treat it as a gap in this skill's checklist, not a one-off mistake.
+  - Update Step 3's file-type list (or add a new bullet) so the category is covered going forward.
+  - Add a new before/after example to `references/pr-history-examples.md`, following the format of the existing entries, so future runs recognize the same pattern.
+
+See `references/pr-history-examples.md` for concrete before/after snippets of the categories of stray reference described in Step 3 — useful as a sanity check for what "stray" looks like in practice.

--- a/.claude/skills/rename/SKILL.md
+++ b/.claude/skills/rename/SKILL.md
@@ -31,6 +31,7 @@ description: Executes a full renaming task in the GLIDE codebase — renaming a 
     - any acronym/abbreviation the concept has (e.g. `PPI` vs `PPRM`)
     - plural/derived forms sharing the same root — renaming a `Cluster*` class can also touch unrelated prose like "cluster classical estimator"; audit the whole word family, not just the exact old identifier
   - Whether the rename is a **pure rename** (same behavior, new name) or bundled with other changes, so the CHANGELOG entry doesn't conflate them.
+- A rename of a public symbol is a straight rename, not a deprecation: GLIDE's CLAUDE.md rejects backwards-compatibility shims, so don't leave the old name behind as an alias with a deprecation warning — remove it outright and let the CHANGELOG's `Changed` entry record the break.
 
 ## Step 2 — Rename the core implementation first
 
@@ -61,6 +62,7 @@ description: Executes a full renaming task in the GLIDE codebase — renaming a 
   - **Tutorial and deep-dive/scientific-validation notebooks** — check headers, bold prose, table cells, imports, variable names, plot labels, f-strings, `print()` statements, dict keys used as legend labels, and color constant names *and* their inline comments. Notebook titles in particular lag behind code renames easily since the first cell is easy to skim past.
   - **`docs/api/*.md`** — mkdocstrings `:::` directives and summary tables, both the link anchor and the display text.
   - **`docs/tutorials/index.md`**.
+  - **`docs/landing/`** — `tests/generate_fixtures.py` imports directly from `glide.estimators` and `glide.simulators`; a stale import here fails `make check-landing-fixtures` (chained into `make tests`) rather than showing up as a stray in prose, so don't skip this directory because it looks like a marketing page.
   - **`mkdocs.yml`** — nav display titles *and* file paths/slugs, which must change if a notebook was renamed.
   - **`README.md`** — the "Implemented Algorithms" table, citation links.
   - **`CONTRIBUTING.md`** — the ASCII architecture directory tree lists module filenames like `├── ppi.py`, easy to miss since it reads as prose, not code.
@@ -73,6 +75,7 @@ description: Executes a full renaming task in the GLIDE codebase — renaming a 
   - Give each subagent: the full old → new mapping and the surface-forms list from Step 1, the specific file path to work on, and the guidance above (read the whole file first, use NotebookEdit for `.ipynb` files rather than raw JSON edits, watch for derived words in prose).
   - Since each file's task is a bounded, well-specified rename once the mapping is fixed, a cheaper/faster model (`haiku`) is a good fit for most of these dispatches — reserve a stronger model for any file where the rename is entangled with genuinely ambiguous prose.
   - Have each subagent report back a short summary of what it changed so the changes can be spot-checked.
+  - Before moving to Step 4, skim the subagents' changes together for phrasing consistency (e.g., one file settling on "Clustered PPI" while another says "Cluster-level PPI") — Step 4's grep only catches leftover old names, not inconsistent new-name phrasing across files.
 
 ## Step 4 — Mandatory second-pass verification
 
@@ -89,10 +92,12 @@ description: Executes a full renaming task in the GLIDE codebase — renaming a 
 make lint
 make type-check
 make tests
+make coverage
 make test-notebooks
 ```
 
-- `make tests` runs with `--doctest-modules`, so a stale doctest import or example will fail here — a second independent safety net on top of Step 4's grep.
+- `make tests` runs with `--doctest-modules`, so a stale doctest import or example will fail here — a second independent safety net on top of Step 4's grep. It also chains `check-landing-fixtures`, so a stale import in `docs/landing/tests/generate_fixtures.py` fails here too.
+- `make coverage` requires 100%: a rename that leaves an old alias or an unreachable branch behind will show up as a coverage drop even if `make tests` passes.
 
 ## Step 6 — Done, and close the loop for next time
 

--- a/.claude/skills/rename/SKILL.md
+++ b/.claude/skills/rename/SKILL.md
@@ -5,16 +5,15 @@ description: Executes a full renaming task in the GLIDE codebase — renaming a 
 
 ## Overview
 
-- GLIDE has done this exact kind of rename many times, and the pattern is consistent: a rename that looks like a single find-and-replace almost always needs a follow-up cleanup pass.
-- The old name resurfaces in places a mechanical search over `.py` files doesn't reach:
+- A rename spans more than the source code: the old name resurfaces in places a mechanical search over `.py` files doesn't reach:
   - Local variable names in notebooks.
   - Plot color constants.
   - f-string labels.
   - Markdown headers.
   - Words derived from the same root that aren't the literal renamed token.
-- `CLAUDE.md`'s "Consistency and Propagation" section already says to grep for all sites using the old name before considering a rename done. That principle, stated generically, keeps missing things in practice. It needs:
+- Grepping for the old name is necessary but not sufficient on its own. Full coverage additionally requires:
   - A concrete, ordered checklist.
-  - A policy of actually reading each affected file rather than trusting grep snippets.
+  - Actually reading each affected file in full rather than trusting grep snippets.
   - A mandatory second pass.
 - Follow the steps below in order.
 
@@ -31,14 +30,15 @@ description: Executes a full renaming task in the GLIDE codebase — renaming a 
     - any acronym/abbreviation the concept has (e.g. `PPI` vs `PPRM`)
     - plural/derived forms sharing the same root — renaming a `Cluster*` class can also touch unrelated prose like "cluster classical estimator"; audit the whole word family, not just the exact old identifier
   - Whether the rename is a **pure rename** (same behavior, new name) or bundled with other changes, so the CHANGELOG entry doesn't conflate them.
-- A rename of a public symbol is a straight rename, not a deprecation: GLIDE's CLAUDE.md rejects backwards-compatibility shims, so don't leave the old name behind as an alias with a deprecation warning — remove it outright and let the CHANGELOG's `Changed` entry record the break.
+- A rename of a public symbol is a straight rename, not a deprecation: remove the old name outright rather than keeping it as an alias with a deprecation warning. Record the change via the CHANGELOG's `Changed` entry instead.
 
 ## Step 2 — Rename the core implementation first
 
 - Rename in this order, since everything else propagates from here:
   1. The class/function/parameter/module itself in `glide/`.
   2. Its export in the relevant `glide/*/__init__.py` (estimators, samplers, monitors, simulators, etc.).
-  3. If a module or test file's name is derived from the symbol, rename the file with `git mv` (not delete+recreate) so blame/history survives.
+  3. Its docstring's natural-language prose (summary, parameter descriptions, `Notes`/`References` sections) — these describe the symbol in words, not just in the signature, so update them alongside the code.
+  4. If a module or test file's name is derived from the symbol, rename the file with `git mv` (not delete+recreate) so blame/history survives.
 - Grep before moving on, restricted to `glide/`:
 
   ```bash
@@ -62,11 +62,11 @@ description: Executes a full renaming task in the GLIDE codebase — renaming a 
   - **Tutorial and deep-dive/scientific-validation notebooks** — check headers, bold prose, table cells, imports, variable names, plot labels, f-strings, `print()` statements, dict keys used as legend labels, and color constant names *and* their inline comments. Notebook titles in particular lag behind code renames easily since the first cell is easy to skim past.
   - **`docs/api/*.md`** — mkdocstrings `:::` directives and summary tables, both the link anchor and the display text.
   - **`docs/tutorials/index.md`**.
-  - **`docs/landing/`** — `tests/generate_fixtures.py` imports directly from `glide.estimators` and `glide.simulators`; a stale import here fails `make check-landing-fixtures` (chained into `make tests`) rather than showing up as a stray in prose, so don't skip this directory because it looks like a marketing page.
+  - **`docs/landing/`** — `tests/generate_fixtures.py` imports directly from `glide.estimators` and `glide.simulators`; a stale import fails `make check-landing-fixtures` (chained into `make tests`).
   - **`mkdocs.yml`** — nav display titles *and* file paths/slugs, which must change if a notebook was renamed.
   - **`README.md`** — the "Implemented Algorithms" table, citation links.
   - **`CONTRIBUTING.md`** — the ASCII architecture directory tree lists module filenames like `├── ppi.py`, easy to miss since it reads as prose, not code.
-  - **`CHANGELOG.md`** — add a bullet under `### Changed` in `## [Next release]` at the top of that section's list, per project convention; don't touch the Contributors line. If the symbol was introduced in an already-released version whose changelog entry still names it, ask the user whether to correct that historical entry too — editing released history is unusual, but has been this project's practice for a symbol renamed shortly after its own release.
+  - **`CHANGELOG.md`** — add a bullet under `### Changed` in `## [Next release]`, at the top of that section's list; don't touch the Contributors line. If the symbol was introduced by an entry still under `## [Next release]`, rename it in place within that entry instead of adding a second bullet. If the symbol was introduced in an already-released version, leave that historical entry untouched and record the rename as a new bullet under `## [Next release]` instead.
 - For every candidate file, actually **read the whole file** before editing it:
   - Never rely on grep's context lines alone — a snippet can hide additional occurrences elsewhere in the file.
   - Some hits need judgment (is this word derived from the renamed root, or a coincidental unrelated use of the same English word?) that only reading the surrounding content resolves.
@@ -96,8 +96,8 @@ make coverage
 make test-notebooks
 ```
 
-- `make tests` runs with `--doctest-modules`, so a stale doctest import or example will fail here — a second independent safety net on top of Step 4's grep. It also chains `check-landing-fixtures`, so a stale import in `docs/landing/tests/generate_fixtures.py` fails here too.
-- `make coverage` requires 100%: a rename that leaves an old alias or an unreachable branch behind will show up as a coverage drop even if `make tests` passes.
+- `make tests` runs with `--doctest-modules` (catches stale doctest imports/examples) and chains `check-landing-fixtures` (catches a stale import in `docs/landing/tests/generate_fixtures.py`).
+- `make coverage` requires 100%: an old alias or unreachable branch left behind shows up as a coverage drop even when `make tests` passes.
 
 ## Step 6 — Done, and close the loop for next time
 

--- a/.claude/skills/rename/references/pr-history-examples.md
+++ b/.claude/skills/rename/references/pr-history-examples.md
@@ -1,0 +1,100 @@
+# Worked examples from GLIDE's rename history
+
+Concrete before/after snippets pulled from real GLIDE renames and their follow-up "caught stray X" commits. Use these to sanity-check that you're catching the same categories of stray reference, not just the literal symbol name.
+
+## 1. Notebook variable names outlive the class rename
+
+A monitor class had already been renamed to `EmpiricalPPRM`/`AsymptoticPPRM` in an earlier commit, but a local variable in the tutorial notebooks was still named after the old acronym:
+
+```python
+# before (stray, caught in a later cleanup pass)
+ppi_result_no_drift = AsymptoticPPRM().detect(...)
+print(f"PPI monitor drift detected: {ppi_result_no_drift.drift_detected}")
+
+# after
+pprm_result_no_drift = AsymptoticPPRM().detect(...)
+print(f"PPRM drift detected: {pprm_result_no_drift.drift_detected}")
+```
+
+Lesson: renaming the class does nothing to the variable a human (or a previous LLM pass) happened to name after the *old* class. Grep for the old name as a variable-name substring too, not just as a class reference.
+
+## 2. Plot color constants and their own inline comments
+
+```python
+# before
+C_PPI = "#27AE60"  # PPI monitor running mean/bound        — green
+C_ALARM_PPI = "#8E44AD"  # PPI monitor alarm               — purple
+
+# after
+C_PPRM = "#27AE60"  # PPRM running mean/bound              — green
+C_ALARM_PPRM = "#8E44AD"  # PPRM alarm                     — purple
+```
+
+Lesson: the comment text itself needs the rename too, and comment alignment (the trailing `—` column) often needs re-padding once the label text length changes.
+
+## 3. Dict keys used as legend labels
+
+```python
+# before
+colors = {"True only": "steelblue", "Cluster PPI++": "darkorange", "Proxy only": "red"}
+...
+ax.plot(correlations, ess_mean, marker="o", color="darkorange", label="Cluster PPI++ ESS (mean)")
+
+# after
+colors = {"True only": "steelblue", "Clustered PPI++": "darkorange", "Proxy only": "red"}
+...
+ax.plot(correlations, ess_mean, marker="o", color="darkorange", label="Clustered PPI++ ESS (mean)")
+```
+
+These dict keys are also used later as dictionary lookups (`raw_stats[correlation]["Cluster PPI++"]`) — every lookup site has to change in lockstep or the notebook throws a `KeyError` at run time. This is a case where `make test-notebooks` catches what grep might miss if you only search for the class name and not the display string.
+
+## 4. Words derived from the same root, not the literal old identifier
+
+The rename was `ClusterPPIMeanEstimator` → `ClusteredPPIMeanEstimator`, but plain prose using the adjective "cluster" (not the class name) also needed the same word change:
+
+```markdown
+<!-- before -->
+- **True only** | `y_true` (annotated clusters) | Cluster classical estimator, the gold standard for validity |
+
+<!-- after -->
+- **True only** | `y_true` (annotated clusters) | Clustered classical estimator, the gold standard for validity |
+```
+
+Lesson: decide the "root word" for the whole rename (`cluster` → `clustered`) and audit prose using that root, not only occurrences of the exact class/function token.
+
+## 5. Notebook titles lag behind the code rename
+
+```markdown
+<!-- before -->
+# Scientific Validity of Asymptotic PPI Mean Monitoring
+
+<!-- after -->
+# Scientific Validity of Asymptotic PPRM
+```
+
+This needed a dedicated follow-up commit after the main rename — the H1 title of the notebook doesn't get touched by a code-level rename and is easy to forget because it's the very first cell, often skipped when skimming a diff top-down.
+
+## 6. Stale references in CONTRIBUTING.md's architecture tree
+
+```diff
+ ├── monitors/               # Public API — drift monitors over batched data
+-│   ├── ppi.py
++│   ├── empirical_ppi.py
+ │   ├── ...
+```
+
+This is prose-shaped (an ASCII tree inside a markdown file), so it's easy to miss when searching only for code references. `CONTRIBUTING.md` and `README.md` are always worth a dedicated grep pass.
+
+## 7. Historical CHANGELOG entries corrected retroactively
+
+`Cluster*` was renamed to `Clustered*` shortly after being introduced. The already-released `## [0.7.0]` entry (not just the new unreleased entry) named the old symbols, so it was corrected too:
+
+```diff
+ ## [0.7.0] – 2026-06-12
+
+ ### ✨ Added
+-- Cluster-level inference support: `ClusterPPIMeanEstimator`, `ClusterClassicalMeanEstimator`, `UniformClusterSampler`, ...
++- Cluster-level inference support: `ClusteredPPIMeanEstimator`, `ClusteredClassicalMeanEstimator`, `UniformClusteredSampler`, ...
+```
+
+This is unusual (changelog entries normally describe history as it happened) and was only done because the symbol hadn't been out in a release for long. Ask the user before doing this on a rename of something that's been stable for a while.

--- a/.claude/skills/rename/references/pr-history-examples.md
+++ b/.claude/skills/rename/references/pr-history-examples.md
@@ -16,7 +16,7 @@ pprm_result_no_drift = AsymptoticPPRM().detect(...)
 print(f"PPRM drift detected: {pprm_result_no_drift.drift_detected}")
 ```
 
-Lesson: renaming the class does nothing to the variable a human (or a previous LLM pass) happened to name after the *old* class. Grep for the old name as a variable-name substring too, not just as a class reference.
+Lesson: a rename only touches direct references to the symbol, not variables a human (or a previous LLM pass) independently named after it. Grep for the old name as a substring of variable names too, not only as an exact symbol reference.
 
 ## 2. Plot color constants and their own inline comments
 
@@ -30,7 +30,7 @@ C_PPRM = "#27AE60"  # PPRM running mean/bound              — green
 C_ALARM_PPRM = "#8E44AD"  # PPRM alarm                     — purple
 ```
 
-Lesson: the comment text itself needs the rename too, and comment alignment (the trailing `—` column) often needs re-padding once the label text length changes.
+Lesson: a comment describing a renamed symbol needs the same rename applied to its text, and any manual alignment tied to the old text's length (here, the trailing `—` column) needs to be re-padded once the length changes.
 
 ## 3. Dict keys used as legend labels
 
@@ -46,7 +46,7 @@ colors = {"True only": "steelblue", "Clustered PPI++": "darkorange", "Proxy only
 ax.plot(correlations, ess_mean, marker="o", color="darkorange", label="Clustered PPI++ ESS (mean)")
 ```
 
-These dict keys are also used later as dictionary lookups (`raw_stats[correlation]["Cluster PPI++"]`) — every lookup site has to change in lockstep or the notebook throws a `KeyError` at run time. This is a case where `make test-notebooks` catches what grep might miss if you only search for the class name and not the display string.
+Lesson: a display string used as a dict key must be renamed at every definition and lookup site in lockstep (here, later lookups like `raw_stats[correlation]["Cluster PPI++"]`), or the mismatch surfaces at runtime as a `KeyError` instead of at diff time. `make test-notebooks` catches this class of stray even when a grep pass scoped to the class name alone misses the separate display-string variant.
 
 ## 4. Words derived from the same root, not the literal old identifier
 
@@ -72,7 +72,7 @@ Lesson: decide the "root word" for the whole rename (`cluster` → `clustered`) 
 # Scientific Validity of Asymptotic PPRM
 ```
 
-This needed a dedicated follow-up commit after the main rename — the H1 title of the notebook doesn't get touched by a code-level rename and is easy to forget because it's the very first cell, often skipped when skimming a diff top-down.
+Lesson: a notebook's title is prose in its first cell, not code, so a code-level rename never touches it automatically. It requires its own explicit edit, and a diff review that starts from the code cells downward will skip over it.
 
 ## 6. Stale references in CONTRIBUTING.md's architecture tree
 
@@ -83,18 +83,4 @@ This needed a dedicated follow-up commit after the main rename — the H1 title 
  │   ├── ...
 ```
 
-This is prose-shaped (an ASCII tree inside a markdown file), so it's easy to miss when searching only for code references. `CONTRIBUTING.md` and `README.md` are always worth a dedicated grep pass.
-
-## 7. Historical CHANGELOG entries corrected retroactively
-
-`Cluster*` was renamed to `Clustered*` shortly after being introduced. The already-released `## [0.7.0]` entry (not just the new unreleased entry) named the old symbols, so it was corrected too:
-
-```diff
- ## [0.7.0] – 2026-06-12
-
- ### ✨ Added
--- Cluster-level inference support: `ClusterPPIMeanEstimator`, `ClusterClassicalMeanEstimator`, `UniformClusterSampler`, ...
-+- Cluster-level inference support: `ClusteredPPIMeanEstimator`, `ClusteredClassicalMeanEstimator`, `UniformClusteredSampler`, ...
-```
-
-This is unusual (changelog entries normally describe history as it happened) and was only done because the symbol hadn't been out in a release for long. Ask the user before doing this on a rename of something that's been stable for a while.
+Lesson: an ASCII directory tree inside a markdown file is prose-shaped but encodes real file paths; a grep pass scoped to code references alone will miss it. `CONTRIBUTING.md` and `README.md` need their own dedicated grep pass for this reason.


### PR DESCRIPTION

### Description

- Adds a new Claude Code skill (`.claude/skills/rename/SKILL.md`) that walks through a full renaming task in the GLIDE codebase (renaming a class, function, parameter, module, or concept), plus a `references/pr-history-examples.md` file with before/after examples of stray references missed in past rename PRs.
- Handles this [ticket](https://github.com/orgs/EmertonData/projects/26/views/2?pane=issue&itemId=216861331)
- The skill was elaborated based on recent renaming PRs and tailored to be immune to previously experienced pitfalls, with examples of such failures baked in. It's meant to continuously improve as it's used: it asks users to flag any missed stale symbol in the future so the checklist and examples stay accurate.

### Checklist

Quality gates that must be satisfied before requesting a review:

- [x] I have read `CONTRIBUTING.md`
- [ ] `make lint` passes
- [ ] `make type-check` passes
- [ ] `make tests` passes
- [ ] `make coverage` reports 100% coverage
- [ ] `make test-notebooks` passes
- [ ] New public API has numpy-style docstrings
- [ ] New public API is inserted in the API reference section of the documentation
- [ ] Docs build without warnings (`make doc`)
- [ ] `CHANGELOG.md` updated if the change is user-facing

### LLM usage

Disclose if an LLM was used in writing this PR:
- [ ] No LLM used
- [x] I used an LLM and I went through and validated all the code myself